### PR TITLE
Update Readme, add default namespace for leader election

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# tinkerbell
+# Tinkerbell
+
+Tinkerbell is a bare metal provisioning engine. It supports network and ISO booting and BMC interactions as well as a metadata service, and a workflow engine for provisioning. Some of the features include:
+
+- Cloud-init integration
+- DHCP with Host reservation or ProxyDHCP
+- Third party DHCP server integration
+- BMC support via Redfish, IPMI, IntelAMT, and more
+- Auto discovery of Hardware
+
+For more details, see the [Tinkerbell documentation](https://tinkerbell.org).

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -57,6 +57,7 @@ func Execute(ctx context.Context, args []string) error {
 	controllerOpts := []controller.Option{
 		controller.WithMetricsAddr(netip.MustParseAddrPort(fmt.Sprintf("%s:%d", detectPublicIPv4().String(), 8080))),
 		controller.WithProbeAddr(netip.MustParseAddrPort(fmt.Sprintf("%s:%d", detectPublicIPv4().String(), 8081))),
+		controller.WithLeaderElectionNamespace("default"),
 	}
 	tc := &flag.TinkControllerConfig{
 		Config: controller.NewConfig(controllerOpts...),
@@ -67,6 +68,7 @@ func Execute(ctx context.Context, args []string) error {
 		rufio.WithProbeAddr(netip.MustParseAddrPort(fmt.Sprintf("%s:%d", detectPublicIPv4().String(), 8083))),
 		rufio.WithBmcConnectTimeout(2 * time.Minute),
 		rufio.WithPowerCheckInterval(30 * time.Minute),
+		rufio.WithLeaderElectionNamespace("default"),
 	}
 	rc := &flag.RufioConfig{
 		Config: rufio.NewConfig(rufioOpts...),
@@ -248,6 +250,16 @@ func defaultLogger(level int) logr.Logger {
 				if v == "tinkerbell" {
 					idx = i
 					break
+				}
+				// This trims the source file for 3rd party packages to include
+				// just enough information to identify the package. Without this,
+				// the source file can be long and make the log line more cluttered
+				// and hard to read.
+				if v == "mod" {
+					if i+1 < len(p) {
+						idx = i + 1
+						break
+					}
 				}
 			}
 			ss.File = filepath.Join(p[idx:]...)

--- a/cmd/tinkerbell/flag/rufio.go
+++ b/cmd/tinkerbell/flag/rufio.go
@@ -36,7 +36,7 @@ var RufioControllerProbeAddr = Config{
 
 var RufioControllerLeaderElectionNamespace = Config{
 	Name:  "rufio-controller-leader-election-namespace",
-	Usage: "namespace in which the leader election configmap will be created",
+	Usage: "namespace in which the leader election lease will be created",
 }
 
 var RufioBMCConnectTimeout = Config{

--- a/cmd/tinkerbell/flag/tink_controller.go
+++ b/cmd/tinkerbell/flag/tink_controller.go
@@ -34,5 +34,5 @@ var TinkControllerProbeAddr = Config{
 
 var TinkControllerLeaderElectionNamespace = Config{
 	Name:  "tink-controller-leader-election-namespace",
-	Usage: "namespace in which the leader election configmap will be created",
+	Usage: "namespace in which the leader election lease will be created",
 }

--- a/rufio/rufio.go
+++ b/rufio/rufio.go
@@ -86,6 +86,12 @@ func WithPowerCheckInterval(interval time.Duration) Option {
 	}
 }
 
+func WithLeaderElectionNamespace(namespace string) Option {
+	return func(c *Config) {
+		c.LeaderElectionNamespace = namespace
+	}
+}
+
 func NewConfig(opts ...Option) *Config {
 	defatuls := &Config{
 		EnableLeaderElection: true,

--- a/tink/controller/controller.go
+++ b/tink/controller/controller.go
@@ -55,6 +55,12 @@ func WithProbeAddr(addrPort netip.AddrPort) Option {
 	}
 }
 
+func WithLeaderElectionNamespace(namespace string) Option {
+	return func(c *Config) {
+		c.LeaderElectionNamespace = namespace
+	}
+}
+
 func NewConfig(opts ...Option) *Config {
 	defatuls := &Config{
 		EnableLeaderElection: true,


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Rufio and Tink controller need to create lease objects for leader election. When Tinkerbell is run outside of a Kubernetes cluster this namespace must be explicitly defined. When Tinkerbell is run in cluster, if a namespace is not define, the namespace where Tinkerbell is running is used.

Also, in the logging output, trim the source file name for 3rd party packages.

Update the readme.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
