### PR TITLE
[tink controller] Workflow reconcile update

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     environment:
       TINKERBELL_BACKEND_KUBE_CONFIG: /kube/kubeconfig
       TINKERBELL_IPXE_HTTP_SCRIPT_OSIE_URL: ${OSIE_URL:?Error:"OSIE_URL env var is not set"}
-      TINKERBELL_IPXE_HTTP_SCRIPT_EXTRA_KERNEL_ARGS: "tink_worker_image=quay.io/tinkerbell/tink-worker"
+      TINKERBELL_IPXE_HTTP_SCRIPT_EXTRA_KERNEL_ARGS: "tink_worker_image=ghcr.io/tinkerbell/tink-agent"
     volumes:
       - kubeconfig:/kube
     restart: on-failure

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -144,7 +144,7 @@ func (r *Reconciler) processNewWorkflow(ctx context.Context, logger logr.Logger,
 			msg := "template not found"
 			// If the message is different than what has already been set in the condition, then we update the condition.
 			// This is needed so as to not overwhelm the kubernetes event system if failures grow.
-			trs := getCondition(stored.Status.Conditions, v1alpha1.TemplateRenderedSuccess)
+			trs := getConditionTemplateRenderedSuccess(stored.Status.Conditions)
 			if trs == nil || trs.Message != msg {
 				stored.Status.SetCondition(v1alpha1.WorkflowCondition{
 					Type:    v1alpha1.TemplateRenderedSuccess,
@@ -164,7 +164,7 @@ func (r *Reconciler) processNewWorkflow(ctx context.Context, logger logr.Logger,
 		stored.Status.TemplateRendering = v1alpha1.TemplateRenderingFailed
 		// If the message is different than what has already been set in the condition, then we update the condition.
 		// This is needed so as to not overwhelm the kubernetes event system if failures grow.
-		trs := getCondition(stored.Status.Conditions, v1alpha1.TemplateRenderedSuccess)
+		trs := getConditionTemplateRenderedSuccess(stored.Status.Conditions)
 		if trs == nil || trs.Message != err.Error() {
 			stored.Status.SetCondition(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.TemplateRenderedSuccess,
@@ -186,7 +186,7 @@ func (r *Reconciler) processNewWorkflow(ctx context.Context, logger logr.Logger,
 		msg := fmt.Sprintf("error getting hardware: %v", err)
 		// If the message is different than what has already been set in the condition, then we update the condition.
 		// This is needed so as to not overwhelm the kubernetes event system if failures grow.
-		trs := getCondition(stored.Status.Conditions, v1alpha1.TemplateRenderedSuccess)
+		trs := getConditionTemplateRenderedSuccess(stored.Status.Conditions)
 		if trs == nil || trs.Message != msg {
 			stored.Status.SetCondition(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.TemplateRenderedSuccess,
@@ -206,7 +206,7 @@ func (r *Reconciler) processNewWorkflow(ctx context.Context, logger logr.Logger,
 		msg := fmt.Sprintf("hardware not found: %v", err)
 		// If the message is different than what has already been set in the condition, then we update the condition.
 		// This is needed so as to not overwhelm the kubernetes event system if failures grow.
-		trs := getCondition(stored.Status.Conditions, v1alpha1.TemplateRenderedSuccess)
+		trs := getConditionTemplateRenderedSuccess(stored.Status.Conditions)
 		if trs == nil || trs.Message != msg {
 			stored.Status.SetCondition(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.TemplateRenderedSuccess,
@@ -237,7 +237,7 @@ func (r *Reconciler) processNewWorkflow(ctx context.Context, logger logr.Logger,
 		msg := fmt.Sprintf("error rendering template: %v", err)
 		// If the message is different than what has already been set in the condition, then we update the condition.
 		// This is needed so as to not overwhelm the kubernetes event system if failures grow.
-		trs := getCondition(stored.Status.Conditions, v1alpha1.TemplateRenderedSuccess)
+		trs := getConditionTemplateRenderedSuccess(stored.Status.Conditions)
 		if trs == nil || trs.Message != msg {
 			stored.Status.SetCondition(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.TemplateRenderedSuccess,
@@ -272,9 +272,9 @@ func (r *Reconciler) processNewWorkflow(ctx context.Context, logger logr.Logger,
 	return reconcile.Result{}, nil
 }
 
-func getCondition(all []v1alpha1.WorkflowCondition, want v1alpha1.WorkflowConditionType) *v1alpha1.WorkflowCondition {
+func getConditionTemplateRenderedSuccess(all []v1alpha1.WorkflowCondition) *v1alpha1.WorkflowCondition {
 	for _, c := range all {
-		if c.Type == want {
+		if c.Type == v1alpha1.TemplateRenderedSuccess {
 			return &c
 		}
 	}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Limit updating of conditions. Only update conditions when they are different from existing conditions on an object. This is needed so as to not overwhelm the Kubernetes event system if failures grow.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
