### PR TITLE
Serial over SSH

### DIFF
--- a/cmd/tinkerbell/flag/global.go
+++ b/cmd/tinkerbell/flag/global.go
@@ -22,6 +22,7 @@ type GlobalConfig struct {
 	EnableTinkServer     bool
 	EnableTinkController bool
 	EnableRufio          bool
+	EnableSecondStar     bool
 }
 
 func RegisterGlobal(fs *Set, gc *GlobalConfig) {
@@ -39,6 +40,7 @@ func RegisterGlobal(fs *Set, gc *GlobalConfig) {
 	fs.Register(EnabledTinkServer, ffval.NewValueDefault(&gc.EnableTinkServer, gc.EnableTinkServer))
 	fs.Register(EnabledTinkController, ffval.NewValueDefault(&gc.EnableTinkController, gc.EnableTinkController))
 	fs.Register(EnabledRufioController, ffval.NewValueDefault(&gc.EnableRufio, gc.EnableRufio))
+	fs.Register(EnabledSecondStar, ffval.NewValueDefault(&gc.EnableSecondStar, gc.EnableSecondStar))
 }
 
 // All these flags are used by at least two services or
@@ -114,4 +116,9 @@ var EnabledTinkController = Config{
 var EnabledRufioController = Config{
 	Name:  "enable-rufio-controller",
 	Usage: "enable Rufio Controller service",
+}
+
+var EnabledSecondStar = Config{
+	Name:  "enable-secondstar",
+	Usage: "enable SecondStar service",
 }

--- a/cmd/tinkerbell/flag/secondstar.go
+++ b/cmd/tinkerbell/flag/secondstar.go
@@ -1,0 +1,51 @@
+package flag
+
+import (
+	"github.com/peterbourgon/ff/v4/ffval"
+	"github.com/tinkerbell/tinkerbell/pkg/backend/kube"
+	"github.com/tinkerbell/tinkerbell/secondstar"
+)
+
+type SecondStarConfig struct {
+	Config      *secondstar.Config
+	HostKeyPath string
+}
+
+var KubeIndexesSecondStar = map[kube.IndexType]kube.Index{
+	kube.IndexTypeHardwareName: kube.Indexes[kube.IndexTypeHardwareName],
+	kube.IndexTypeMachineName:  kube.Indexes[kube.IndexTypeMachineName],
+}
+
+func RegisterSecondStarFlags(fs *Set, ssc *SecondStarConfig) {
+	fs.Register(SecondStarPort, ffval.NewValueDefault(&ssc.Config.SSHPort, ssc.Config.SSHPort))
+	fs.Register(SecondStarHostKey, ffval.NewValueDefault(&ssc.HostKeyPath, ssc.HostKeyPath))
+	fs.Register(SecondStarIPMIToolPath, ffval.NewValueDefault(&ssc.Config.IPMITOOLPath, ssc.Config.IPMITOOLPath))
+}
+
+var SecondStarPort = Config{
+	Name:  "secondstar-port",
+	Usage: "Port to listen on for SecondStar",
+}
+
+var SecondStarHostKey = Config{
+	Name:  "secondstar-host-key",
+	Usage: "Path to the host key file for SecondStar",
+}
+
+var SecondStarIPMIToolPath = Config{
+	Name:  "secondstar-ipmitool-path",
+	Usage: "Path to the ipmitool binary",
+}
+
+func (ssc *SecondStarConfig) Convert() error {
+	// convert the host key path to an SSH Signer
+	if ssc.HostKeyPath == "" {
+		return nil
+	}
+	s, err := secondstar.HostKeyFrom(ssc.HostKeyPath)
+	if err != nil {
+		return err
+	}
+	ssc.Config.HostKey = s
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/gin-gonic/gin v1.10.0
+	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-logr/logr v1.4.2
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/golang/mock v1.6.0
@@ -38,6 +39,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
+	golang.org/x/crypto v0.33.0
 	golang.org/x/net v0.35.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/sys v0.30.0
@@ -62,6 +64,7 @@ require (
 	github.com/Microsoft/hcsshim v0.12.9 // indirect
 	github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230 // indirect
 	github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 // indirect
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmc-toolbox/common v0.0.0-20250112191656-b6de52e8303d // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
@@ -173,7 +176,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
-	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/term v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230 h1:t95Grn2
 github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230/go.mod h1:t2EzW1qybnPDQ3LR/GgeF0GOzHUXT5IVMLP2gkW1cmc=
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 h1:a0MBqYm44o0NcthLKCljZHe1mxlN6oahCQHHThnSwB4=
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22/go.mod h1:/B7V22rcz4860iDqstGvia/2+IYWXf3/JdQCVd/1D2A=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
@@ -139,6 +141,8 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
+github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
+github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/pkg/backend/kube/index.go
+++ b/pkg/backend/kube/index.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"github.com/tinkerbell/tinkerbell/pkg/api/v1alpha1/bmc"
 	v1alpha1 "github.com/tinkerbell/tinkerbell/pkg/api/v1alpha1/tinkerbell"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -11,6 +12,8 @@ const (
 	IndexTypeMACAddr                    IndexType = MACAddrIndex
 	IndexTypeIPAddr                     IndexType = IPAddrIndex
 	IndexTypeWorkflowByNonTerminalState IndexType = WorkflowByNonTerminalState
+	IndexTypeHardwareName               IndexType = "hardware.metadata.name"
+	IndexTypeMachineName                IndexType = "machine.metadata.name"
 )
 
 // Indexes that are currently known.
@@ -29,6 +32,16 @@ var Indexes = map[IndexType]Index{
 		Obj:          &v1alpha1.Workflow{},
 		Field:        WorkflowByNonTerminalState,
 		ExtractValue: WorkflowByNonTerminalStateFunc,
+	},
+	IndexTypeHardwareName: {
+		Obj:          &v1alpha1.Hardware{},
+		Field:        HardwareNameIndex,
+		ExtractValue: HardwareNameFunc,
+	},
+	IndexTypeMachineName: {
+		Obj:          &bmc.Machine{},
+		Field:        MachineNameIndex,
+		ExtractValue: MachineNameFunc,
 	},
 }
 
@@ -101,4 +114,25 @@ func WorkflowByNonTerminalStateFunc(obj client.Object) []string {
 	}
 
 	return resp
+}
+
+// NameIndex is an index used with a controller-runtime client to lookup objects by name.
+const HardwareNameIndex = ".metadata.name"
+
+func HardwareNameFunc(obj client.Object) []string {
+	hw, ok := obj.(*v1alpha1.Hardware)
+	if !ok {
+		return nil
+	}
+	return []string{hw.ObjectMeta.Name}
+}
+
+const MachineNameIndex = ".metadata.name"
+
+func MachineNameFunc(obj client.Object) []string {
+	m, ok := obj.(*bmc.Machine)
+	if !ok {
+		return nil
+	}
+	return []string{m.ObjectMeta.Name}
 }

--- a/pkg/backend/kube/kube.go
+++ b/pkg/backend/kube/kube.go
@@ -6,10 +6,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/tinkerbell/tinkerbell/pkg/api/v1alpha1/bmc"
 	v1alpha1 "github.com/tinkerbell/tinkerbell/pkg/api/v1alpha1/tinkerbell"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/scale/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -73,6 +74,15 @@ func NewBackend(cfg Backend, opts ...cluster.Option) (*Backend, error) {
 	if err := v1alpha1.AddToScheme(rs); err != nil {
 		return nil, err
 	}
+
+	if err := bmc.AddToScheme(rs); err != nil {
+		return nil, err
+	}
+
+	if err := scheme.AddToScheme(rs); err != nil {
+		return nil, err
+	}
+
 	conf := func(o *cluster.Options) {
 		o.Scheme = rs
 		if cfg.Namespace != "" {

--- a/pkg/backend/kube/secondstar.go
+++ b/pkg/backend/kube/secondstar.go
@@ -17,7 +17,6 @@ import (
 
 // GetByMac implements the handler.BackendReader interface and returns DHCP and netboot data based on a mac address.
 func (b *Backend) ReadBMCMachine(ctx context.Context, name string) (*data.BMCMachine, error) {
-
 	// get the hardware object, using the name, from the cluster
 	// get the ssh public keys from the hardware object, add them to the return data.BMCMachine object
 	// get the bmcRef from the hardware object
@@ -81,16 +80,16 @@ func (b *Backend) machine(ctx context.Context, name string, machine *data.BMCMac
 	if len(bmcList.Items) > 1 {
 		return fmt.Errorf("got %d bmc machine objects for name: %s, expected only 1", len(bmcList.Items), name)
 	}
-	bmc := bmcList.Items[0]
+	bmcMachine := bmcList.Items[0]
 
-	machine.Host = bmc.Spec.Connection.Host
-	if bmc.Spec.Connection.ProviderOptions != nil && bmc.Spec.Connection.ProviderOptions.IPMITOOL != nil {
-		machine.Port = ternary(bmc.Spec.Connection.ProviderOptions.IPMITOOL.Port == 0, 623, bmc.Spec.Connection.ProviderOptions.IPMITOOL.Port)
-		machine.CipherSuite = ternary(bmc.Spec.Connection.ProviderOptions.IPMITOOL.CipherSuite == "", "17", bmc.Spec.Connection.ProviderOptions.IPMITOOL.CipherSuite)
+	machine.Host = bmcMachine.Spec.Connection.Host
+	if bmcMachine.Spec.Connection.ProviderOptions != nil && bmcMachine.Spec.Connection.ProviderOptions.IPMITOOL != nil {
+		machine.Port = ternary(bmcMachine.Spec.Connection.ProviderOptions.IPMITOOL.Port == 0, 623, bmcMachine.Spec.Connection.ProviderOptions.IPMITOOL.Port)
+		machine.CipherSuite = ternary(bmcMachine.Spec.Connection.ProviderOptions.IPMITOOL.CipherSuite == "", "17", bmcMachine.Spec.Connection.ProviderOptions.IPMITOOL.CipherSuite)
 	}
 
 	// lookup the secret object from the cluster. This gives us the user and pass.
-	username, password, err := resolveAuthSecretRef(ctx, b.cluster.GetClient(), v1.SecretReference{Name: bmc.Spec.Connection.AuthSecretRef.Name, Namespace: bmc.Spec.Connection.AuthSecretRef.Namespace})
+	username, password, err := resolveAuthSecretRef(ctx, b.cluster.GetClient(), v1.SecretReference{Name: bmcMachine.Spec.Connection.AuthSecretRef.Name, Namespace: bmcMachine.Spec.Connection.AuthSecretRef.Namespace})
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/kube/secondstar.go
+++ b/pkg/backend/kube/secondstar.go
@@ -1,0 +1,128 @@
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tinkerbell/tinkerbell/pkg/api/v1alpha1/bmc"
+	v1alpha1 "github.com/tinkerbell/tinkerbell/pkg/api/v1alpha1/tinkerbell"
+	"github.com/tinkerbell/tinkerbell/pkg/data"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetByMac implements the handler.BackendReader interface and returns DHCP and netboot data based on a mac address.
+func (b *Backend) ReadBMCMachine(ctx context.Context, name string) (*data.BMCMachine, error) {
+
+	// get the hardware object, using the name, from the cluster
+	// get the ssh public keys from the hardware object, add them to the return data.BMCMachine object
+	// get the bmcRef from the hardware object
+	// get the machine.bmc object, using the ref, from the cluster
+	// get the bmc host, port, and cipher suites from the machine.bmc object, add them to the return data.BMCMachine object
+	// get the secret object, using the machine.bmc object's secret ref, from the cluster
+	// get the user and pass from the secret object, parse out the user and password and add them to the return data.BMCMachine object
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "backend.kube.GetByIP")
+	defer span.End()
+
+	hardwareList := &v1alpha1.HardwareList{}
+
+	// list hardware objects with the given name
+	if err := b.cluster.GetClient().List(ctx, hardwareList, &client.MatchingFields{".metadata.name": name}); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+
+		return nil, fmt.Errorf("failed listing hardware for (%v): %w", name, err)
+	}
+
+	if len(hardwareList.Items) == 0 {
+		err := hardwareNotFoundError{name: name, namespace: ternary(b.Namespace == "", "all namespaces", b.Namespace)}
+		span.SetStatus(codes.Error, err.Error())
+
+		return nil, err
+	}
+
+	if len(hardwareList.Items) > 1 {
+		err := fmt.Errorf("got %d hardware objects for ip: %s, expected only 1", len(hardwareList.Items), name)
+		span.SetStatus(codes.Error, err.Error())
+
+		return nil, err
+	}
+
+	hw := hardwareList.Items[0]
+	response := &data.BMCMachine{}
+	if hw.Spec.Metadata != nil && hw.Spec.Metadata.Instance != nil {
+		response.SSHPublicKeys = hw.Spec.Metadata.Instance.SSHKeys
+	}
+	bmcName := hw.Spec.BMCRef.Name
+
+	if err := b.machine(ctx, bmcName, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (b *Backend) machine(ctx context.Context, name string, machine *data.BMCMachine) error {
+	if name == "" {
+		return fmt.Errorf("BMC Machine name is required")
+	}
+
+	bmcList := &bmc.MachineList{}
+	if err := b.cluster.GetClient().List(ctx, bmcList, &client.MatchingFields{".metadata.name": name}); err != nil {
+		return fmt.Errorf("failed listing bmc machine for (%v): %w", name, err)
+	}
+	if len(bmcList.Items) == 0 {
+		return fmt.Errorf("bmc machine not found: %s", name)
+	}
+	if len(bmcList.Items) > 1 {
+		return fmt.Errorf("got %d bmc machine objects for name: %s, expected only 1", len(bmcList.Items), name)
+	}
+	bmc := bmcList.Items[0]
+
+	machine.Host = bmc.Spec.Connection.Host
+	if bmc.Spec.Connection.ProviderOptions != nil && bmc.Spec.Connection.ProviderOptions.IPMITOOL != nil {
+		machine.Port = ternary(bmc.Spec.Connection.ProviderOptions.IPMITOOL.Port == 0, 623, bmc.Spec.Connection.ProviderOptions.IPMITOOL.Port)
+		machine.CipherSuite = ternary(bmc.Spec.Connection.ProviderOptions.IPMITOOL.CipherSuite == "", "17", bmc.Spec.Connection.ProviderOptions.IPMITOOL.CipherSuite)
+	}
+
+	// lookup the secret object from the cluster. This gives us the user and pass.
+	username, password, err := resolveAuthSecretRef(ctx, b.cluster.GetClient(), v1.SecretReference{Name: bmc.Spec.Connection.AuthSecretRef.Name, Namespace: bmc.Spec.Connection.AuthSecretRef.Namespace})
+	if err != nil {
+		return err
+	}
+	machine.User = username
+	machine.Pass = password
+
+	return nil
+}
+
+// resolveAuthSecretRef Gets the Secret from the SecretReference.
+// Returns the username and password encoded in the Secret.
+func resolveAuthSecretRef(ctx context.Context, c client.Client, secretRef v1.SecretReference) (string, string, error) {
+	secret := &v1.Secret{}
+	key := types.NamespacedName{Namespace: secretRef.Namespace, Name: secretRef.Name}
+
+	if err := c.Get(ctx, key, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", "", fmt.Errorf("secret %s not found: %w", key, err)
+		}
+
+		return "", "", fmt.Errorf("failed to retrieve secret %s : %w", secretRef, err)
+	}
+
+	username, ok := secret.Data["username"]
+	if !ok {
+		return "", "", fmt.Errorf("'username' required in Machine secret")
+	}
+
+	password, ok := secret.Data["password"]
+	if !ok {
+		return "", "", fmt.Errorf("'password' required in Machine secret")
+	}
+
+	return string(username), string(password), nil
+}

--- a/pkg/data/bmc.go
+++ b/pkg/data/bmc.go
@@ -1,0 +1,10 @@
+package data
+
+type BMCMachine struct {
+	Host          string
+	User          string
+	Pass          string
+	Port          int
+	CipherSuite   string
+	SSHPublicKeys []string
+}

--- a/rufio/internal/controller/machine.go
+++ b/rufio/internal/controller/machine.go
@@ -134,7 +134,7 @@ func (r *MachineReconciler) doReconcile(ctx context.Context, bm *bmc.Machine, bm
 		}
 
 		// requeue as bmc connections can be transient.
-		return ctrl.Result{RequeueAfter: machineRequeueInterval}, nil
+		return ctrl.Result{RequeueAfter: r.powerCheckInterval}, nil
 	}
 
 	// Close BMC connection after reconciliation
@@ -169,7 +169,7 @@ func (r *MachineReconciler) doReconcile(ctx context.Context, bm *bmc.Machine, bm
 		return ctrl.Result{}, utilerrors.NewAggregate(multiErr)
 	}
 
-	return ctrl.Result{RequeueAfter: machineRequeueInterval}, nil
+	return ctrl.Result{RequeueAfter: r.powerCheckInterval}, nil
 }
 
 // updatePowerState gets the current power state of the machine.

--- a/rufio/rufio.go
+++ b/rufio/rufio.go
@@ -93,15 +93,15 @@ func WithLeaderElectionNamespace(namespace string) Option {
 }
 
 func NewConfig(opts ...Option) *Config {
-	defatuls := &Config{
+	defaults := &Config{
 		EnableLeaderElection: true,
 	}
 
 	for _, opt := range opts {
-		opt(defatuls)
+		opt(defaults)
 	}
 
-	return defatuls
+	return defaults
 }
 
 func (c *Config) Start(ctx context.Context, log logr.Logger) error {

--- a/secondstar/internal/handler.go
+++ b/secondstar/internal/handler.go
@@ -1,0 +1,211 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/go-logr/logr"
+	"github.com/tinkerbell/tinkerbell/pkg/data"
+)
+
+type Handle struct{}
+
+// State is the internal State needed to track multiple sessions
+// and provide a way to share stdin between sessions.
+type State struct {
+	file       *os.File
+	mainClosed chan struct{}
+	// connectedSessions is a map of all the extra sessions connected to the main session
+	connectedSessions map[string]struct{}
+	multiwriter       *MultiWriter
+	stdin             io.Writer
+}
+
+func Handler(ctx context.Context, log logr.Logger, globalState map[string]State, ipmitoolPath string) func(s ssh.Session) {
+	return func(s ssh.Session) {
+		// search for an ipmitool session that is already running with the same user and host
+
+		log.Info("new session", "user", s.User())
+
+		if st, found := globalState[s.User()]; found {
+			log.Info("connecting to existing session")
+			//_, winCh, _ := s.Pty()
+			//go func() {
+			//	for win := range winCh {
+			//		setWinsize(st.file, win.Width, win.Height)
+			//	}
+			//}()
+
+			name := fmt.Sprintf("%v-%v", s.User(), len(st.connectedSessions)+1)
+			st.connectedSessions[name] = struct{}{}
+			st.multiwriter.Add(s) // stdout
+			defer func() {
+				st.multiwriter.Remove(s)
+				delete(st.connectedSessions, name)
+			}()
+			escapeReader, escapeWriter := io.Pipe()
+			mw := io.MultiWriter(st.stdin, escapeWriter)
+			// watch for escape sequences
+			// escape sequence is ~.
+			// if ~. is detected, close the session
+			go func() {
+				for {
+					b := make([]byte, 1)
+					_, err := escapeReader.Read(b)
+					if err != nil {
+						log.Error(err, "error reading escape sequence")
+						return
+					}
+					if b[0] == '~' {
+						_, err := escapeReader.Read(b)
+						if err != nil {
+							log.Error(err, "error reading escape sequence")
+							return
+						}
+						if b[0] == '.' {
+							log.Info("escape sequence detected")
+							s.Exit(0)
+							return
+						}
+					}
+				}
+			}()
+			go io.Copy(mw, s) // stdin
+			select {
+			case <-st.mainClosed:
+				log.Info("main session closed", "name", name)
+				s.Exit(0)
+				return
+			case <-ctx.Done():
+				log.Info("context done", "name", name)
+				s.Exit(0)
+				return
+			case <-s.Context().Done():
+				log.Info("session context done", "name", name)
+				s.Exit(0)
+				return
+			}
+		}
+		// Get the bmc ref from the context
+		// lookup the machine.bmc object from the cluster. This gives us the host and port and secret reference.
+		// lookup the secret object from the cluster. This gives us the user and pass.
+		// session user will eventually be the Hardware name and will be used to lookup all credential info. Also, maybe ssh key for validation.
+		bmc, ok := s.Context().Value("bmc").(data.BMCMachine)
+		if !ok {
+			log.Info("error getting bmc info, exiting session")
+			s.Exit(1)
+			return
+		}
+
+		ipmitoolCMD := []string{ipmitoolPath, "-I", "lanplus", "-E", "-H", bmc.Host, "-U", bmc.User, "-p", strconv.Itoa(bmc.Port), "sol", "activate"}
+		cmd := exec.CommandContext(s.Context(), ipmitoolCMD[0], ipmitoolCMD[1:]...)
+		ptyReq, _, _ := s.Pty()
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", ptyReq.Term))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("IPMITOOL_PASSWORD=%s", bmc.Pass))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("IPMITOOL_USERNAME=%s", bmc.User))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("IPMITOOL_CIPHER_SUITE=%s", bmc.CipherSuite))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("IPMITOOL_PORT=%d", bmc.Port))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("IPMITOOL_HOST=%s", bmc.Host))
+
+		in, err := cmd.StdinPipe()
+		if err != nil {
+			log.Error(err, "error getting stdin pipe")
+			s.Exit(2)
+			return
+		}
+		out, err := cmd.StdoutPipe()
+		if err != nil {
+			log.Error(err, "error getting stdout pipe")
+			s.Exit(2)
+			return
+		}
+		if err := cmd.Start(); err != nil {
+			log.Error(err, "error starting command")
+			s.Exit(2)
+			return
+		}
+
+		escapeReader, escapeWriter := io.Pipe()
+		mw := io.MultiWriter(in, escapeWriter)
+
+		exp := New()
+		wr := io.MultiWriter(s, exp)
+		globalState[s.User()] = State{
+			connectedSessions: make(map[string]struct{}),
+			mainClosed:        make(chan struct{}),
+			multiwriter:       exp,
+			stdin:             in,
+		}
+
+		// watch for escape sequences
+		// escape sequence is ~.
+		// if ~. is detected, close the session
+		go func() {
+			for {
+				b := make([]byte, 1)
+				_, err := escapeReader.Read(b)
+				if err != nil {
+					log.Error(err, "error reading escape sequence")
+					return
+				}
+				if b[0] == '~' {
+					_, err := escapeReader.Read(b)
+					if err != nil {
+						log.Error(err, "error reading escape sequence")
+						return
+					}
+					if b[0] == '.' {
+						log.Info("escape sequence detected")
+						s.Exit(0)
+						return
+					}
+				}
+			}
+		}()
+
+		go func() {
+			io.Copy(mw, s) // stdin
+		}()
+
+		io.Copy(wr, out) // stdout
+
+		if err := cmd.Wait(); err != nil {
+			ps := cmd.ProcessState
+			status := ps.Sys().(syscall.WaitStatus)
+			switch {
+			case status.Exited():
+				log.Info("process exited", "status", status.ExitStatus())
+			case status.Signaled():
+				log.Info("process signaled", "signal", status.Signal().String())
+			case status.Stopped():
+				log.Info("process stopped", "signal", status.Signal().String())
+			default:
+				log.Error(err, "error waiting for command")
+			}
+		}
+
+		if len(globalState[s.User()].connectedSessions) > 0 {
+			globalState[s.User()].mainClosed <- struct{}{}
+		}
+		// close all the channels in the tracker
+		close(globalState[s.User()].mainClosed)
+		delete(globalState, s.User())
+		log.Info("initial session closed")
+
+		deactivateArgs := []string{ipmitoolPath, "-I", "lanplus", "-E", "-H", bmc.Host, "-U", bmc.User, "-p", strconv.Itoa(bmc.Port), "sol", "deactivate"}
+		deactivateCmd := exec.CommandContext(context.Background(), deactivateArgs[0], deactivateArgs[1:]...)
+		deactivateCmd.Env = append(deactivateCmd.Env, fmt.Sprintf("IPMITOOL_PASSWORD=%s", bmc.Pass))
+		if out, err := deactivateCmd.CombinedOutput(); err != nil {
+			// TODO: Check if the error is due to the sol already being deactivated
+			log.Error(err, "error deactivating sol", "output", string(out))
+		}
+
+		log.Info("session closed")
+	}
+}

--- a/secondstar/internal/key.go
+++ b/secondstar/internal/key.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"context"
+	"log"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/tinkerbell/tinkerbell/pkg/data"
+)
+
+type Reader interface {
+	ReadBMCMachine(ctx context.Context, name string) (*data.BMCMachine, error)
+}
+
+func PubkeyAuth(r Reader) func(ssh.Context, ssh.PublicKey) bool {
+	return func(ctx ssh.Context, key ssh.PublicKey) bool {
+		hw, err := r.ReadBMCMachine(ctx, ctx.User())
+		if err != nil {
+			log.Printf("error getting hardware object: %v\n", err)
+			return false
+		}
+
+		if hw == nil {
+			log.Println("hardware object is nil")
+			return false
+		}
+
+		ctx.SetValue("bmc", *hw)
+		for _, k := range hw.SSHPublicKeys {
+			pkey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(k))
+			if err != nil {
+				continue
+			}
+			if ssh.KeysEqual(key, pkey) {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/secondstar/internal/multi.go
+++ b/secondstar/internal/multi.go
@@ -1,0 +1,65 @@
+// https://github.com/alanshaw/multiwriter
+package internal
+
+import (
+	"io"
+	"sync"
+)
+
+// MultiWriter is a writer that writes to multiple other writers.
+type MultiWriter struct {
+	sync.RWMutex
+	writers []io.Writer
+}
+
+// New creates a writer that duplicates its writes to all the provided writers,
+// similar to the Unix tee(1) command. Writers can be added and removed
+// dynamically after creation.
+//
+// Each write is written to each listed writer, one at a time. If a listed
+// writer returns an error, that overall write operation stops and returns the
+// error; it does not continue down the list.
+func New(writers ...io.Writer) *MultiWriter {
+	mw := &MultiWriter{writers: writers}
+	return mw
+}
+
+// Write writes some bytes to all the writers.
+func (mw *MultiWriter) Write(p []byte) (n int, err error) {
+	mw.RLock()
+	defer mw.RUnlock()
+
+	for _, w := range mw.writers {
+		n, err = w.Write(p)
+		if err != nil {
+			return
+		}
+
+		if n < len(p) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+
+	return len(p), nil
+}
+
+// Add appends a writer to the list of writers this multiwriter writes to.
+func (mw *MultiWriter) Add(w io.Writer) {
+	mw.Lock()
+	mw.writers = append(mw.writers, w)
+	mw.Unlock()
+}
+
+// Remove will remove a previously added writer from the list of writers.
+func (mw *MultiWriter) Remove(w io.Writer) {
+	mw.Lock()
+	var writers []io.Writer
+	for _, ew := range mw.writers {
+		if ew != w {
+			writers = append(writers, ew)
+		}
+	}
+	mw.writers = writers
+	mw.Unlock()
+}

--- a/secondstar/secondstar.go
+++ b/secondstar/secondstar.go
@@ -1,0 +1,70 @@
+package secondstar
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	gssh "github.com/gliderlabs/ssh"
+	"github.com/go-logr/logr"
+	"github.com/tinkerbell/tinkerbell/pkg/data"
+	"github.com/tinkerbell/tinkerbell/secondstar/internal"
+	"golang.org/x/crypto/ssh"
+)
+
+type Reader interface {
+	ReadBMCMachine(ctx context.Context, name string) (*data.BMCMachine, error)
+}
+
+type Config struct {
+	SSHPort      int
+	HostKey      ssh.Signer
+	IPMITOOLPath string
+	Backend      Reader
+}
+
+func (c *Config) Start(ctx context.Context, log logr.Logger) error {
+	tracker := make(map[string]internal.State, 0)
+	handler := internal.Handler(ctx, log, tracker, c.IPMITOOLPath)
+
+	log.Info("starting ssh server", "port", c.SSHPort)
+
+	server := &gssh.Server{
+		Addr:             fmt.Sprintf(":%d", c.SSHPort),
+		Handler:          handler,
+		PublicKeyHandler: internal.PubkeyAuth(c.Backend),
+		Banner:           "Welcome to SecondStar\n",
+	}
+
+	if c.HostKey != nil {
+		server.AddHostKey(c.HostKey)
+	}
+
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down ssh server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		server.Shutdown(shutdownCtx)
+	}()
+
+	if err := server.ListenAndServe(); err != nil && err != gssh.ErrServerClosed {
+		return fmt.Errorf("failed to listen: %w", err)
+	}
+	return nil
+}
+
+// HostKeyFrom reads a host key from a file and returns a signer.
+func HostKeyFrom(filePath string) (ssh.Signer, error) {
+	hostKey, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading host key: %w", err)
+	}
+	signer, err := ssh.ParsePrivateKey(hostKey)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing host key: %w", err)
+	}
+
+	return signer, nil
+}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This implements a new feature for getting access to a serial-over-lan interface with SSH. Serial over SSH. The "service" or code is organized into a package name `secondstar`, as in the location of Neverland in the modern Peter Pan story. "_Second star to the right and straight on 'til morning_".

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
