### PR TITLE
Add embedded build tags to apiserver pkg: add cache for binaries:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,18 @@ jobs:
           sudo mount -o remount,size=3G /run/user/1001 || true
           go get -t ./... && go mod tidy
 
+      - name: Restore Go cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          # always grab from the restore-keys pattern below,
+          # like Linux-go-$hash-YYYY-MM-DD as saved by CI
+          key: nonexistent
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('go.mod') }}-
+
       - name: Compile binaries for ${{ matrix.name }}
         run: make ${{ matrix.make-target }}
       

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1,3 +1,6 @@
+//go:build embedded
+// +build embedded
+
 package apiserver
 
 import (


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This keeps this isolated to when embedding is used. Also, enabled a build cache for binary builds.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
