### PR TITLE
small Helm chart fixes ref ports for disabled services and actually disabling SecondStar

### DIFF
--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -190,6 +190,7 @@ spec:
             - name: TINKERBELL_ENABLE_RUFIO_CONTROLLER
               value: {{ .Values.deployment.envs.globals.enableRufioController | quote }}
           ports:
+          {{- if .Values.deployment.envs.globals.enableSmee }}
             {{- with .Values.deployment.ports.tftp }}
             - containerPort: {{ .port }}
               name: {{ .name }}
@@ -210,6 +211,7 @@ spec:
               name: {{ .name }}
               protocol: {{ .protocol }}
             {{- end }}
+          {{- end }}
             {{- with .Values.deployment.ports.httpTootles }}
             - containerPort: {{ .port }}
               name: {{ .name }}

--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -189,6 +189,8 @@ spec:
               value: {{ .Values.deployment.envs.globals.enableTinkController | quote }}
             - name: TINKERBELL_ENABLE_RUFIO_CONTROLLER
               value: {{ .Values.deployment.envs.globals.enableRufioController | quote }}
+            - name: TINKERBELL_ENABLE_SECONDSTAR
+              value: {{ .Values.deployment.envs.globals.enableSecondstar | quote }}
           ports:
           {{- if .Values.deployment.envs.globals.enableSmee }}
             {{- with .Values.deployment.ports.tftp }}
@@ -222,10 +224,12 @@ spec:
               name: {{ .name }}
               protocol: {{ .protocol }}
             {{- end }}
+          {{- if .Values.deployment.envs.globals.enableSecondstar }}
             {{- with .Values.deployment.ports.ssh }}
             - containerPort: {{ .port }}
               name: {{ .name }}
               protocol: {{ .protocol }}
+          {{- end }}
             {{- end }}
           resources: {{ toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:

--- a/helm/tinkerbell/templates/service.yaml
+++ b/helm/tinkerbell/templates/service.yaml
@@ -24,6 +24,7 @@ spec:
     targetPort: 50061
     protocol: TCP
     name: http-tootles
+  {{- if .Values.deployment.envs.globals.enableSmee }}
   - port: 69
     targetPort: 69
     protocol: UDP
@@ -40,6 +41,7 @@ spec:
     targetPort: 7171
     protocol: TCP
     name: http-ipxe
+  {{- end }}
   - port: 2222
     targetPort: 2222
     protocol: TCP

--- a/helm/tinkerbell/templates/service.yaml
+++ b/helm/tinkerbell/templates/service.yaml
@@ -42,9 +42,11 @@ spec:
     protocol: TCP
     name: http-ipxe
   {{- end }}
+  {{- if .Values.deployment.envs.globals.enableSecondstar }}
   - port: 2222
     targetPort: 2222
     protocol: TCP
     name: ssh
+  {{- end }}
   selector:
     app: tinkerbell

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -1,4 +1,3 @@
-
 # trusted_proxies=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
 # LB_IP=192.168.2.116
 # the ARTIFACTS_FILE_SERVER is used to set the load balancer IP for the HookOS/nginx service object and will be used to configure TINKERBELL_IPXE_HTTP_SCRIPT_OSIE_URL in the Tinkerbell deployment.
@@ -175,9 +174,6 @@ rbac:
   name: tink-controller-role # or tink-controller-cluster-role
   bindingName: tink-controller-rolebinding # or tink-controller-cluster-rolebinding
   serviceAccountName: tinkerbell
-
-publicIP: 192.168.2.114
-trustedProxies: []
 
 # hookos objects enables downloading and serving HookOS artifacts.
 # it is optional and enabled by default.


### PR DESCRIPTION
- helm/tinkerbell: allow actually disabling SecondStar, and if so, don't declare its port 
- helm/tinkerbell: if not deploying Smee, don't declare its ports 
- helm/tinkerbell: drop duplicate publicIP/trustedProxies in values.yaml 