### PR TITLE
helm/tinkerbell: allow turning the Deployment into a Daemonset

### DIFF
--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -2,15 +2,22 @@
 {{- $trustedProxies := .Values.trustedProxies }}
 {{- $sourceInterface := .Values.deployment.init.sourceInterface }}
 {{- $dhcpInterfaceType := .Values.deployment.init.interfaceMode }}
+{{- if .Values.deployment.daemonSet.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+{{- else }}
 apiVersion: apps/v1
 kind: Deployment
+{{- end }}
 metadata:
   labels:
     app: {{ .Values.name }}
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  {{- if not .Values.deployment.daemonSet.enabled }}
   replicas: {{ .Values.deployment.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.name }}
@@ -18,8 +25,10 @@ spec:
       {{- with .Values.deployment.selector }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+  {{- if not .Values.deployment.daemonSet.enabled }}
   strategy:
     type: {{ .Values.deployment.strategy.type }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -38,6 +38,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      nodeSelector:
+        {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{- if .Values.deployment.init.enabled }}
       hostPID: true
       {{- end }}

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -11,6 +11,8 @@ publicIP:
 trustedProxies: []
 artifactsFileServer:
 deployment:
+  daemonSet:
+    enabled: false
   image: ghcr.io/tinkerbell/tinkerbell:latest
   imagePullPolicy: IfNotPresent
   replicas: 1

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -23,6 +23,7 @@ deployment:
   toleration: []
   affinity: {}
   selector: {}
+  nodeSelector: {}
   envs:
     rufio:
       enableLeaderElection: true


### PR DESCRIPTION
Quick way. One day we could refactor the podSpec into a separate helper and re-use common parts across split deployment/daemonset .yaml templates, but again, most shared settings are already under the "deployment" key.

- helm/tinkerbell: allow turning the Deployment into a Daemonset
- helm/tinkerbell: add nodeSelector 
