### PR TITLE
[HELM CHART] Make kernel parameters configurable:

### DIFF
--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -132,7 +132,7 @@ spec:
             - name: TINKERBELL_IPXE_HTTP_SCRIPT_BIND_PORT
               value: {{ .Values.deployment.envs.smee.ipxeHttpScriptBindPort | quote }}
             - name: TINKERBELL_IPXE_HTTP_SCRIPT_EXTRA_KERNEL_ARGS
-              value: tink_worker_image=ghcr.io/tinkerbell/tink-agent:latest
+              value: {{ join " " ( append .Values.deployment.envs.smee.ipxeHttpScriptExtraKernelArgs ( printf "tink_worker_image=%s" .Values.deployment.agentImage ) ) | quote }}
             - name: TINKERBELL_IPXE_SCRIPT_TRUSTED_PROXIES
               value: {{ ( join "," $trustedProxies ) | quote }}
             - name: TINKERBELL_IPXE_HTTP_SCRIPT_RETRIES

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -14,6 +14,7 @@ deployment:
     enabled: false
   image: ghcr.io/tinkerbell/tinkerbell:latest
   imagePullPolicy: IfNotPresent
+  agentImage: ghcr.io/tinkerbell/tink-agent:latest
   replicas: 1
   args: []
   additionalEnvs: []
@@ -66,7 +67,8 @@ deployment:
       ipxeHttpScriptEnabled: true
       ipxeHttpScriptBindAddr: ""
       ipxeHttpScriptBindPort: 7171
-      ipxeHttpScriptExtraKernelArgs: ""
+      # Additional kernel arguments to pass to the OSIE. (k=v k=v) that are appended to the kernel cmdline in the iPXE script
+      ipxeHttpScriptExtraKernelArgs: []
       #ipxeHttpScriptTrustedProxies: ""
       ipxeHttpScriptRetries: 1
       ipxeHttpScriptRetryDelay: 1


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This plums through configuring kernel parameters for the iPXE `auto.ipxe` script. It handles appending the Tink Agent container image to any specified parameters.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
