### PR TITLE
Fix image base for GHA release:

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - "v*"
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}
+  IMAGE: ghcr.io/tinkerbell
   REGISTRY: ghcr.io
 
 jobs:
@@ -32,14 +32,14 @@ jobs:
           # We do this instead of using docker/metadata-action because the helm chart
           # uses a tag of vX.Y.Z-<sha> and with docker/metadata-action I couldn't find a
           # way to get this tag format for the existing helm chart image.
-          echo "SRC_IMAGE=${{ env.IMAGE }}/${{ matrix.name }}:$(crane ls ${{ env.IMAGE }}/${{ matrix.name }} | grep $(git rev-parse --short HEAD))" >> "$GITHUB_ENV"
+          echo "SRC_IMAGE=${{ env.IMAGE_BASE }}/${{ matrix.name }}:$(crane ls ${{ env.IMAGE_BASE }}/${{ matrix.name }} | grep $(git rev-parse --short HEAD))" >> "$GITHUB_ENV"
 
       - name: Release tags
         id: meta
         uses: docker/metadata-action@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          images: ${{ env.IMAGE }}/${{ matrix.name }}
+          images: ${{ env.IMAGE_BASE }}/${{ matrix.name }}
           flavor: latest=false
           tags: |
             # {{version}} is major.minor.patch


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Using `${{ github.repository }}` caused the `IMAGE` variable to be `ghcr.io/tinkerbell/tinkerbell`. In the job matrix this caused the names to be `ghcr.io/tinkerbell/tinkerbell/tinkerbell` and `ghcr.io/tinkerbell/tinkerbell/tink-agent`, etc.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
