### PR TITLE
helm/tinkerbell: fix namespace references

### DIFF
--- a/helm/tinkerbell/templates/hookos/download-configmap.yaml
+++ b/helm/tinkerbell/templates/hookos/download-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: download-hook
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 data:
   entrypoint.sh: |-
     #!/usr/bin/env bash

--- a/helm/tinkerbell/templates/hookos/pvc.yaml
+++ b/helm/tinkerbell/templates/hookos/pvc.yaml
@@ -4,7 +4,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .Values.hookos.persistence.localPersistentVolume.storageClassName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 ---
@@ -35,7 +35,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hook-artifacts
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- with .Values.hookos.persistence.localPersistentVolume.extraLabels }}
     {{- toYaml . | nindent 4 }}

--- a/helm/tinkerbell/templates/leader-election-role-binding.yaml
+++ b/helm/tinkerbell/templates/leader-election-role-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tinkerbell
-  namespace: "tinkerbell"
+  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tinkerbell
-  namespace: "tinkerbell"
+  namespace: {{ .Release.Namespace | quote }}

--- a/helm/tinkerbell/templates/leader-election-role.yaml
+++ b/helm/tinkerbell/templates/leader-election-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: tinkerbell
-  namespace: "tinkerbell"
+  namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups:
   - ""

--- a/helm/tinkerbell/templates/role-binding.yaml
+++ b/helm/tinkerbell/templates/role-binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tinkerbell
-    namespace: "tinkerbell"
+    namespace: {{ .Release.Namespace | quote }}

--- a/helm/tinkerbell/templates/service-account.yaml
+++ b/helm/tinkerbell/templates/service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tinkerbell
-  namespace: "tinkerbell"
+  namespace: {{ .Release.Namespace | quote }}

--- a/helm/tinkerbell/templates/service.yaml
+++ b/helm/tinkerbell/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: tinkerbell
   name: tinkerbell
-  namespace: tinkerbell
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
   type: {{ .Values.service.type }}


### PR DESCRIPTION
A few hardcoded `"tinkerbell"` namespace in the Helm Chart. Replace with Release's namespace. Standardize on the quote.