### PR TITLE
Increase syslog message buffer to 32kb:

### DIFF
--- a/smee/internal/syslog/message.go
+++ b/smee/internal/syslog/message.go
@@ -53,7 +53,7 @@ const (
 )
 
 type message struct {
-	buf  [2048]byte
+	buf  [32768]byte // 32kB, this is the max buffer size.
 	size int
 	time time.Time
 	host net.IP


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
With the Agent now logging attributes at start up the log message with the attributes was not being captured properly in the syslog receiver and the attributes log line was not logged at all. Increasing the buffer allows for larger log lines send over syslog to get logged properly.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
