### PR TITLE
Add env var for enable/disable CRD migrations:

### DIFF
--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -202,6 +202,8 @@ spec:
               value: {{ .Values.deployment.envs.globals.enableRufioController | quote }}
             - name: TINKERBELL_ENABLE_SECONDSTAR
               value: {{ .Values.deployment.envs.globals.enableSecondstar | quote }}
+            - name: TINKERBELL_ENABLE_CRD_MIGRATIONS
+              value: {{ .Values.deployment.envs.globals.enableCRDMigrations | quote }}
           ports:
           {{- if .Values.deployment.envs.globals.enableSmee }}
             {{- with .Values.deployment.ports.tftp }}

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -112,6 +112,7 @@ deployment:
       enableTinkController: true
       enableRufioController: true
       enableSecondstar: true
+      enableCRDMigrations: true
   hostNetwork: false
   ports:
     tftp:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This is needed if users don't want Tinkerbell to touch any existing CRDs.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
