### PR TITLE
small GHA/CI fixes for iPXE building

### DIFF
--- a/.github/workflows/ipxe.yaml
+++ b/.github/workflows/ipxe.yaml
@@ -1,6 +1,8 @@
 name: iPXE Build
 on:
   push:
+    paths:
+      - "smee/internal/ipxe/binary/file/script/**"
     branches:
       - main
 

--- a/.github/workflows/ipxe.yaml
+++ b/.github/workflows/ipxe.yaml
@@ -19,4 +19,5 @@ jobs:
       - name: Build iPXE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IPXE_TARGET_GH_OWNER_REPO: ${{ github.repository }}
         run: (cd smee/internal/ipxe/binary/file/; MAKEFLAGS=-j$(nproc) ./script/build_and_pr.sh)

--- a/smee/internal/ipxe/binary/file/script/build_and_pr.sh
+++ b/smee/internal/ipxe/binary/file/script/build_and_pr.sh
@@ -35,7 +35,7 @@ binaries=(
 
 git_email="github-actions[bot]@users.noreply.github.com"
 git_name="github-actions[bot]"
-repo="tinkerbell/tinkerbell"
+repo="${IPXE_TARGET_GH_OWNER_REPO:-"tinkerbell/tinkerbell"}"
 
 # check for the GITHUB_TOKEN environment variable
 function check_github_token() {
@@ -142,7 +142,7 @@ function commit_changes() {
 # push changes to origin
 function push_changes() {
     local branch="${1}"
-    local repository="${2:-tinkerbell/tinkerbell}"
+    local repository="${2:-"${IPXE_TARGET_GH_OWNER_REPO:-"tinkerbell/tinkerbell"}"}"
     local git_actor="${3:-github-actions[bot]}"
     local token="${4:-${GITHUB_TOKEN}}"
 

--- a/smee/internal/ipxe/binary/file/script/build_and_pr.sh
+++ b/smee/internal/ipxe/binary/file/script/build_and_pr.sh
@@ -43,6 +43,11 @@ function check_github_token() {
     echo "GITHUB_TOKEN is not set"
     exit 1
   fi
+  echo "Checking for 'gh' CLI"
+  if ! command -v gh &> /dev/null; then
+    echo "'gh' CLI is not installed. Please install it to use this script."
+    exit 3
+  fi
 }
 
 # check for changes to iPXE files
@@ -160,7 +165,7 @@ function create_pull_request() {
 
     # create pull request
     echo "Creating pull request"
-    if ! script/gh pr create --base "${base}" --body "${body}" --title "${title}" --head "${branch}"; then
+    if ! gh pr create --base "${base}" --body "${body}" --title "${title}" --head "${branch}"; then
         echo "Failed to create pull request" 1>&2
         exit 1
     fi

--- a/smee/internal/ipxe/binary/file/script/shell.nix
+++ b/smee/internal/ipxe/binary/file/script/shell.nix
@@ -21,6 +21,7 @@ in
             expect
             gcc12
             git
+            gh
             gnumake
             gnused
             go


### PR DESCRIPTION
#### smee: ipxe: gha: introduce IPXE_TARGET_GH_OWNER_REPO

- so forks can get GHA ipxe builds going

#### smee: ipxe: gha: only trigger on changes to `smee/internal/ipxe/binary/file/script`'s files

- and not on every push

#### smee: ipxe: build: use `gh` from nix

- remove `gh` binary


