### PR TITLE
Quieter Agent logging:

### DIFF
--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -65,6 +65,9 @@ func (c *Config) Run(ctx context.Context, log logr.Logger) {
 			if errors.Is(err, context.Canceled) {
 				return
 			}
+			if isNoWorkflow(err) {
+				continue
+			}
 			log.Info("error reading/retrieving action", "error", err)
 			continue
 		}
@@ -389,4 +392,17 @@ func humanDuration(d time.Duration, precision int) string {
 
 	// Join all parts with spaces
 	return strings.Join(parts, "")
+}
+
+func isNoWorkflow(err error) bool {
+	type noWorkflow interface {
+		NoWorkflow() bool
+	}
+	if err == nil {
+		return false
+	}
+	if _, ok := err.(noWorkflow); ok {
+		return true
+	}
+	return false
 }

--- a/tink/agent/internal/transport/grpc/error.go
+++ b/tink/agent/internal/transport/grpc/error.go
@@ -1,0 +1,11 @@
+package grpc
+
+type NoWorkflowError struct{}
+
+func (e *NoWorkflowError) Error() string {
+	return "No workflow found"
+}
+
+func (e *NoWorkflowError) NoWorkflow() bool {
+	return true
+}

--- a/tink/agent/internal/transport/grpc/grpc.go
+++ b/tink/agent/internal/transport/grpc/grpc.go
@@ -14,8 +14,10 @@ import (
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -50,6 +52,9 @@ func (c *Config) Read(ctx context.Context) (spec.Action, error) {
 func (c *Config) doRead(ctx context.Context) (spec.Action, error) {
 	response, err := c.TinkServerClient.GetAction(ctx, &proto.ActionRequest{WorkerId: toPtr(c.WorkerID), WorkerAttributes: c.Attributes})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return spec.Action{}, &NoWorkflowError{}
+		}
 		return spec.Action{}, fmt.Errorf("error getting action: %w", err)
 	}
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Logging all errors generically when reading/retrieving actions adds noise to the logs and with high numbers of Agents would cause way too much noise. Also, the error logs can potentially confuse users about actual errors vs just no Workflow is available at the moment. This logs only when the error is not an error related to a Workflows not available.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
