### PR TITLE
fix: remove duplicate `type`

### DIFF
--- a/helm/tinkerbell/templates/service.yaml
+++ b/helm/tinkerbell/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: tinkerbell
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   {{- if .Values.service.lbClass }}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This PR removes the duplicate `type` from the Service definition
## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #159 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?
Fixes a bug, no additional steps are required.
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
