### PR TITLE
Add WorkflowRuleSets ClusterRole:

### DIFF
--- a/helm/tinkerbell/templates/role.yaml
+++ b/helm/tinkerbell/templates/role.yaml
@@ -3,36 +3,18 @@ kind: ClusterRole
 metadata:
   name: tinkerbell
 rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
     verbs: ["create", "get", "list", "patch", "update", "delete"]
-  - apiGroups:
-      - tinkerbell.org
-    resources:
-      - hardware
-      - hardware/status
-      - templates
-      - templates/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - tinkerbell.org
-    resources:
-      - workflows
-      - workflows/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-      - delete
+  - apiGroups: ["tinkerbell.org"]
+    resources: ["hardware", "hardware/status", "templates", "templates/status"]
+    verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["tinkerbell.org"]
+    resources: ["workflows", "workflows/status"]
+    verbs: ["get", "list", "patch", "update", "watch", "delete", "create"]
+  - apiGroups: ["tinkerbell.org"]
+    resources: ["workflowrulesets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This is needed so that Tink Server can read the WorkflowRuleSets. Updated the formatting of all ClusterRole rules so that they use the same yaml formatting.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
