### PR TITLE
Move retries to tink-server:

### DIFF
--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -249,7 +249,6 @@ func (o *Options) ConfigureAndRun(ctx context.Context, log logr.Logger, id strin
 			Log:              log,
 			TinkServerClient: proto.NewWorkflowServiceClient(conn),
 			AgentID:          id,
-			RetryInterval:    time.Second * 5,
 			Actions:          make(chan spec.Action),
 		}
 		if o.AttributeDetectionEnabled {

--- a/tink/agent/internal/transport/grpc/grpc.go
+++ b/tink/agent/internal/transport/grpc/grpc.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/go-logr/logr"
@@ -28,7 +27,6 @@ type Config struct {
 	Log              logr.Logger
 	TinkServerClient proto.WorkflowServiceClient
 	AgentID          string
-	RetryInterval    time.Duration
 	Actions          chan spec.Action
 	Attributes       *data.AgentAttributes
 }

--- a/tink/agent/internal/transport/grpc/grpc_test.go
+++ b/tink/agent/internal/transport/grpc/grpc_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cenkalti/backoff/v5"
 	"github.com/google/go-cmp/cmp"
 	"github.com/tinkerbell/tinkerbell/pkg/proto"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
@@ -93,9 +92,6 @@ func TestRead(t *testing.T) {
 			config := &Config{
 				TinkServerClient: mockClient,
 				AgentID:          "worker-123",
-				RetryOptions: []backoff.RetryOption{
-					backoff.WithMaxTries(1),
-				},
 			}
 
 			ctx := context.Background()
@@ -139,9 +135,6 @@ func TestWrite(t *testing.T) {
 			config := &Config{
 				TinkServerClient: mockClient,
 				AgentID:          "worker-123",
-				RetryOptions: []backoff.RetryOption{
-					backoff.WithMaxTries(1),
-				},
 			}
 
 			ctx := context.Background()

--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -62,7 +62,7 @@ func (h *Handler) GetAction(ctx context.Context, req *proto.ActionRequest) (*pro
 	if len(h.RetryOptions) == 0 {
 		h.RetryOptions = []backoff.RetryOption{
 			backoff.WithMaxElapsedTime(time.Minute),
-			backoff.WithBackOff(backoff.NewExponentialBackOff()),
+			backoff.WithBackOff(backoff.NewConstantBackOff(time.Second)),
 		}
 	}
 	// We retry multiple times as we read-write to the Workflow Status and there can be caching and eventually consistent issues
@@ -276,7 +276,7 @@ func (h *Handler) ReportActionStatus(ctx context.Context, req *proto.ActionStatu
 	if len(h.RetryOptions) == 0 {
 		h.RetryOptions = []backoff.RetryOption{
 			backoff.WithMaxElapsedTime(time.Minute),
-			backoff.WithBackOff(backoff.NewExponentialBackOff()),
+			backoff.WithBackOff(backoff.NewConstantBackOff(time.Second)),
 		}
 	}
 	// We retry multiple times as we read-write to the Workflow Status and there can be caching and eventually consistent issues

--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -62,7 +62,7 @@ func (h *Handler) GetAction(ctx context.Context, req *proto.ActionRequest) (*pro
 	if len(h.RetryOptions) == 0 {
 		h.RetryOptions = []backoff.RetryOption{
 			backoff.WithMaxElapsedTime(time.Minute),
-			backoff.WithBackOff(backoff.NewConstantBackOff(time.Second)),
+			backoff.WithBackOff(backoff.NewExponentialBackOff()),
 		}
 	}
 	// We retry multiple times as we read-write to the Workflow Status and there can be caching and eventually consistent issues
@@ -276,7 +276,7 @@ func (h *Handler) ReportActionStatus(ctx context.Context, req *proto.ActionStatu
 	if len(h.RetryOptions) == 0 {
 		h.RetryOptions = []backoff.RetryOption{
 			backoff.WithMaxElapsedTime(time.Minute),
-			backoff.WithBackOff(backoff.NewConstantBackOff(time.Second)),
+			backoff.WithBackOff(backoff.NewExponentialBackOff()),
 		}
 	}
 	// We retry multiple times as we read-write to the Workflow Status and there can be caching and eventually consistent issues

--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -61,8 +61,8 @@ func (h *Handler) GetAction(ctx context.Context, req *proto.ActionRequest) (*pro
 	}
 	if len(h.RetryOptions) == 0 {
 		h.RetryOptions = []backoff.RetryOption{
-			backoff.WithMaxElapsedTime(time.Minute * 1),
-			backoff.WithBackOff(backoff.NewExponentialBackOff()),
+			backoff.WithMaxElapsedTime(time.Minute),
+			backoff.WithBackOff(backoff.NewConstantBackOff(time.Second)),
 		}
 	}
 	// We retry multiple times as we read-write to the Workflow Status and there can be caching and eventually consistent issues
@@ -275,8 +275,8 @@ func (h *Handler) ReportActionStatus(ctx context.Context, req *proto.ActionStatu
 	}
 	if len(h.RetryOptions) == 0 {
 		h.RetryOptions = []backoff.RetryOption{
-			backoff.WithMaxElapsedTime(time.Minute * 5),
-			backoff.WithBackOff(backoff.NewExponentialBackOff()),
+			backoff.WithMaxElapsedTime(time.Minute),
+			backoff.WithBackOff(backoff.NewConstantBackOff(time.Second)),
 		}
 	}
 	// We retry multiple times as we read-write to the Workflow Status and there can be caching and eventually consistent issues


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Having retries in both tink-server and tink-agent caused noticeable delays in Workflow Actions running. With retries in tink-server only the delays disappeared. Benchmarking showed improved performance as well. A rudimentary benchmark showed over 1000 concurrent Agents performed fine. This is a not an official benchmark as the backing Kubernetes cluster plays a significant part in the performance and the benchmark was done with a local k3d cluster.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
