### PR TITLE
Validate DHCP fields instead of requiring them:

### DIFF
--- a/pkg/backend/kube/kube_test.go
+++ b/pkg/backend/kube/kube_test.go
@@ -91,10 +91,6 @@ func TestToDHCPData(t *testing.T) {
 			in:        nil,
 			shouldErr: true,
 		},
-		"no mac": {
-			in:        &v1alpha1.DHCP{},
-			shouldErr: true,
-		},
 		"bad mac": {
 			in:        &v1alpha1.DHCP{MAC: "bad"},
 			shouldErr: true,
@@ -107,8 +103,8 @@ func TestToDHCPData(t *testing.T) {
 			in:        &v1alpha1.DHCP{MAC: "aa:bb:cc:dd:ee:ff", IP: &v1alpha1.IP{Address: "192.168.2.4"}},
 			shouldErr: true,
 		},
-		"v1alpha1.IP == nil": {
-			in:        &v1alpha1.DHCP{MAC: "aa:bb:cc:dd:ee:ff", IP: nil},
+		"bad IP": {
+			in:        &v1alpha1.DHCP{MAC: "aa:bb:cc:dd:ee:ff", IP: &v1alpha1.IP{Address: "bad"}},
 			shouldErr: true,
 		},
 		"bad gateway": {

--- a/pkg/backend/kube/secondstar.go
+++ b/pkg/backend/kube/secondstar.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetByMac implements the handler.BackendReader interface and returns DHCP and netboot data based on a mac address.
+// ReadBMCMachine implements the handler.BackendReader interface and returns DHCP and netboot data based on a mac address.
 func (b *Backend) ReadBMCMachine(ctx context.Context, name string) (*data.BMCMachine, error) {
 	// get the hardware object, using the name, from the cluster
 	// get the ssh public keys from the hardware object, add them to the return data.BMCMachine object

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetHackInstance returns a hack.Instance by calling the getByIP method and converting the result.
+// GetHackInstance returns a hack.Instance by calling the hwByIP method and converting the result.
 // This is a method that the Tootles service uses.
 func (b *Backend) GetHackInstance(ctx context.Context, ip string) (data.HackInstance, error) {
 	hw, err := b.hwByIP(ctx, ip)
@@ -112,7 +112,7 @@ func toEC2Instance(hw v1alpha1.Hardware) data.Ec2Instance {
 
 func (b *Backend) hwByIP(ctx context.Context, ip string) (*v1alpha1.Hardware, error) {
 	tracer := otel.Tracer(tracerName)
-	ctx, span := tracer.Start(ctx, "backend.kube.GetByIP")
+	ctx, span := tracer.Start(ctx, "backend.kube.hwByIP")
 	defer span.End()
 	hardwareList := &v1alpha1.HardwareList{}
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This is needed because GetByMac and GetByIP both return data.DHCP and data.Netboot, but the DHCP proxy handler in Smee only needs data.Netboot. By only doing validation, the proxy handler functions properly.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #197 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
