### PR TITLE
Rename HookOS 6.6 kernel and initramfs after downloading:

### DIFF
--- a/helm/tinkerbell/templates/hookos/deployment.yaml
+++ b/helm/tinkerbell/templates/hookos/deployment.yaml
@@ -25,15 +25,6 @@ spec:
       containers:
       - name: {{ .Values.optional.hookos.name }}
         image: {{ .Values.optional.hookos.image }}
-        command: ["/bin/bash", "-xeuc"]
-        args:
-        - |
-          export POD_NAMESERVER=$(awk '/nameserver/ {print $2}' /etc/resolv.conf);
-          [[ $POD_NAMESERVER == *.* ]] || POD_NAMESERVER="[$POD_NAMESERVER]";
-          envsubst '$POD_NAMESERVER' \
-            </tmp/nginx.conf.template \
-            >/etc/nginx/nginx.conf
-          exec nginx -g 'daemon off;'
         ports:
         - containerPort: {{ .Values.optional.hookos.port }}
           protocol: TCP
@@ -46,7 +37,7 @@ spec:
             cpu: 10m
             memory: 64Mi
         volumeMounts:
-        - mountPath: /tmp
+        - mountPath: /etc/nginx
           readOnly: true
           name: nginx-conf
         - mountPath: /usr/share/nginx/html
@@ -64,9 +55,6 @@ spec:
       - name: nginx-conf
         configMap:
           name: nginx-conf
-          items:
-            - key: nginx.conf
-              path: nginx.conf.template
       - name: hook-artifacts
         persistentVolumeClaim:
           claimName: {{ coalesce .Values.optional.hookos.persistence.existingClaim .Values.optional.hookos.persistence.localPersistentVolume.name }}

--- a/helm/tinkerbell/templates/hookos/download-configmap.yaml
+++ b/helm/tinkerbell/templates/hookos/download-configmap.yaml
@@ -26,15 +26,15 @@ data:
     }
     
     function validate_option() {
-      local option="$1"
-      local valid_values="$2"
-      local value="$3"
+        local option="$1"
+        local valid_values="$2"
+        local value="$3"
     
-      if [[ ! " ${valid_values[@]} " =~ " ${value} " ]]; then
+        if [[ ! " ${valid_values[@]} " =~ " ${value} " ]]; then
         >&2 echo "Invalid value: '$value' for '${option}'. Valid values are: [${valid_values[*]}]"
         usage
         exit 1
-      fi
+        fi
     }
     
     
@@ -106,7 +106,7 @@ data:
         
         (cd "${out_dir}" && sha512sum -c <<< "${checksum_data}")
         if [ $? -ne 0 ]; then
-          return 1
+            return 1
         fi
         return 0
     }
@@ -139,55 +139,55 @@ data:
     
     args=$(getopt -a -o u:a:v:e:s:o:h --long url:,arch:,version:,ext:,specific-artifacts:,output-dir:,help -- "$@")
     if [[ $? -gt 0 ]]; then
-      usage
+        usage
     fi
     
     eval set -- ${args}
     while :
     do
-      case $1 in
+        case $1 in
         -u | --url)
-          if [[ ! -z $2 ]]; then
+            if [[ ! -z $2 ]]; then
             url=$2
-          fi
-          shift 2 ;;
+            fi
+            shift 2 ;;
         -a | --arch)
-          if [[ ! -z $2 ]]; then
+            if [[ ! -z $2 ]]; then
             validate_option "arch" "${valid_arches[*]}" $2
             arch=$2
-          fi
-          shift 2 ;;
+            fi
+            shift 2 ;;
         -v | --version)
-          if [[ ! -z $2 ]]; then
+            if [[ ! -z $2 ]]; then
             validate_option "version" "${valid_versions[*]}" $2
             version=$2
-          fi
-          shift 2 ;;
+            fi
+            shift 2 ;;
         -e | --ext)
-          if [[ ! -z $2 ]]; then
+            if [[ ! -z $2 ]]; then
             validate_option "ext" "${valid_exts[*]}" $2
             ext=$2
-          fi
-          shift 2 ;;
+            fi
+            shift 2 ;;
         -s | --specific-artifacts)
-          if [[ ! -z $2 ]]; then
+            if [[ ! -z $2 ]]; then
             specific_artifacts=$2
-          fi
-          shift 2 ;;
+            fi
+            shift 2 ;;
         -o | --output-dir)
-          if [[ ! -z $2 ]]; then
+            if [[ ! -z $2 ]]; then
             output_dir=$2
-          fi
-          shift 2 ;;
+            fi
+            shift 2 ;;
         -h | --help)
-          usage
-          exit 1
-          shift ;;
+            usage
+            exit 1
+            shift ;;
         # -- means the end of the arguments; drop this, and break out of the while loop
         --) shift; break ;;
         *) >&2 echo Unsupported option: $1
-           usage ;;
-      esac
+            usage ;;
+        esac
     done
     
     echo "==> Downloading HookOS artifacts from ${url} for architecture(s): ${arch} and extension(s): ${ext} and version(s): ${version}"
@@ -196,7 +196,7 @@ data:
     # 2. Generate a list of artifacts to download based on the options provided
     # 3. Run a checksum check for all artifacts to be downloaded. For artifacts that pass (meaning the artifact is already downloaded), do nothing. Make a list of artifacts that need downloaded.
     # 4. If all artifacts are already downloaded, sleep and wait for signals.
-    # 5. Download artifacts that need downloaded.
+    # 5. Download and extract artifacts that need downloaded.
     # 6. Run a checksum check for all downloaded artifacts.
     # 7. If all checksums pass, sleep and wait for signals. If any checksum fails, exit with 1.
     
@@ -224,7 +224,15 @@ data:
         if run_checksum512 "${checksums}" "${output_dir}"; then
             cd "${output_dir}"
             echo "==> Extracting existing artifacts"
-            for f in $(ls *.tar.gz | grep -vE "^dtbs"); do echo "==> Extracting ${f}"; tar --no-same-permissions --overwrite -ozxvf "${f}"; done
+            for f in $(ls *.tar.gz | grep -vE "^dtbs"); do echo "==> Extracting ${f}"; tar --no-same-permissions --overwrite -ozxvf "${f}"; done    
+            # If 6.6 is selected, create a symlink to the expected kernel naming convention
+            if [[ "${version}" == "6.6" ]]; then
+                echo "==> Creating symlinks for 6.6 kernel artifacts"
+                ln -sf ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
+                ln -sf ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
+                ln -sf ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
+                ln -sf ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
+            fi
             return 0
         fi
     
@@ -240,6 +248,14 @@ data:
         cd "${output_dir}"
         echo "==> Extracting artifacts"
         for f in $(ls *.tar.gz | grep -vE "^dtbs"); do echo "==> Extracting ${f}"; tar --no-same-permissions --overwrite -ozxvf "${f}"; done
+        # If 6.6 is selected, create a symlink to the expected kernel naming convention
+        if [[ "${version}" == "6.6" ]]; then
+            echo "==> Creating symlinks for 6.6 artifacts"
+            ln -sf ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
+            ln -sf ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
+            ln -sf ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
+            ln -sf ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
+        fi
     }
     
     if ! main; then

--- a/helm/tinkerbell/templates/hookos/download-configmap.yaml
+++ b/helm/tinkerbell/templates/hookos/download-configmap.yaml
@@ -125,7 +125,7 @@ data:
     }
 
     function rename_6_6_artifacts() {
-        # If 6.6 is selected, rename them to the expected kernel and initramfs naming convention expected by auto.ipxe
+        # rename them to the expected kernel and initramfs naming convention expected by auto.ipxe
         mv ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
         mv ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
         mv ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
@@ -233,7 +233,7 @@ data:
             cd "${output_dir}"
             echo "==> Extracting existing artifacts"
             for f in $(ls *.tar.gz | grep -vE "^dtbs"); do echo "==> Extracting ${f}"; tar --no-same-permissions --overwrite -ozxvf "${f}"; done    
-            # If 6.6 is selected, create a symlink to the expected kernel naming convention
+            # If 6.6 is selected, rename them to the expected kernel and initramfs naming convention expected by auto.ipxe
             if [[ "${version}" == "6.6" ]]; then
                 echo "==> Renaming 6.6 kernel artifacts"
                 rename_6_6_artifacts
@@ -253,7 +253,7 @@ data:
         cd "${output_dir}"
         echo "==> Extracting artifacts"
         for f in $(ls *.tar.gz | grep -vE "^dtbs"); do echo "==> Extracting ${f}"; tar --no-same-permissions --overwrite -ozxvf "${f}"; done
-        # If 6.6 is selected, create a symlink to the expected kernel naming convention
+        # If 6.6 is selected, rename them to the expected kernel and initramfs naming convention expected by auto.ipxe
         if [[ "${version}" == "6.6" ]]; then
             echo "==> Renaming 6.6 kernel artifacts"
             rename_6_6_artifacts

--- a/helm/tinkerbell/templates/hookos/download-configmap.yaml
+++ b/helm/tinkerbell/templates/hookos/download-configmap.yaml
@@ -123,6 +123,14 @@ data:
     
         echo "${checksums}"
     }
+
+    func rename_6_6_artifacts() {
+        # If 6.6 is selected, rename them to the expected kernel and initramfs naming convention expected by auto.ipxe
+        mv ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
+        mv ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
+        mv ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
+        mv ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
+    }
     
     # default values
     url="https://github.com/tinkerbell/hook/releases/download/latest"
@@ -228,10 +236,7 @@ data:
             # If 6.6 is selected, create a symlink to the expected kernel naming convention
             if [[ "${version}" == "6.6" ]]; then
                 echo "==> Renaming 6.6 kernel artifacts"
-                mv ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
-                mv ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
-                mv ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
-                mv ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
+                rename_6_6_artifacts
             fi
             return 0
         fi
@@ -251,10 +256,7 @@ data:
         # If 6.6 is selected, create a symlink to the expected kernel naming convention
         if [[ "${version}" == "6.6" ]]; then
             echo "==> Renaming 6.6 kernel artifacts"
-            mv ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
-            mv ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
-            mv ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
-            mv ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
+            rename_6_6_artifacts
         fi
     }
     

--- a/helm/tinkerbell/templates/hookos/download-configmap.yaml
+++ b/helm/tinkerbell/templates/hookos/download-configmap.yaml
@@ -124,7 +124,7 @@ data:
         echo "${checksums}"
     }
 
-    func rename_6_6_artifacts() {
+    function rename_6_6_artifacts() {
         # If 6.6 is selected, rename them to the expected kernel and initramfs naming convention expected by auto.ipxe
         mv ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
         mv ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64

--- a/helm/tinkerbell/templates/hookos/download-configmap.yaml
+++ b/helm/tinkerbell/templates/hookos/download-configmap.yaml
@@ -227,11 +227,11 @@ data:
             for f in $(ls *.tar.gz | grep -vE "^dtbs"); do echo "==> Extracting ${f}"; tar --no-same-permissions --overwrite -ozxvf "${f}"; done    
             # If 6.6 is selected, create a symlink to the expected kernel naming convention
             if [[ "${version}" == "6.6" ]]; then
-                echo "==> Creating symlinks for 6.6 kernel artifacts"
-                ln -sf ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
-                ln -sf ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
-                ln -sf ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
-                ln -sf ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
+                echo "==> Renaming 6.6 kernel artifacts"
+                mv ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
+                mv ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
+                mv ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
+                mv ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
             fi
             return 0
         fi
@@ -250,11 +250,11 @@ data:
         for f in $(ls *.tar.gz | grep -vE "^dtbs"); do echo "==> Extracting ${f}"; tar --no-same-permissions --overwrite -ozxvf "${f}"; done
         # If 6.6 is selected, create a symlink to the expected kernel naming convention
         if [[ "${version}" == "6.6" ]]; then
-            echo "==> Creating symlinks for 6.6 artifacts"
-            ln -sf ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
-            ln -sf ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
-            ln -sf ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
-            ln -sf ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
+            echo "==> Renaming 6.6 kernel artifacts"
+            mv ./initramfs-latest-lts-x86_64 ./initramfs-x86_64
+            mv ./vmlinuz-latest-lts-x86_64 ./vmlinuz-x86_64
+            mv ./vmlinuz-latest-lts-aarch64 ./vmlinuz-aarch64
+            mv ./initramfs-latest-lts-aarch64 ./initramfs-aarch64
         fi
     }
     

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -2,7 +2,7 @@
 # LB_IP=192.168.2.116
 # the ARTIFACTS_FILE_SERVER is used to set the load balancer IP for the HookOS/nginx service object and will be used to configure TINKERBELL_IPXE_HTTP_SCRIPT_OSIE_URL in the Tinkerbell deployment.
 # ARTIFACTS_FILE_SERVER=http://192.168.2.117:7173
-# helm install tinkerbell tinkerbell/ --create-namespace --namespace tinkerbell --wait --set "trustedProxies={${trusted_proxies}}" --set "publicIP=$LB_IP" --set "artifactsFileServer=$ARTIFACTS_FILE_SERVER" --set "deployment.agentImageTag=latest"
+# helm install tinkerbell tinkerbell/ --create-namespace --namespace tinkerbell --wait --set "trustedProxies={${trusted_proxies}}" --set "publicIP=$LB_IP" --set "artifactsFileServer=$ARTIFACTS_FILE_SERVER" --set "deployment.agentImageTag=latest" --set "deployment.imageTag=latest"
 artifactsFileServer:
 deploy: true
 deployment:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
When the 6.6 kernel is specified for download, this script renames `initramfs-latest-lts-` to `initramfs-` and `vmlinuz-latest-lts-` to `vmlinuz-`, ensuring they are named as expected by the `auto.ipxe` script.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
