### PR TITLE
add hostname to auto ipxe script

### DIFF
--- a/smee/internal/ipxe/script/hook.go
+++ b/smee/internal/ipxe/script/hook.go
@@ -18,7 +18,7 @@ set retry_delay:int32 {{ .RetryDelay }}
 set idx:int32 0
 :retry_kernel
 kernel ${download-url}/${kernel} {{- if ne .VLANID "" }} vlan_id={{ .VLANID }} {{- end }} {{- range .ExtraKernelParams}} {{.}} {{- end}} \
-facility={{ .Facility }} syslog_host={{ .SyslogHost }} grpc_authority={{ .TinkGRPCAuthority }} tinkerbell_tls={{ .TinkerbellTLS }} tinkerbell_insecure_tls={{ .TinkerbellInsecureTLS }} worker_id={{ .WorkerID }} hw_addr={{ .HWAddr }} \
+facility={{ .Facility }} syslog_host={{ .SyslogHost }} grpc_authority={{ .TinkGRPCAuthority }} tinkerbell_tls={{ .TinkerbellTLS }} tinkerbell_insecure_tls={{ .TinkerbellInsecureTLS }} worker_id={{ .WorkerID }} hw_addr={{ .HWAddr }} id={{ .Hostname }} \
 modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
 
 :download_initrd
@@ -66,4 +66,5 @@ type Hook struct {
 	RetryDelay            int    // number of seconds to wait between retries
 	Kernel                string // name of the kernel file
 	Initrd                string // name of the initrd file
+	Hostname              string // example rack01-server02
 }

--- a/smee/internal/ipxe/script/ipxe.go
+++ b/smee/internal/ipxe/script/ipxe.go
@@ -53,6 +53,7 @@ type info struct {
 	IPXEScript    string
 	IPXEScriptURL *url.URL
 	OSIE          OSIE
+	Hostname      string
 }
 
 // OSIE or OS Installation Environment is the data about where the OSIE parts are located.
@@ -83,6 +84,7 @@ func getByMac(ctx context.Context, mac net.HardwareAddr, br BackendReader) (info
 		Arch:          d.Arch,
 		VLANID:        d.VLANID,
 		WorkflowID:    d.MACAddress.String(),
+		Hostname:      d.Hostname,
 		Facility:      n.Facility,
 		IPXEScript:    n.IPXEScript,
 		IPXEScriptURL: n.IPXEScriptURL,
@@ -106,6 +108,7 @@ func getByIP(ctx context.Context, ip net.IP, br BackendReader) (info, error) {
 		Arch:          d.Arch,
 		VLANID:        d.VLANID,
 		WorkflowID:    d.MACAddress.String(),
+		Hostname:      d.Hostname,
 		Facility:      n.Facility,
 		IPXEScript:    n.IPXEScript,
 		IPXEScriptURL: n.IPXEScriptURL,
@@ -298,6 +301,7 @@ func (h *Handler) defaultScript(span trace.Span, hw info) (string, error) {
 		WorkerID:              wID,
 		Retries:               h.IPXEScriptRetries,
 		RetryDelay:            h.IPXEScriptRetryDelay,
+		Hostname:              hw.Hostname,
 	}
 	if hw.OSIE.BaseURL != nil && hw.OSIE.BaseURL.String() != "" {
 		auto.DownloadURL = hw.OSIE.BaseURL.String()


### PR DESCRIPTION
when booting osie we need to know the hostname to update the metadata and hw-info on self-test.

today we don't have any way to pass on a single hardware information that would be passed to the osie when first boot.

this extention will add the id={hostname} to the /proc/cmdline which will allow hwinfo process to extract this field and update selftest.

on v1beta1 we will have a more generic way to pass in kernel args on the hardware level.

we used to use facility but for some-reason this is not passed on by https://github.com/tinkerbell/dhcp which is the current kube-backend for tink:

When the OSIE boots our tink-agent is using the hostname to lookup some values and configure our metadata server. We need this info when we boot, before we start the rootfs inauguration.

https://github.com/tinkerbell/dhcp/blame/d8def67df9bdce1ff5269cd475094f08f25900bf/backend/kube/kube.go#L276

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
