### PR TITLE
Plum through enabling/disabling netboot:

### DIFF
--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -39,6 +39,7 @@ func RegisterSmeeFlags(fs *Set, sc *SmeeConfig) {
 	fs.Register(SmeeLogLevel, ffval.NewValueDefault(&sc.LogLevel, sc.LogLevel))
 	// DHCP flags
 	fs.Register(DHCPEnabled, ffval.NewValueDefault(&sc.Config.DHCP.Enabled, sc.Config.DHCP.Enabled))
+	fs.Register(DHCPEnableNetbootOptions, ffval.NewValueDefault(&sc.Config.DHCP.EnableNetbootOptions, sc.Config.DHCP.EnableNetbootOptions))
 	fs.Register(DHCPModeFlag, &sc.Config.DHCP.Mode)
 	fs.Register(DHCPBindAddr, &ntip.Addr{Addr: &sc.Config.DHCP.BindAddr})
 	fs.Register(DHCPBindInterface, ffval.NewValueDefault(&sc.Config.DHCP.BindInterface, sc.Config.DHCP.BindInterface))
@@ -380,4 +381,9 @@ var TinkServerInsecureTLS = Config{
 var SmeeLogLevel = Config{
 	Name:  "smee-log-level",
 	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
+}
+
+var DHCPEnableNetbootOptions = Config{
+	Name:  "dhcp-enable-netboot-options",
+	Usage: "[dhcp] enable sending netboot DHCP options",
 }

--- a/smee/smee.go
+++ b/smee/smee.go
@@ -144,7 +144,10 @@ type IPXEHTTPScriptServer struct {
 }
 
 type DHCP struct {
+	// Enabled configures whether the DHCP server is enabled.
 	Enabled bool
+	// EnableNetbootOptions configures whether sending netboot options is enabled.
+	EnableNetbootOptions bool
 	// Mode determines the behavior of the DHCP server.
 	// See the DHCPMode type for valid values.
 	Mode DHCPMode
@@ -197,11 +200,12 @@ type TinkServer struct {
 func NewConfig(c Config, publicIP netip.Addr) *Config {
 	defaults := &Config{
 		DHCP: DHCP{
-			Enabled:       true,
-			Mode:          DefaultDHCPMode,
-			BindAddr:      netip.MustParseAddr("0.0.0.0"),
-			BindPort:      67,
-			BindInterface: "",
+			Enabled:              true,
+			EnableNetbootOptions: true,
+			Mode:                 DefaultDHCPMode,
+			BindAddr:             netip.MustParseAddr("0.0.0.0"),
+			BindPort:             67,
+			BindInterface:        "",
 			IPXEHTTPBinaryURL: &url.URL{
 				Scheme: "http",
 				Path:   "/ipxe",
@@ -479,7 +483,7 @@ func (c *Config) dhcpHandler(log logr.Logger) (server.Handler, error) {
 				IPXEBinServerTFTP: tftpIP,
 				IPXEBinServerHTTP: &httpBinaryURL,
 				IPXEScriptURL:     ipxeScript,
-				Enabled:           true,
+				Enabled:           c.DHCP.EnableNetbootOptions,
 			},
 			OTELEnabled: true,
 			SyslogAddr:  c.DHCP.SyslogIP,
@@ -494,7 +498,7 @@ func (c *Config) dhcpHandler(log logr.Logger) (server.Handler, error) {
 				IPXEBinServerTFTP: tftpIP,
 				IPXEBinServerHTTP: &httpBinaryURL,
 				IPXEScriptURL:     ipxeScript,
-				Enabled:           true,
+				Enabled:           c.DHCP.EnableNetbootOptions,
 			},
 			OTELEnabled:      true,
 			AutoProxyEnabled: false,
@@ -509,7 +513,7 @@ func (c *Config) dhcpHandler(log logr.Logger) (server.Handler, error) {
 				IPXEBinServerTFTP: tftpIP,
 				IPXEBinServerHTTP: &httpBinaryURL,
 				IPXEScriptURL:     ipxeScript,
-				Enabled:           true,
+				Enabled:           c.DHCP.EnableNetbootOptions,
 			},
 			OTELEnabled:      true,
 			AutoProxyEnabled: true,


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This was hardcoded to true. This allows enabling/disabling the sending of netboot options in all DHCP handlers. This only makes sense when using the "reservation" handler/dhcp mode.

Even with the reservation mode/handler, disabling netboot options means that the user must bring their own proxyDHCP service. This has only been reported as needed when netbooting Raspberry PI SBCs because their firmware bootloaders don't natively work with iPXE.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
