### PR TITLE
Add port to HTTP filename in DHCP examples

### DIFF
--- a/docs/technical/smee/DHCP.md
+++ b/docs/technical/smee/DHCP.md
@@ -40,6 +40,9 @@ Most DHCP services all customization of a `next server` option. This option gene
 
 The following code snippets are generic examples of the config needed to enable the two-step process to an existing DHCP service. It does not cover the IPAM info that is also required.
 
+**NOTE:** The HTTP URL pointing to the `auto.ipxe` script may need a port defined, depending on how Tinkerbell is deployed.
+          At the time of writing, the Tinkerbell Helm chart deploys the Smee HTTP server responsible for delivering the iPXE script on port `7171`.
+
 [dnsmasq](https://linux.die.net/man/8/dnsmasq)
 
 `dnsmasq.conf`
@@ -47,7 +50,7 @@ The following code snippets are generic examples of the config needed to enable 
 ```text
 dhcp-match=tinkerbell, option:user-class, Tinkerbell
 dhcp-boot=tag:!tinkerbell,ipxe.efi,none,192.168.2.112
-dhcp-boot=tag:tinkerbell,http://192.168.2.112/auto.ipxe
+dhcp-boot=tag:tinkerbell,http://192.168.2.112:7171/auto.ipxe
 ```
 
 [Kea DHCP](https://www.isc.org/kea/)
@@ -61,7 +64,7 @@ dhcp-boot=tag:tinkerbell,http://192.168.2.112/auto.ipxe
       {
         "name": "tinkerbell",
         "test": "substring(option[77].hex,0,10) == 'Tinkerbell'",
-        "boot-file-name": "http://192.168.2.112/auto.ipxe"
+        "boot-file-name": "http://192.168.2.112:7171/auto.ipxe"
       },
       {
         "name": "default",
@@ -84,7 +87,7 @@ dhcp-boot=tag:tinkerbell,http://192.168.2.112/auto.ipxe
 
 ```text
  if exists user-class and option user-class = "Tinkerbell" {
-     filename "http://192.168.2.112/auto.ipxe";
+     filename "http://192.168.2.112:7171/auto.ipxe";
  } else {
      filename "ipxe.efi";
  }


### PR DESCRIPTION
By default, the iPXE script is delivered by an HTTP server listening on port 7171, not the default port 80, so the port needs to be provided in the bootfile name send to the host.

## Description

A very small docs fix. In the examples on how to configure DHCP servers for delivering the iPXE script, the HTTP URLs don't contain the default `7171` port used when deploying Tinkerbell via the Helm chart, meaning hosts trying to use those examples would not be able to fetch the file.

## Why is this needed

I've not raised an issue for this.

Fixes: #

## How Has This Been Tested?
This is a docs change, revealed to me by hammering onto a dnsmasq config and staring at tcpdump output for a long long time before realising my DHCP setup was fine, I was just missing a port in the HTTP URL. 


## How are existing users impacted? What migration steps/scripts do we need?

No changes required from users. Impact should be a lot of time saved staring at tcpdumps trying to figure out what's wrong.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
