### PR TITLE
Refactor Auto Discovery:

### DIFF
--- a/api/v1alpha1/tinkerbell/hardware.go
+++ b/api/v1alpha1/tinkerbell/hardware.go
@@ -45,6 +45,11 @@ type Hardware struct {
 
 // HardwareSpec defines the desired state of Hardware.
 type HardwareSpec struct {
+	// AgentID is the unique identifier an Agent uses that is associated with this Hardware.
+	// This is used to identify Hardware during the discovery and enrollment process.
+	// It is typically the MAC address of the primary network interface.
+	AgentID string `json:"agentID,omitempty"`
+
 	// BMCRef contains a relation to a BMC state management type in the same
 	// namespace as the Hardware. This may be used for BMC management by
 	// orchestrators.

--- a/cmd/tinkerbell/flag/tink_server.go
+++ b/cmd/tinkerbell/flag/tink_server.go
@@ -18,6 +18,7 @@ type TinkServerConfig struct {
 
 var KubeIndexesTinkServer = map[kube.IndexType]kube.Index{
 	kube.IndexTypeWorkflowAgentID: kube.Indexes[kube.IndexTypeWorkflowAgentID],
+	kube.IndexTypeHardwareAgentID: kube.Indexes[kube.IndexTypeHardwareAgentID],
 }
 
 func RegisterTinkServerFlags(fs *Set, t *TinkServerConfig) {

--- a/crd/bases/tinkerbell.org_hardware.yaml
+++ b/crd/bases/tinkerbell.org_hardware.yaml
@@ -50,6 +50,12 @@ spec:
           spec:
             description: HardwareSpec defines the desired state of Hardware.
             properties:
+              agentID:
+                description: |-
+                  AgentID is the unique identifier an Agent uses that is associated with this Hardware.
+                  This is used to identify Hardware during the discovery and enrollment process.
+                  It is typically the MAC address of the primary network interface.
+                type: string
               bmcRef:
                 description: |-
                   BMCRef contains a relation to a BMC state management type in the same

--- a/docs/technical/AUTO_DISCOVERY.md
+++ b/docs/technical/AUTO_DISCOVERY.md
@@ -11,8 +11,11 @@ Auto discovery allows Tinkerbell to automatically create Hardware objects for ma
 When an Agent connects to Tink Server:
 
 1. The Agent sends its attributes (serial numbers, MAC addresses, etc.) to the Tink server.
-1. Tink Server checks if an existing Hardware object exists for the Agent in the configured namespace. The name of the Hardware object is `discovery-{Agent ID}`.
+1. Tink Server checks if there is a Hardware object with the `spec.agentID` that matches the Agent ID.
 1. If no Hardware object exists, Tink server creates a new Hardware object with the name `discovery-{Agent ID}` and populates it with the Agent's attributes.
+
+> [!Note]
+> To create a Hardware object in Kubernetes using the Agent ID, we must follow the Kubernetes naming conventions. This means that the Hardware object name might be modified to fit the requirements, such as replacing invalid characters or truncating the name if it exceeds the maximum length. If the Agent ID is a MAC address, the `:` characters will be replaced with `-` to ensure the name is valid.
 
 > [!NOTE]  
 > As Auto Discovery requires the Tink Agent to connect to the Tink Server and the expectation is that no Hardware object exists, it is generally required that Auto Enrollment be enabled.

--- a/docs/technical/AUTO_ENROLLMENT.md
+++ b/docs/technical/AUTO_ENROLLMENT.md
@@ -21,6 +21,9 @@ When an Agent connects to the Tink Server:
 > As Auto Enrollment requires the Tink Agent to connect to the Tink Server and the expectation is that no Hardware object exists, it is generally required that the `--dhcp-mode` CLI flag or the `TINKERBELL_DHCP_MODE` environment variable be set to `auto-proxy`.
 > `auto-proxy` mode will get a Machine into HookOS and running the Tink Agent without needing a pre-existing Hardware object. See the [DHCP Boot Modes documentation](./DHCP_BOOT_MODES.md) for more details on the `auto-proxy` mode.
 
+> [!Note]
+> To create a Workflow object in Kubernetes using the Agent ID, we must follow the Kubernetes naming conventions. This means that the Workflow object name might be modified to fit the requirements, such as replacing invalid characters or truncating the name if it exceeds the maximum length. If the Agent ID is a MAC address, colon characters (`:`) will be replaced with dashes (`-`) to ensure the name is valid.
+
 ## How to enable Auto Enrollment
 
 There is a CLI flag and an environment variable.

--- a/pkg/backend/kube/error.go
+++ b/pkg/backend/kube/error.go
@@ -28,7 +28,7 @@ func (h hardwareNotFoundError) Status() metav1.Status {
 }
 
 type foundMultipleHardwareError struct {
-	name      string
+	id        string
 	namespace string
 	count     int
 }
@@ -36,5 +36,5 @@ type foundMultipleHardwareError struct {
 func (f foundMultipleHardwareError) MultipleFound() bool { return true }
 
 func (f foundMultipleHardwareError) Error() string {
-	return fmt.Sprintf("found %d hardware objects for name: %s, namespace: %s", f.count, f.name, f.namespace)
+	return fmt.Sprintf("found %d hardware objects for agentID: %s, namespace: %s", f.count, f.id, f.namespace)
 }

--- a/pkg/backend/kube/error.go
+++ b/pkg/backend/kube/error.go
@@ -26,3 +26,15 @@ func (h hardwareNotFoundError) Status() metav1.Status {
 		Code:   http.StatusNotFound,
 	}
 }
+
+type foundMultipleHardwareError struct {
+	name      string
+	namespace string
+	count     int
+}
+
+func (f foundMultipleHardwareError) MultipleFound() bool { return true }
+
+func (f foundMultipleHardwareError) Error() string {
+	return fmt.Sprintf("found %d hardware objects for name: %s, namespace: %s", f.count, f.name, f.namespace)
+}

--- a/pkg/backend/kube/index.go
+++ b/pkg/backend/kube/index.go
@@ -14,6 +14,7 @@ const (
 	IndexTypeHardwareName    IndexType = "hardware.metadata.name"
 	IndexTypeMachineName     IndexType = "machine.metadata.name"
 	IndexTypeWorkflowAgentID IndexType = WorkflowByAgentID
+	IndexTypeHardwareAgentID IndexType = HardwareByAgentID
 )
 
 // Indexes that are currently known.
@@ -42,6 +43,11 @@ var Indexes = map[IndexType]Index{
 		Obj:          &tinkerbell.Workflow{},
 		Field:        WorkflowByAgentID,
 		ExtractValue: WorkflowByAgentIDFunc,
+	},
+	IndexTypeHardwareAgentID: {
+		Obj:          &tinkerbell.Hardware{},
+		Field:        HardwareByAgentID,
+		ExtractValue: HardwareByAgentIDFunc,
 	},
 }
 
@@ -124,4 +130,17 @@ func WorkflowByAgentIDFunc(obj client.Object) []string {
 		return []string{}
 	}
 	return []string{wf.Status.AgentID}
+}
+
+const HardwareByAgentID = ".spec.agentID"
+
+func HardwareByAgentIDFunc(obj client.Object) []string {
+	hw, ok := obj.(*tinkerbell.Hardware)
+	if !ok {
+		return nil
+	}
+	if hw.Spec.AgentID == "" {
+		return []string{}
+	}
+	return []string{hw.Spec.AgentID}
 }

--- a/pkg/backend/kube/tink_server.go
+++ b/pkg/backend/kube/tink_server.go
@@ -79,7 +79,7 @@ func (b *Backend) ReadHardware(ctx context.Context, id, namespace string) (*v1al
 
 	if len(hw.Items) > 1 {
 		// This is unexpected, as we should not have multiple hardware objects with the same agent ID.
-		return nil, &foundMultipleHardwareError{name: id, namespace: namespace, count: len(hw.Items)}
+		return nil, &foundMultipleHardwareError{id: id, namespace: namespace, count: len(hw.Items)}
 	}
 
 	return &hw.Items[0], nil

--- a/pkg/backend/kube/tink_server.go
+++ b/pkg/backend/kube/tink_server.go
@@ -65,12 +65,24 @@ func (b *Backend) CreateWorkflow(ctx context.Context, wf *v1alpha1.Workflow) err
 }
 
 func (b *Backend) ReadHardware(ctx context.Context, id, namespace string) (*v1alpha1.Hardware, error) {
-	hw := &v1alpha1.Hardware{}
-	err := b.cluster.GetClient().Get(ctx, types.NamespacedName{Name: id, Namespace: namespace}, hw)
-	if err != nil {
+	hw := &v1alpha1.HardwareList{}
+	if err := b.cluster.GetClient().List(ctx, hw, &client.MatchingFields{
+		HardwareByAgentID: id,
+	}); err != nil {
 		return nil, fmt.Errorf("failed to get hardware %s/%s: %w", namespace, id, err)
 	}
-	return hw, nil
+	if len(hw.Items) == 0 {
+		err := hardwareNotFoundError{name: id, namespace: ternary(b.Namespace == "", "all namespaces", b.Namespace)}
+
+		return nil, err
+	}
+
+	if len(hw.Items) > 1 {
+		// This is unexpected, as we should not have multiple hardware objects with the same agent ID.
+		return nil, &foundMultipleHardwareError{name: id, namespace: namespace, count: len(hw.Items)}
+	}
+
+	return &hw.Items[0], nil
 }
 
 func (b *Backend) CreateHardware(ctx context.Context, hw *v1alpha1.Hardware) error {

--- a/smee/internal/ipxe/script/auto_test.go
+++ b/smee/internal/ipxe/script/auto_test.go
@@ -29,6 +29,7 @@ func TestGenerateTemplate(t *testing.T) {
 			},
 			script: HookScript,
 			want: `#!ipxe
+set syslog 1.2.3.4
 
 echo Loading the Tinkerbell Hook iPXE script...
 
@@ -88,6 +89,7 @@ exit
 			},
 			script: HookScript,
 			want: `#!ipxe
+set syslog 1.2.3.4
 
 echo Loading the Tinkerbell Hook iPXE script...
 

--- a/smee/internal/ipxe/script/hook.go
+++ b/smee/internal/ipxe/script/hook.go
@@ -3,6 +3,10 @@ package script
 // HookScript is the default iPXE script for loading Hook.
 var HookScript = `#!ipxe
 
+{{- if .SyslogHost }}
+set syslog {{ .SyslogHost }}
+{{- end}}
+
 echo Loading the Tinkerbell Hook iPXE script...
 {{- if .TraceID }}
 echo Debug TraceID: {{ .TraceID }}

--- a/tink/server/internal/grpc/discovery.go
+++ b/tink/server/internal/grpc/discovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 
 	v1alpha1 "github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
 	"github.com/tinkerbell/tinkerbell/pkg/data"
@@ -12,21 +13,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	discoveryPrefix = "discovery-"
+)
+
 // Discover will create a Hardware object for an ID if it does not already exist.
 // The attrs will be used to populate the Hardware object.
 // If the Hardware object already exists, it will not be modified.
 // If the Hardware object is created, it will be created in the namespace defined in the AutoDiscovery configuration.
 func (h *Handler) Discover(ctx context.Context, id string, attrs *data.AgentAttributes) (*v1alpha1.Hardware, error) {
 	ns := h.AutoCapabilities.Discovery.Namespace
-	hwName := fmt.Sprintf("discovery-%s", id)
+	hwName, err := makeValidName(id, discoveryPrefix)
+	if err != nil {
+		journal.Log(ctx, "Error making discovery ID a valid Kubernetes name", "error", err)
+		return nil, fmt.Errorf("failed to make discovery ID %s a valid Kubernetes name: %w", id, err)
+	}
 	journal.Log(ctx, "Discovering hardware", "id", id, "hardwareName", hwName, "namespace", ns)
 
 	// Check if Hardware object already exists
-	existing, err := h.AutoCapabilities.Discovery.ReadHardware(ctx, hwName, ns)
+	existing, err := h.AutoCapabilities.Discovery.ReadHardware(ctx, id, ns)
 	if err == nil {
 		// Hardware object already exists, do not modify
 		journal.Log(ctx, "Hardware object already exists, skipping creation")
 		return existing, nil
+	}
+
+	if foundMultipleHardware(err) {
+		// Multiple Hardware objects found for the same ID, this is unexpected
+		journal.Log(ctx, "Multiple hardware objects found for the same ID", "error", err)
+		return nil, fmt.Errorf("multiple hardware objects found for ID %s in namespace %s: %w", id, ns, err)
 	}
 
 	if !apierrors.IsNotFound(err) {
@@ -47,7 +62,9 @@ func (h *Handler) Discover(ctx context.Context, id string, attrs *data.AgentAttr
 				"tinkerbell.org/auto-discovered": "true",
 			},
 		},
-		Spec: v1alpha1.HardwareSpec{},
+		Spec: v1alpha1.HardwareSpec{
+			AgentID: id,
+		},
 	}
 
 	if hw.Annotations == nil {
@@ -59,7 +76,7 @@ func (h *Handler) Discover(ctx context.Context, id string, attrs *data.AgentAttr
 	}
 
 	// Populate Hardware object with discovered attributes
-	updateHardware(hw, attrs)
+	updateHardware(ctx, hw, attrs)
 	journal.Log(ctx, "Populated hardware object with discovered attributes", "hardware", hw)
 
 	// Create the Hardware object in the cluster
@@ -72,7 +89,7 @@ func (h *Handler) Discover(ctx context.Context, id string, attrs *data.AgentAttr
 	return hw, nil
 }
 
-func updateHardware(hw *v1alpha1.Hardware, attrs *data.AgentAttributes) {
+func updateHardware(ctx context.Context, hw *v1alpha1.Hardware, attrs *data.AgentAttributes) {
 	if hw == nil || attrs == nil {
 		return
 	}
@@ -92,6 +109,11 @@ func updateHardware(hw *v1alpha1.Hardware, attrs *data.AgentAttributes) {
 	for _, iface := range attrs.NetworkInterfaces {
 		if iface != nil {
 			if iface.Mac != nil && *iface.Mac != "" {
+				// validate MAC address format
+				if _, err := net.ParseMAC(*iface.Mac); err != nil {
+					journal.Log(ctx, "Invalid MAC address format", "mac", *iface.Mac)
+					continue
+				}
 				hw.Spec.Interfaces = append(hw.Spec.Interfaces, v1alpha1.Interface{
 					DHCP: &v1alpha1.DHCP{
 						MAC: *iface.Mac,
@@ -100,4 +122,12 @@ func updateHardware(hw *v1alpha1.Hardware, attrs *data.AgentAttributes) {
 			}
 		}
 	}
+}
+
+func foundMultipleHardware(e error) bool {
+	type foundMultiple interface {
+		MultipleFound() bool
+	}
+	fn, ok := e.(foundMultiple)
+	return ok && fn.MultipleFound()
 }

--- a/tink/server/internal/grpc/discovery.go
+++ b/tink/server/internal/grpc/discovery.go
@@ -21,17 +21,17 @@ const (
 // The attrs will be used to populate the Hardware object.
 // If the Hardware object already exists, it will not be modified.
 // If the Hardware object is created, it will be created in the namespace defined in the AutoDiscovery configuration.
-func (h *Handler) Discover(ctx context.Context, id string, attrs *data.AgentAttributes) (*v1alpha1.Hardware, error) {
+func (h *Handler) Discover(ctx context.Context, agentID string, attrs *data.AgentAttributes) (*v1alpha1.Hardware, error) {
 	ns := h.AutoCapabilities.Discovery.Namespace
-	hwName, err := makeValidName(id, discoveryPrefix)
+	hwName, err := makeValidName(agentID, discoveryPrefix)
 	if err != nil {
 		journal.Log(ctx, "Error making discovery ID a valid Kubernetes name", "error", err)
-		return nil, fmt.Errorf("failed to make discovery ID %s a valid Kubernetes name: %w", id, err)
+		return nil, fmt.Errorf("failed to make discovery ID %s a valid Kubernetes name: %w", agentID, err)
 	}
-	journal.Log(ctx, "Discovering hardware", "id", id, "hardwareName", hwName, "namespace", ns)
+	journal.Log(ctx, "Discovering hardware", "agentID", agentID, "hardwareName", hwName, "namespace", ns)
 
 	// Check if Hardware object already exists
-	existing, err := h.AutoCapabilities.Discovery.ReadHardware(ctx, id, ns)
+	existing, err := h.AutoCapabilities.Discovery.ReadHardware(ctx, agentID, ns)
 	if err == nil {
 		// Hardware object already exists, do not modify
 		journal.Log(ctx, "Hardware object already exists, skipping creation")
@@ -41,7 +41,7 @@ func (h *Handler) Discover(ctx context.Context, id string, attrs *data.AgentAttr
 	if foundMultipleHardware(err) {
 		// Multiple Hardware objects found for the same ID, this is unexpected
 		journal.Log(ctx, "Multiple hardware objects found for the same ID", "error", err)
-		return nil, fmt.Errorf("multiple hardware objects found for ID %s in namespace %s: %w", id, ns, err)
+		return nil, fmt.Errorf("multiple hardware objects found for ID %s in namespace %s: %w", agentID, ns, err)
 	}
 
 	if !apierrors.IsNotFound(err) {
@@ -63,7 +63,7 @@ func (h *Handler) Discover(ctx context.Context, id string, attrs *data.AgentAttr
 			},
 		},
 		Spec: v1alpha1.HardwareSpec{
-			AgentID: id,
+			AgentID: agentID,
 		},
 	}
 

--- a/tink/server/internal/grpc/discovery_test.go
+++ b/tink/server/internal/grpc/discovery_test.go
@@ -73,6 +73,7 @@ func TestHandlerDiscover(t *testing.T) {
 					ResourceVersion: "1",
 				},
 				Spec: tinkerbell.HardwareSpec{
+					AgentID:    "test-id",
 					Interfaces: []tinkerbell.Interface{{DHCP: &tinkerbell.DHCP{MAC: "00:11:22:33:44:55"}}},
 				},
 			},

--- a/tink/server/internal/grpc/kube_test.go
+++ b/tink/server/internal/grpc/kube_test.go
@@ -109,6 +109,11 @@ func TestMakeValid(t *testing.T) {
 			inputPrefix:  "enrollment-",
 			expectedName: "enrollment-hello123456gaa",
 		},
+		"convert MAC address to valid name": {
+			inputName:    "3c:ec:ef:4c:4f:54",
+			inputPrefix:  "enrollment-",
+			expectedName: "enrollment-3c-ec-ef-4c-4f-54",
+		},
 	}
 
 	for name, test := range testCases {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Discovering Hardware objects in cluster by name is problematic. Once a Hardware object is created, renaming it will cause a new one to be created. Then there will be issues with network booting as there will be more than one Hardware object and network booting won't occur.

To resolve this, an `agentID` field in the Hardware spec has been added and is used when looking up Hardware. This allows the creation of a Hardware object as part of the discovery process with the name `discovery-*`, and then users can rename these objects as needed.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
