### PR TITLE
smee: pass otel config from global

### DIFF
--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -144,6 +144,8 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 
 	// Smee
 	s.Convert(&globals.TrustedProxies, globals.PublicIP)
+	s.Config.OTEL.Endpoint = globals.OTELEndpoint
+	s.Config.OTEL.InsecureEndpoint = globals.OTELInsecure
 
 	// Tootles
 	h.Convert(&globals.TrustedProxies)


### PR DESCRIPTION
## Description

Smee supports OTEL but does not inherit from the global to be set.

## Why is this needed

Make OTEL configs effective for Smee.