### PR TITLE
Fix broadcast-interface container command

### DIFF
--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -316,7 +316,7 @@ spec:
       initContainers:
       - name: broadcast-interface
         image: {{ .Values.deployment.init.image }}
-        command: ["/script/host_interface.sh", "-s", "{{ $sourceInterface }}", "-t", "{{ $dhcpInterfaceType }}"]
+        command: ["/script/host_interface.sh", "-s{{ $sourceInterface }}", "-t", "{{ $dhcpInterfaceType }}"]
         volumeMounts:
             - name: script
               mountPath: "/script"


### PR DESCRIPTION
## Description

This PR fixes an issue with the `-s` option on the `host-interface-config-map.yaml` script introduced in f950881513e30453d4f68d8ebff6f80231024814. In that commit, the `-s` argument was made optional. As per the [getopt man page](https://www.man7.org/linux/man-pages/man1/getopt.1.html), options with optional arguments have to have the argument following the option directly, without spaces.

Due to this, the `-s` option as given in the [broadcast-interface container's command](https://github.com/tinkerbell/tinkerbell/blob/863c916e14326fd446c414637995b7388494080b/helm/tinkerbell/templates/deployment.yml#L319) leads to the argument always being ignored and the default approach of using the interface with the default route being used instead.

## Why is this needed

Fixes: #261 

## How Has This Been Tested?
I ran the playground with the libvirt provider and:
- logged into the `stack` VM
- Edited the deployment with `kubectl edit -n tink-system deployment.apps/tinkerbell`
- Joined the `-s` parameter to read `-seth1`, as this PR will do
- Ran through a full provisioning as per the playground setup
- Also verified that the init container used `eth1` now by looking at its logs

## How are existing users impacted? What migration steps/scripts do we need?

There is a potential effect on users who set `deployment.init.sourceInterface` and never realized that it wasn't working. Their setup might suddenly break if e.g. the interface they provided doesn't exist or isn't correctly configured.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
