### PR TITLE
Add checksum annotation for HookOS download script:

### DIFF
--- a/helm/tinkerbell/templates/hookos/deployment.yaml
+++ b/helm/tinkerbell/templates/hookos/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/hookos/nginx-configmap.yaml") . | sha256sum }}
+        checksum/download-hook: {{ include (print $.Template.BasePath "/hookos/download-configmap.yaml") . | sha256sum }}
       labels:
         {{- with .Values.optional.hookos.selector }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This will trigger the HookOS deployment rollout when the HookOS download script changes. Same as what is currently done for the nginx config map.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
