### PR TITLE
Fix syslog panic; Remove mergify speculative checks:

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,5 @@
+merge_queue:
+  max_parallel_checks: 1
 queue_rules:
   - name: default
     queue_conditions:

--- a/Makefile
+++ b/Makefile
@@ -310,11 +310,11 @@ $(GOLANGCI_LINT_BIN):
 
 LINTERS += golangci-lint-lint
 golangci-lint-lint: $(GOLANGCI_LINT_BIN)
-	find . -name go.mod -execdir sh -c '"$(GOLANGCI_LINT_BIN)" run --timeout 10m -c "$(GOLANGCI_LINT_CONFIG)"' '{}' '+'
+	find . -name go.mod -not -path "./out/*" -execdir sh -c '"$(GOLANGCI_LINT_BIN)" run --timeout 10m -c "$(GOLANGCI_LINT_CONFIG)"' '{}' '+'
 
 FIXERS += golangci-lint-fix
 golangci-lint-fix: $(GOLANGCI_LINT_BIN)
-	find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLANGCI_LINT_CONFIG)" --fix \;
+	find . -name go.mod -not -path "./out/*" -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLANGCI_LINT_CONFIG)" --fix \;
 
 .PHONY: _lint $(LINTERS)
 _lint: $(LINTERS)

--- a/smee/internal/syslog/receiver.go
+++ b/smee/internal/syslog/receiver.go
@@ -109,7 +109,12 @@ func (r *Receiver) run(ctx context.Context) {
 		msg.time = time.Now().UTC()
 		msg.host = from.IP
 		msg.size = n
-		r.parse <- msg
+		select {
+		case <-ctx.Done():
+			r.Logger.Info("context done, exiting syslog receiver")
+			return
+		case r.parse <- msg:
+		}
 		msg = nil
 	}
 }


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Fix panic on closed channel. This resolves a panic when the context is canceled and syslog messages are still being received.

Remove mergify speculative checks . This increases the merge time significantly because a new draft PR is opened for each PR, and all the tests must run. This is new behavior from Mergify, and I don't want it right now.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
