### PR TITLE
Make QPS and burst configurable:

### DIFF
--- a/cmd/tinkerbell/backend.go
+++ b/cmd/tinkerbell/backend.go
@@ -9,6 +9,11 @@ import (
 	"github.com/tinkerbell/tinkerbell/pkg/backend/noop"
 )
 
+const (
+	defaultQPS   = 100
+	defaultBurst = 100
+)
+
 type kubeBackendOpt func(k *kube.Backend)
 
 func WithQPS(qps float32) kubeBackendOpt {
@@ -29,8 +34,8 @@ func newKubeBackend(ctx context.Context, kubeconfig, apiurl, namespace string, i
 		APIURL:         apiurl,
 		Namespace:      namespace,
 		Indexes:        indexes,
-		QPS:            100, // Default QPS value. A negative value disables client-side ratelimiting.
-		Burst:          100, // Default burst value.
+		QPS:            defaultQPS,   // Default QPS value. A negative value disables client-side ratelimiting.
+		Burst:          defaultBurst, // Default burst value.
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/tinkerbell/backend.go
+++ b/cmd/tinkerbell/backend.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	defaultQPS   = 100
-	defaultBurst = 100
+	defaultQPS   float32 = 100
+	defaultBurst int     = 100
 )
 
 type kubeBackendOpt func(k *kube.Backend)
@@ -29,20 +29,20 @@ func WithBurst(burst int) kubeBackendOpt {
 }
 
 func newKubeBackend(ctx context.Context, kubeconfig, apiurl, namespace string, indexes map[kube.IndexType]kube.Index, opts ...kubeBackendOpt) (*kube.Backend, error) {
-	kb, err := kube.NewBackend(kube.Backend{
+	defaultConfig := kube.Backend{
 		ConfigFilePath: kubeconfig,
 		APIURL:         apiurl,
 		Namespace:      namespace,
 		Indexes:        indexes,
 		QPS:            defaultQPS,   // Default QPS value. A negative value disables client-side ratelimiting.
 		Burst:          defaultBurst, // Default burst value.
-	})
+	}
+	for _, opt := range opts {
+		opt(&defaultConfig)
+	}
+	kb, err := kube.NewBackend(defaultConfig)
 	if err != nil {
 		return nil, err
-	}
-
-	for _, opt := range opts {
-		opt(kb)
 	}
 
 	go func() {

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -227,7 +227,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 	switch globals.Backend {
 	case "kube":
 		if globals.EnableCRDMigrations {
-			backendNoIndexes, err := newKubeBackend(ctx, globals.BackendKubeConfig, "", globals.BackendKubeNamespace, nil)
+			backendNoIndexes, err := newKubeBackend(ctx, globals.BackendKubeConfig, "", globals.BackendKubeNamespace, nil, WithQPS(globals.BackendKubeOptions.QPS), WithBurst(globals.BackendKubeOptions.Burst))
 			if err != nil {
 				return fmt.Errorf("failed to create kube backend with no indexes: %w", err)
 			}
@@ -244,7 +244,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			log.Info("CRD migrations completed")
 		}
 
-		b, err := newKubeBackend(ctx, globals.BackendKubeConfig, "", globals.BackendKubeNamespace, enabledIndexes(globals.EnableSmee, globals.EnableTootles, globals.EnableTinkServer, globals.EnableSecondStar))
+		b, err := newKubeBackend(ctx, globals.BackendKubeConfig, "", globals.BackendKubeNamespace, enabledIndexes(globals.EnableSmee, globals.EnableTootles, globals.EnableTinkServer, globals.EnableSecondStar), WithQPS(globals.BackendKubeOptions.QPS), WithBurst(globals.BackendKubeOptions.Burst))
 		if err != nil {
 			return fmt.Errorf("failed to create kube backend: %w", err)
 		}

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -52,6 +52,10 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			EnableKubeAPIServer: (embeddedApiserverExecute != nil),
 			EnableETCD:          (embeddedEtcdExecute != nil),
 		},
+		BackendKubeOptions: flag.BackendKubeOptions{
+			QPS:   100, // Default QPS value. A negative value disables client-side ratelimiting.
+			Burst: 100, // Default burst value.
+		},
 	}
 
 	s := &flag.SmeeConfig{

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -53,8 +53,8 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			EnableETCD:          (embeddedEtcdExecute != nil),
 		},
 		BackendKubeOptions: flag.BackendKubeOptions{
-			QPS:   100, // Default QPS value. A negative value disables client-side ratelimiting.
-			Burst: 100, // Default burst value.
+			QPS:   defaultQPS,   // Default QPS value. A negative value disables client-side ratelimiting.
+			Burst: defaultBurst, // Default burst value.
 		},
 	}
 

--- a/cmd/tinkerbell/flag/global.go
+++ b/cmd/tinkerbell/flag/global.go
@@ -25,11 +25,17 @@ type GlobalConfig struct {
 	EnableSecondStar     bool
 	EnableCRDMigrations  bool
 	EmbeddedGlobalConfig EmbeddedGlobalConfig
+	BackendKubeOptions   BackendKubeOptions
 }
 
 type EmbeddedGlobalConfig struct {
 	EnableKubeAPIServer bool
 	EnableETCD          bool
+}
+
+type BackendKubeOptions struct {
+	QPS   float32
+	Burst int
 }
 
 func RegisterGlobal(fs *Set, gc *GlobalConfig) {
@@ -38,6 +44,8 @@ func RegisterGlobal(fs *Set, gc *GlobalConfig) {
 	fs.Register(BackendFilePath, ffval.NewValueDefault(&gc.BackendFilePath, gc.BackendFilePath))
 	fs.Register(BackendKubeConfig, ffval.NewValueDefault(&gc.BackendKubeConfig, gc.BackendKubeConfig))
 	fs.Register(BackendKubeNamespace, ffval.NewValueDefault(&gc.BackendKubeNamespace, gc.BackendKubeNamespace))
+	fs.Register(KubeQPS, ffval.NewValueDefault(&gc.BackendKubeOptions.QPS, gc.BackendKubeOptions.QPS))
+	fs.Register(KubeBurst, ffval.NewValueDefault(&gc.BackendKubeOptions.Burst, gc.BackendKubeOptions.Burst))
 	fs.Register(OTELEndpoint, ffval.NewValueDefault(&gc.OTELEndpoint, gc.OTELEndpoint))
 	fs.Register(OTELInsecure, ffval.NewValueDefault(&gc.OTELInsecure, gc.OTELInsecure))
 	fs.Register(TrustedProxies, &ntip.PrefixList{PrefixList: &gc.TrustedProxies})
@@ -71,17 +79,28 @@ var BackendConfig = Config{
 
 var BackendFilePath = Config{
 	Name:  "backend-file-path",
-	Usage: "path to the file backend",
+	Usage: "[file] path to the file backend, this is only implemented when running only the Smee service",
 }
 
+// Kube backend flags.
 var BackendKubeConfig = Config{
 	Name:  "backend-kube-config",
-	Usage: "path to the kubeconfig file",
+	Usage: "[kube] path to the kubeconfig file",
 }
 
 var BackendKubeNamespace = Config{
 	Name:  "backend-kube-namespace",
-	Usage: "namespace to watch for resources",
+	Usage: "[kube] namespace to watch for resources",
+}
+
+var KubeQPS = Config{
+	Name:  "kube-qps",
+	Usage: "[kube] maximum queries per second to the Kubernetes API server. A 0 value equates to 5 (client sdk constraint). A negative value disables client-side ratelimiting.",
+}
+
+var KubeBurst = Config{
+	Name:  "kube-burst",
+	Usage: "[kube] maximum burst for throttle in the Kubernetes client. A 0 value equates to 10 (client sdk constraint). A negative value disables client-side burst limiting.",
 }
 
 // OTEL flags.

--- a/cmd/tinkerbell/flag/global.go
+++ b/cmd/tinkerbell/flag/global.go
@@ -94,12 +94,12 @@ var BackendKubeNamespace = Config{
 }
 
 var KubeQPS = Config{
-	Name:  "kube-qps",
+	Name:  "backend-kube-qps",
 	Usage: "[kube] maximum queries per second to the Kubernetes API server. A 0 value equates to 5 (client sdk constraint). A negative value disables client-side ratelimiting.",
 }
 
 var KubeBurst = Config{
-	Name:  "kube-burst",
+	Name:  "backend-kube-burst",
 	Usage: "[kube] maximum burst for throttle in the Kubernetes client. A 0 value equates to 10 (client sdk constraint). A negative value disables client-side burst limiting.",
 }
 

--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -202,10 +202,14 @@ spec:
               value: {{ .Values.deployment.envs.globals.backend | quote }}
             - name: TINKERBELL_BACKEND_FILE_PATH
               value: {{ .Values.deployment.envs.globals.backendFilePath | quote }}
+            - name: TINKERBELL_BACKEND_KUBE_BURST
+              value: {{ .Values.deployment.envs.globals.backendKubeBurst | quote }}
             - name: TINKERBELL_BACKEND_KUBE_CONFIG
               value: {{ .Values.deployment.envs.globals.backendKubeConfig | quote }}
             - name: TINKERBELL_BACKEND_KUBE_NAMESPACE
               value: {{ .Values.deployment.envs.globals.backendKubeNamespace | quote }}
+            - name: TINKERBELL_BACKEND_KUBE_QPS
+              value: {{ .Values.deployment.envs.globals.backendKubeQPS | quote }}
             - name: TINKERBELL_OTEL_ENDPOINT
               value: {{ .Values.deployment.envs.globals.otelEndpoint | quote }}
             - name: TINKERBELL_OTEL_INSECURE

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -22,8 +22,10 @@ deployment:
     globals:
       backend: "kube"
       backendFilePath: ""
+      backendKubeBurst: 100
       backendKubeConfig: ""
       backendKubeNamespace: ""
+      backendKubeQPS: 100
       enableCRDMigrations: true
       enableRufioController: true
       enableSecondstar: true

--- a/pkg/backend/kube/kube.go
+++ b/pkg/backend/kube/kube.go
@@ -45,8 +45,10 @@ type Backend struct {
 	Indexes       map[IndexType]Index
 	DynamicClient dynamic.Interface
 	// QPS is the maximum queries per second to the Kubernetes API server.
+	// If set to 0, defaults to 5. Negative values disable rate limiting.
 	QPS float32
 	// Burst is the maximum burst for throttle in the Kubernetes client.
+	// If set to 0, defaults to 10. Negative values disable burst limiting.
 	Burst int
 }
 

--- a/pkg/backend/kube/kube.go
+++ b/pkg/backend/kube/kube.go
@@ -44,6 +44,10 @@ type Backend struct {
 	// Indexes to register
 	Indexes       map[IndexType]Index
 	DynamicClient dynamic.Interface
+	// QPS is the maximum queries per second to the Kubernetes API server.
+	QPS float32
+	// Burst is the maximum burst for throttle in the Kubernetes client.
+	Burst int
 }
 
 type Index struct {
@@ -142,9 +146,8 @@ func loadConfig(cfg Backend) (Backend, error) {
 	if err != nil {
 		return Backend{}, fmt.Errorf("failed to load client config: %w", err)
 	}
-	// TODO: make this cli configurable.
-	config.QPS = -2000
-	config.Burst = 2000
+	config.QPS = cfg.QPS
+	config.Burst = cfg.Burst
 	cfg.ClientConfig = config
 
 	return cfg, nil


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows configuring the kube backend's QPS and burst values. Needed for performance tuning of the controllers.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
