### PR TITLE
Tink Agent: filter out block devices with unknown controller type

### DIFF
--- a/tink/agent/internal/attribute/attribute.go
+++ b/tink/agent/internal/attribute/attribute.go
@@ -88,7 +88,7 @@ func DiscoverBlockDevices(l logr.Logger) []*data.Block {
 		if d == nil {
 			continue
 		}
-		if d.StorageController != block.STORAGE_CONTROLLER_LOOP {
+		if d.StorageController != block.StorageControllerLoop && d.StorageController != block.StorageControllerUnknown {
 			blockDevices = append(blockDevices, &data.Block{
 				Name:              toPtr(d.Name),
 				ControllerType:    toPtr(d.StorageController.String()),


### PR DESCRIPTION
## Description

while testing inside VMs, the auto-discovery feature of the tink-agent discovers disks /dev/ram{1..15} and /dev/nbd{0..15}. This change filters those out and prefers block devices which have a controllerType which isnt Loop or Unknown

This was found on HookOS 0.10.0-build-196.

## Why is this needed

I'm unsure if *all* block devices are going to be discovered 

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

At least in my lab, on VMs and limited hardware types, this still correctly detects block devices which have an actual vendor reported from the device, and does not add every single "block" device to `spec.disks` in the generated `Hardware` object.

~The underlying `ghw` package reads from `/sys/block/<dev>/device/vendor`, and if the file doesn't exist will default to `"unknown"`~ [seen here](https://github.com/jaypipes/ghw/blob/v0.17.0/pkg/block/block_linux.go#L82-L91).

I am fairly confident this is safe, but due to limited hardware availability, I'd love to get some feedback.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
