### PR TITLE
Implement multi-task multi-agent functionality in Workflows

### DIFF
--- a/api/v1alpha1/tinkerbell/workflow.go
+++ b/api/v1alpha1/tinkerbell/workflow.go
@@ -50,7 +50,7 @@ const (
 // +kubebuilder:printcolumn:JSONPath=".status.currentState.actionName",name=Action,type=string
 // +kubebuilder:printcolumn:JSONPath=".status.currentState.agentID",name=Agent,type=string
 // +kubebuilder:printcolumn:JSONPath=".spec.hardwareRef",name=Hardware,type=string
-// +kubebuilder:printcolumn:JSONPath=".status.templateRending",name=Template-Rendering,type=string,priority=1
+// +kubebuilder:printcolumn:JSONPath=".status.templateRendering",name=Template-Rendering,type=string,priority=1
 
 // Workflow is the Schema for the Workflows API.
 type Workflow struct {
@@ -169,7 +169,7 @@ type WorkflowStatus struct {
 
 	// TemplateRendering indicates whether the template was rendered successfully.
 	// Possible values are "successful" or "failed" or "unknown".
-	TemplateRendering TemplateRendering `json:"templateRending,omitempty"`
+	TemplateRendering TemplateRendering `json:"templateRendering,omitempty"`
 
 	// GlobalTimeout represents the max execution time.
 	GlobalTimeout int64 `json:"globalTimeout,omitempty"`

--- a/crd/bases/tinkerbell.org_workflows.yaml
+++ b/crd/bases/tinkerbell.org_workflows.yaml
@@ -38,7 +38,7 @@ spec:
     - jsonPath: .spec.hardwareRef
       name: Hardware
       type: string
-    - jsonPath: .status.templateRending
+    - jsonPath: .status.templateRendering
       name: Template-Rendering
       priority: 1
       type: string
@@ -448,7 +448,7 @@ spec:
                   - name
                   type: object
                 type: array
-              templateRending:
+              templateRendering:
                 description: |-
                   TemplateRendering indicates whether the template was rendered successfully.
                   Possible values are "successful" or "failed" or "unknown".

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -496,12 +496,6 @@ func updateAgentIDIfNeeded(wf *v1alpha1.Workflow) bool {
 	}
 
 	currentTask := wf.Status.Tasks[currentTaskIndex]
-	// Defensive check to prevent out-of-bounds access
-	if currentTaskIndex+1 >= len(wf.Status.Tasks) {
-		return false
-	}
-	nextTask := wf.Status.Tasks[currentTaskIndex+1]
-
 	// Step 2: Check if the current task is complete
 	// A task is complete when all its actions are in SUCCESS state
 	for _, action := range currentTask.Actions {
@@ -510,6 +504,7 @@ func updateAgentIDIfNeeded(wf *v1alpha1.Workflow) bool {
 		}
 	}
 
+	nextTask := wf.Status.Tasks[currentTaskIndex+1]
 	// Step 3: Check if the next task's first action is pending
 	if len(nextTask.Actions) == 0 {
 		return false // Next task has no actions

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -489,12 +489,10 @@ func updateAgentIDIfNeeded(wf *v1alpha1.Workflow) bool {
 	}
 
 	// Step 1: Check for invalid index or if we're in the last task
-	if currentTaskIndex > len(wf.Status.Tasks)-1 {
+	if currentTaskIndex >= len(wf.Status.Tasks)-1 {
 		// Invalid state: currentTaskIndex out of bounds
+		// or we're in the last task, no update needed
 		return false
-	}
-	if currentTaskIndex == len(wf.Status.Tasks)-1 {
-		return false // We're in the last task, no update needed
 	}
 
 	currentTask := wf.Status.Tasks[currentTaskIndex]

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -488,12 +488,20 @@ func updateAgentIDIfNeeded(wf *v1alpha1.Workflow) bool {
 		return false
 	}
 
-	// Step 1: Check if we're not in the last task
-	if currentTaskIndex >= len(wf.Status.Tasks)-1 {
+	// Step 1: Check for invalid index or if we're in the last task
+	if currentTaskIndex > len(wf.Status.Tasks)-1 {
+		// Invalid state: currentTaskIndex out of bounds
+		return false
+	}
+	if currentTaskIndex == len(wf.Status.Tasks)-1 {
 		return false // We're in the last task, no update needed
 	}
 
 	currentTask := wf.Status.Tasks[currentTaskIndex]
+	// Defensive check to prevent out-of-bounds access
+	if currentTaskIndex+1 >= len(wf.Status.Tasks) {
+		return false
+	}
 	nextTask := wf.Status.Tasks[currentTaskIndex+1]
 
 	// Step 2: Check if the current task is complete

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -172,6 +172,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, mergePatchStatus(ctx, r.client, stored, wflow)
 		}
 
+		// Update AgentID if transitioning between tasks
+		if updateAgentIDIfNeeded(wflow) {
+			journal.Log(ctx, "updated workflow AgentID for task transition", "newAgentID", wflow.Status.AgentID)
+		}
+
 		first := firstAction(wflow)
 		if wflow.Status.GlobalExecutionStop == nil && first != nil && wflow.Status.CurrentState != nil && first.ID == wflow.Status.CurrentState.ActionID {
 			if first.ExecutionStart == nil {
@@ -459,4 +464,61 @@ func firstAction(w *v1alpha1.Workflow) *v1alpha1.Action {
 		}
 	}
 	return nil
+}
+
+// updateAgentIDIfNeeded updates the Workflow's status.AgentID when transitioning between tasks.
+// It checks if the current task is complete and if we need to move to the next task with a different agent.
+func updateAgentIDIfNeeded(wf *v1alpha1.Workflow) bool {
+	// Early return if we don't have the necessary state information
+	if wf.Status.CurrentState == nil || len(wf.Status.Tasks) == 0 {
+		return false
+	}
+
+	// Find the current task index
+	currentTaskIndex := -1
+	for i, task := range wf.Status.Tasks {
+		if task.ID == wf.Status.CurrentState.TaskID {
+			currentTaskIndex = i
+			break
+		}
+	}
+
+	// If we can't find the current task, nothing to do
+	if currentTaskIndex == -1 {
+		return false
+	}
+
+	// Step 1: Check if we're not in the last task
+	if currentTaskIndex >= len(wf.Status.Tasks)-1 {
+		return false // We're in the last task, no update needed
+	}
+
+	currentTask := wf.Status.Tasks[currentTaskIndex]
+	nextTask := wf.Status.Tasks[currentTaskIndex+1]
+
+	// Step 2: Check if the current task is complete
+	// A task is complete when all its actions are in SUCCESS state
+	for _, action := range currentTask.Actions {
+		if action.State != v1alpha1.WorkflowStateSuccess {
+			return false // Current task is not complete
+		}
+	}
+
+	// Step 3: Check if the next task's first action is pending
+	if len(nextTask.Actions) == 0 {
+		return false // Next task has no actions
+	}
+
+	if nextTask.Actions[0].State != v1alpha1.WorkflowStatePending {
+		return false // Next task's first action is not pending
+	}
+
+	// Step 4: Check if the current AgentID is not equal to the next task's agent ID
+	if wf.Status.AgentID == nextTask.AgentID {
+		return false // AgentID is already correct
+	}
+
+	// All conditions met, update the status.AgentID to the next task's agentID
+	wf.Status.AgentID = nextTask.AgentID
+	return true // Indicates that an update was made
 }

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -488,7 +488,7 @@ func updateAgentIDIfNeeded(wf *v1alpha1.Workflow) bool {
 		return false
 	}
 
-	// Step 1: Check for invalid index or if we're in the last task
+	// Step 1: Check for invalid index (>) or if we're in the last task (==)
 	if currentTaskIndex >= len(wf.Status.Tasks)-1 {
 		return false
 	}

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -490,8 +490,6 @@ func updateAgentIDIfNeeded(wf *v1alpha1.Workflow) bool {
 
 	// Step 1: Check for invalid index or if we're in the last task
 	if currentTaskIndex >= len(wf.Status.Tasks)-1 {
-		// Invalid state: currentTaskIndex out of bounds
-		// or we're in the last task, no update needed
 		return false
 	}
 

--- a/tink/controller/internal/workflow/reconciler_test.go
+++ b/tink/controller/internal/workflow/reconciler_test.go
@@ -1064,3 +1064,898 @@ func (f *FrozenTime) MetaV1AfterSec(s int64) *metav1.Time {
 	t := metav1.NewTime(f.AfterSec(s))
 	return &t
 }
+
+func TestUpdateAgentIDIfNeeded(t *testing.T) {
+	tests := map[string]struct {
+		workflow    *v1alpha1.Workflow
+		wantUpdate  bool
+		wantAgentID string
+		description string
+	}{
+		"nil current state": {
+			workflow:    &v1alpha1.Workflow{Status: v1alpha1.WorkflowStatus{}},
+			wantUpdate:  false,
+			wantAgentID: "",
+			description: "should return false when CurrentState is nil",
+		},
+		"empty tasks": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					Tasks:        []v1alpha1.Task{},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "",
+			description: "should return false when no tasks are present",
+		},
+		"current task not found": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "nonexistent"},
+					Tasks: []v1alpha1.Task{
+						{ID: "task1", AgentID: "agent1"},
+					},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "",
+			description: "should return false when current task is not found",
+		},
+		"last task - no update needed": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					Tasks: []v1alpha1.Task{
+						{ID: "task1", AgentID: "agent1"},
+					},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "",
+			description: "should return false when in the last task",
+		},
+		"current task incomplete - action pending": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					AgentID:      "agent1",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+								{ID: "action2", State: v1alpha1.WorkflowStatePending},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{ID: "action3", State: v1alpha1.WorkflowStatePending},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "agent1",
+			description: "should return false when current task has pending actions",
+		},
+		"current task incomplete - action running": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					AgentID:      "agent1",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+								{ID: "action2", State: v1alpha1.WorkflowStateRunning},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{ID: "action3", State: v1alpha1.WorkflowStatePending},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "agent1",
+			description: "should return false when current task has running actions",
+		},
+		"next task has no actions": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					AgentID:      "agent1",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+								{ID: "action2", State: v1alpha1.WorkflowStateSuccess},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{},
+						},
+					},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "agent1",
+			description: "should return false when next task has no actions",
+		},
+		"next task first action not pending": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					AgentID:      "agent1",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+								{ID: "action2", State: v1alpha1.WorkflowStateSuccess},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{ID: "action3", State: v1alpha1.WorkflowStateRunning},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "agent1",
+			description: "should return false when next task's first action is not pending",
+		},
+		"agent ID already matches next task": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					AgentID:      "agent2",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+								{ID: "action2", State: v1alpha1.WorkflowStateSuccess},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{ID: "action3", State: v1alpha1.WorkflowStatePending},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate:  false,
+			wantAgentID: "agent2",
+			description: "should return false when AgentID already matches next task",
+		},
+		"successful transition - agent ID updated": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					AgentID:      "agent1",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+								{ID: "action2", State: v1alpha1.WorkflowStateSuccess},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{ID: "action3", State: v1alpha1.WorkflowStatePending},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate:  true,
+			wantAgentID: "agent2",
+			description: "should update AgentID when transitioning to next task with different agent",
+		},
+		"multiple tasks transition": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task2"},
+					AgentID:      "agent2",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{ID: "action2", State: v1alpha1.WorkflowStateSuccess},
+								{ID: "action3", State: v1alpha1.WorkflowStateSuccess},
+							},
+						},
+						{
+							ID:      "task3",
+							AgentID: "agent3",
+							Actions: []v1alpha1.Action{
+								{ID: "action4", State: v1alpha1.WorkflowStatePending},
+								{ID: "action5", State: v1alpha1.WorkflowStatePending},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate:  true,
+			wantAgentID: "agent3",
+			description: "should update AgentID in multi-task workflow",
+		},
+		"transition with single action in next task": {
+			workflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					CurrentState: &v1alpha1.CurrentState{TaskID: "task1"},
+					AgentID:      "agent1",
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{ID: "action1", State: v1alpha1.WorkflowStateSuccess},
+							},
+						},
+						{
+							ID:      "task2",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{ID: "action2", State: v1alpha1.WorkflowStatePending},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate:  true,
+			wantAgentID: "agent2",
+			description: "should update AgentID when next task has single pending action",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Store original AgentID for comparison
+			originalAgentID := tt.workflow.Status.AgentID
+
+			got := updateAgentIDIfNeeded(tt.workflow)
+
+			// Check if update flag matches expectation
+			if got != tt.wantUpdate {
+				t.Errorf("updateAgentIDIfNeeded() = %v, want %v\nDescription: %s", got, tt.wantUpdate, tt.description)
+			}
+
+			// Check if AgentID was updated correctly
+			if tt.workflow.Status.AgentID != tt.wantAgentID {
+				t.Errorf("AgentID = %v, want %v\nDescription: %s", tt.workflow.Status.AgentID, tt.wantAgentID, tt.description)
+			}
+
+			// Ensure AgentID was not changed when update should be false
+			if !tt.wantUpdate && tt.workflow.Status.AgentID != originalAgentID {
+				t.Errorf("AgentID was modified when it shouldn't be: original=%v, new=%v\nDescription: %s", originalAgentID, tt.workflow.Status.AgentID, tt.description)
+			}
+		})
+	}
+}
+
+func TestReconcileWithMultipleTasksAndAgents(t *testing.T) {
+	tests := map[string]struct {
+		seedWorkflow *v1alpha1.Workflow
+		req          reconcile.Request
+		want         reconcile.Result
+		wantWflow    *v1alpha1.Workflow
+		wantErr      error
+		description  string
+	}{
+		"workflow running with multiple tasks - agent transition": {
+			seedWorkflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1000",
+					Name:            "multi-task-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "multi-task",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent1",
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task1",
+						ActionID: "action1",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:             "action1",
+									Name:           "first-action",
+									State:          v1alpha1.WorkflowStateSuccess,
+									ExecutionStart: TestTime.MetaV1BeforeSec(10),
+								},
+								{
+									ID:             "action2",
+									Name:           "second-action",
+									State:          v1alpha1.WorkflowStateSuccess,
+									ExecutionStart: TestTime.MetaV1BeforeSec(5),
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action3",
+									Name:  "third-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			req: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "multi-task-workflow",
+					Namespace: "default",
+				},
+			},
+			want: reconcile.Result{},
+			wantWflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1001",
+					Name:            "multi-task-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "multi-task",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent2", // Should be updated to agent2
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task1",
+						ActionID: "action1",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:             "action1",
+									Name:           "first-action",
+									State:          v1alpha1.WorkflowStateSuccess,
+									ExecutionStart: TestTime.MetaV1BeforeSec(10),
+								},
+								{
+									ID:             "action2",
+									Name:           "second-action",
+									State:          v1alpha1.WorkflowStateSuccess,
+									ExecutionStart: TestTime.MetaV1BeforeSec(5),
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action3",
+									Name:  "third-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     nil,
+			description: "should update AgentID when transitioning between tasks with different agents",
+		},
+		"workflow running with three tasks - middle transition": {
+			seedWorkflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1000",
+					Name:            "three-task-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "three-task",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent2",
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task2",
+						ActionID: "action3",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action1",
+									Name:  "first-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action3",
+									Name:  "third-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+								{
+									ID:    "action4",
+									Name:  "fourth-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+							},
+						},
+						{
+							ID:      "task3",
+							Name:    "third-task",
+							AgentID: "agent3",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action5",
+									Name:  "fifth-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+								{
+									ID:    "action6",
+									Name:  "sixth-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			req: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "three-task-workflow",
+					Namespace: "default",
+				},
+			},
+			want: reconcile.Result{},
+			wantWflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1001",
+					Name:            "three-task-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "three-task",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent3", // Should be updated to agent3
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task2",
+						ActionID: "action3",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action1",
+									Name:  "first-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action3",
+									Name:  "third-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+								{
+									ID:    "action4",
+									Name:  "fourth-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+							},
+						},
+						{
+							ID:      "task3",
+							Name:    "third-task",
+							AgentID: "agent3",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action5",
+									Name:  "fifth-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+								{
+									ID:    "action6",
+									Name:  "sixth-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     nil,
+			description: "should update AgentID in multi-task workflow from task2 to task3",
+		},
+		"workflow running with same agent - no update needed": {
+			seedWorkflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1000",
+					Name:            "same-agent-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "same-agent",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent1",
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task1",
+						ActionID: "action1",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action1",
+									Name:  "first-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent1", // Same agent
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action2",
+									Name:  "second-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			req: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "same-agent-workflow",
+					Namespace: "default",
+				},
+			},
+			want: reconcile.Result{},
+			wantWflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1000", // No change expected
+					Name:            "same-agent-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "same-agent",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent1", // Should remain unchanged
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task1",
+						ActionID: "action1",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action1",
+									Name:  "first-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action2",
+									Name:  "second-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     nil,
+			description: "should not update AgentID when next task uses same agent",
+		},
+		"workflow running with incomplete current task - no update": {
+			seedWorkflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1000",
+					Name:            "incomplete-task-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "incomplete-task",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent1",
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task1",
+						ActionID: "action1",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action1",
+									Name:  "first-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+								{
+									ID:    "action2",
+									Name:  "second-action",
+									State: v1alpha1.WorkflowStateRunning, // Still running
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action3",
+									Name:  "third-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			req: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "incomplete-task-workflow",
+					Namespace: "default",
+				},
+			},
+			want: reconcile.Result{},
+			wantWflow: &v1alpha1.Workflow{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Workflow",
+					APIVersion: "tinkerbell.org/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1000", // No change expected
+					Name:            "incomplete-task-workflow",
+					Namespace:       "default",
+				},
+				Spec: v1alpha1.WorkflowSpec{
+					TemplateRef: "incomplete-task",
+					HardwareRef: "machine1",
+				},
+				Status: v1alpha1.WorkflowStatus{
+					State:             v1alpha1.WorkflowStateRunning,
+					AgentID:           "agent1", // Should remain unchanged
+					GlobalTimeout:     1800,
+					TemplateRendering: "successful",
+					CurrentState: &v1alpha1.CurrentState{
+						TaskID:   "task1",
+						ActionID: "action1",
+					},
+					Tasks: []v1alpha1.Task{
+						{
+							ID:      "task1",
+							Name:    "first-task",
+							AgentID: "agent1",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action1",
+									Name:  "first-action",
+									State: v1alpha1.WorkflowStateSuccess,
+								},
+								{
+									ID:    "action2",
+									Name:  "second-action",
+									State: v1alpha1.WorkflowStateRunning,
+								},
+							},
+						},
+						{
+							ID:      "task2",
+							Name:    "second-task",
+							AgentID: "agent2",
+							Actions: []v1alpha1.Action{
+								{
+									ID:    "action3",
+									Name:  "third-action",
+									State: v1alpha1.WorkflowStatePending,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     nil,
+			description: "should not update AgentID when current task is incomplete",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			kc := GetFakeClientBuilder()
+			if tc.seedWorkflow != nil {
+				kc = kc.WithObjects(tc.seedWorkflow)
+				kc = kc.WithStatusSubresource(tc.seedWorkflow)
+			}
+			controller := &Reconciler{
+				client:        kc.Build(),
+				nowFunc:       TestTime.Now,
+				dynamicClient: &fakeDynamicClient{},
+			}
+
+			got, gotErr := controller.Reconcile(context.Background(), tc.req)
+			if gotErr != nil {
+				if tc.wantErr == nil {
+					t.Errorf("Got unexpected error: %v\nDescription: %s", gotErr, tc.description)
+				} else if !strings.Contains(gotErr.Error(), tc.wantErr.Error()) {
+					t.Errorf("Got unexpected error: got %q, wanted %q\nDescription: %s", gotErr, tc.wantErr, tc.description)
+				}
+				return
+			}
+			if gotErr == nil && tc.wantErr != nil {
+				t.Errorf("Missing expected error: %v\nDescription: %s", tc.wantErr, tc.description)
+				return
+			}
+			// Skip reconcile.Result comparison for timing-sensitive tests since RequeueAfter depends on execution timing
+			if tc.want.RequeueAfter == 0 && got.RequeueAfter != 0 {
+				// For tests where we expect no requeue but get a timing-dependent requeue, ignore the difference
+				t.Logf("Ignoring RequeueAfter timing difference: expected %v, got %v", tc.want.RequeueAfter, got.RequeueAfter)
+			} else if tc.want != got {
+				t.Errorf("Got unexpected result. Wanted %v, got %v\nDescription: %s", tc.want, got, tc.description)
+			}
+
+			wflow := &v1alpha1.Workflow{}
+			err := controller.client.Get(
+				context.Background(),
+				client.ObjectKey{Name: tc.wantWflow.Name, Namespace: tc.wantWflow.Namespace},
+				wflow)
+			if err != nil {
+				t.Errorf("Error finding desired workflow: %v\nDescription: %s", err, tc.description)
+				return
+			}
+
+			// Check specific AgentID expectations
+			if wflow.Status.AgentID != tc.wantWflow.Status.AgentID {
+				t.Errorf("AgentID mismatch: got %q, want %q\nDescription: %s", wflow.Status.AgentID, tc.wantWflow.Status.AgentID, tc.description)
+			}
+
+			if diff := cmp.Diff(wflow, tc.wantWflow, cmpopts.IgnoreFields(v1alpha1.WorkflowCondition{}, "Time"), cmpopts.IgnoreFields(v1alpha1.Task{}, "ID"), cmpopts.IgnoreFields(v1alpha1.Action{}, "ID"), cmpopts.IgnoreFields(v1alpha1.WorkflowStatus{}, "GlobalExecutionStop")); diff != "" {
+				t.Logf("got: %+v", wflow)
+				t.Logf("want: %+v", tc.wantWflow)
+				t.Errorf("unexpected difference:\n%v\nDescription: %s", diff, tc.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
There are no breaking changes in this PR. This fixes a typo in the Workflow status API: `templateRending` -> `templateRendering`. This also implements multi-task, multi-agent Workflows. The example below shows a Template with 2 tasks that are assigned to 2 different Agents.

```yaml
apiVersion: tinkerbell.org/v1alpha1
kind: Template
metadata:
  name: multi-agent
spec:
  data: |
    name: multi-agent
    global_timeout: 90
    tasks:
      - name: "first task"
        worker: "{{.agent2}}"
        actions:
          - name: "action 1"
            image: alpine
            timeout: 60
            command: ["sleep", "4"]
      - name: "second task"
        worker: "{{.agent2}}"
        actions:
          - name: "action 1"
            image: alpine
            timeout: 60
            command: ["sleep", "4"]
```

Here's the corresponding Workflow:

```yaml
apiVersion: "tinkerbell.org/v1alpha1"
kind: Workflow
metadata:
  name: multi-agent
spec:
  templateRef: multi-agent
  hardwareMap:
    agent1: "1234"
    agent2: "5678"
```

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
