### PR TITLE
Handle the empty string case for new CLI flags:

### DIFF
--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -66,10 +66,10 @@ func RegisterSmeeFlags(fs *Set, sc *SmeeConfig) {
 	fs.Register(IPXEArchMapping, &ffval.Value[map[iana.Arch]constant.IPXEBinary]{
 		ParseFunc: func(s string) (map[iana.Arch]constant.IPXEBinary, error) {
 			if s == "" {
-				return map[iana.Arch]constant.IPXEBinary{}, nil
+				return nil, nil
 			}
 			split := strings.Split(s, ",")
-			if len(split) == 0 {
+			if len(split) == 0 || (len(split) == 1 && split[0] == "") {
 				return nil, nil
 			}
 			m := make(map[iana.Arch]constant.IPXEBinary, len(split))
@@ -218,7 +218,7 @@ func macAddrFormatParser(s string) (constant.MACFormat, error) {
 	case constant.MacAddrFormatNoDelimiter:
 		return constant.MacAddrFormatNoDelimiter, nil
 	case "":
-		return constant.MacAddrFormatColon, nil
+		return constant.MacAddrFormatColon, nil // constant.MacAddrFormatColon is the default
 	default:
 		return "", fmt.Errorf("invalid mac address format: %s, must be one of: [%s]", s, strings.Join([]string{constant.MacAddrFormatColon.String(), constant.MacAddrFormatDot.String(), constant.MacAddrFormatDash.String(), constant.MacAddrFormatNoDelimiter.String()}, ", "))
 	}

--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -69,9 +69,6 @@ func RegisterSmeeFlags(fs *Set, sc *SmeeConfig) {
 				return nil, nil
 			}
 			split := strings.Split(s, ",")
-			if len(split) == 0 || (len(split) == 1 && split[0] == "") {
-				return nil, nil
-			}
 			m := make(map[iana.Arch]constant.IPXEBinary, len(split))
 			for _, pair := range split {
 				kv := strings.SplitN(pair, "=", 2)

--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -65,6 +65,9 @@ func RegisterSmeeFlags(fs *Set, sc *SmeeConfig) {
 	// IPXE flags
 	fs.Register(IPXEArchMapping, &ffval.Value[map[iana.Arch]constant.IPXEBinary]{
 		ParseFunc: func(s string) (map[iana.Arch]constant.IPXEBinary, error) {
+			if s == "" {
+				return map[iana.Arch]constant.IPXEBinary{}, nil
+			}
 			split := strings.Split(s, ",")
 			if len(split) == 0 {
 				return nil, nil
@@ -214,6 +217,8 @@ func macAddrFormatParser(s string) (constant.MACFormat, error) {
 		return constant.MacAddrFormatDash, nil
 	case constant.MacAddrFormatNoDelimiter:
 		return constant.MacAddrFormatNoDelimiter, nil
+	case "":
+		return constant.MacAddrFormatColon, nil
 	default:
 		return "", fmt.Errorf("invalid mac address format: %s, must be one of: [%s]", s, strings.Join([]string{constant.MacAddrFormatColon.String(), constant.MacAddrFormatDot.String(), constant.MacAddrFormatDash.String(), constant.MacAddrFormatNoDelimiter.String()}, ", "))
 	}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The `--ipxe-binary-inject-mac-addr-format` and `--ipxe-override-arch-mapping` flags didn't handle the empty string case and caused the Helm chart to fail to deploy. This resolves that.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
