### PR TITLE
Make extra kernel args last in the kernel parameter list:

### DIFF
--- a/smee/internal/ipxe/script/auto_test.go
+++ b/smee/internal/ipxe/script/auto_test.go
@@ -42,9 +42,9 @@ set retry_delay:int32 3
 
 set idx:int32 0
 :retry_kernel
-kernel ${download-url}/${kernel} tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet \
+kernel ${download-url}/${kernel} \
 facility=onprem syslog_host=1.2.3.4 grpc_authority=1.2.3.4:42113 tinkerbell_tls=false tinkerbell_insecure_tls=false worker_id=3c:ec:ef:4c:4f:54 hw_addr=3c:ec:ef:4c:4f:54 \
-modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
+modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
 
 :download_initrd
 set idx:int32 0
@@ -102,9 +102,9 @@ set retry_delay:int32 3
 
 set idx:int32 0
 :retry_kernel
-kernel ${download-url}/${kernel} vlan_id=16 tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet \
+kernel ${download-url}/${kernel} vlan_id=16 \
 facility=onprem syslog_host=1.2.3.4 grpc_authority=1.2.3.4:42113 tinkerbell_tls=false tinkerbell_insecure_tls=false worker_id=3c:ec:ef:4c:4f:54 hw_addr=3c:ec:ef:4c:4f:54 \
-modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
+modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
 
 :download_initrd
 set idx:int32 0

--- a/smee/internal/ipxe/script/hook.go
+++ b/smee/internal/ipxe/script/hook.go
@@ -21,9 +21,9 @@ set retry_delay:int32 {{ .RetryDelay }}
 
 set idx:int32 0
 :retry_kernel
-kernel ${download-url}/${kernel} {{- if ne .VLANID "" }} vlan_id={{ .VLANID }} {{- end }} {{- range .ExtraKernelParams}} {{.}} {{- end}} \
+kernel ${download-url}/${kernel} {{- if ne .VLANID "" }} vlan_id={{ .VLANID }} {{- end }} \
 facility={{ .Facility }} syslog_host={{ .SyslogHost }} grpc_authority={{ .TinkGRPCAuthority }} tinkerbell_tls={{ .TinkerbellTLS }} tinkerbell_insecure_tls={{ .TinkerbellInsecureTLS }} worker_id={{ .WorkerID }} hw_addr={{ .HWAddr }} \
-modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
+modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=initramfs-${arch} console=tty0 console=ttyS1,115200 {{- range .ExtraKernelParams}} {{.}} {{- end}} && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
 
 :download_initrd
 set idx:int32 0

--- a/smee/internal/ipxe/script/ipxe_test.go
+++ b/smee/internal/ipxe/script/ipxe_test.go
@@ -148,7 +148,7 @@ set idx:int32 0
 :retry_kernel
 kernel ${download-url}/vmlinuz-${arch} \
 syslog_host=${syslog_host} grpc_authority=${grpc_authority} tinkerbell_tls=${tinkerbell_tls} worker_id=${worker_id} hw_addr=${mac} \
-console=tty1 console=tty2 console=ttyAMA0,115200 console=ttyAMA1,115200 console=ttyS0,115200 console=ttyS1,115200 k=v k2=v2 \
+console=tty1 console=tty2 console=ttyAMA0,115200 console=ttyAMA1,115200 console=ttyS0,115200 console=ttyS1,115200 \
 intel_iommu=on iommu=pt k=v k2=v2 initrd=initramfs-${arch} && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
 
 :download_initrd

--- a/smee/internal/ipxe/script/static.go
+++ b/smee/internal/ipxe/script/static.go
@@ -32,7 +32,7 @@ set idx:int32 0
 :retry_kernel
 kernel ${download-url}/vmlinuz-${arch} \
 syslog_host=${syslog_host} grpc_authority=${grpc_authority} tinkerbell_tls=${tinkerbell_tls} worker_id=${worker_id} hw_addr=${mac} \
-console=tty1 console=tty2 console=ttyAMA0,115200 console=ttyAMA1,115200 console=ttyS0,115200 console=ttyS1,115200 {{- range .ExtraKernelParams}} {{.}} {{- end}} \
+console=tty1 console=tty2 console=ttyAMA0,115200 console=ttyAMA1,115200 console=ttyS0,115200 console=ttyS1,115200 \
 intel_iommu=on iommu=pt {{- range .ExtraKernelParams}} {{.}} {{- end}} initrd=initramfs-${arch} && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
 
 :download_initrd

--- a/smee/internal/iso/iso.go
+++ b/smee/internal/iso/iso.go
@@ -288,7 +288,7 @@ func (h *Handler) constructPatch(console, mac string, d *data.DHCP) string {
 		return ""
 	}()
 	hwAddr := fmt.Sprintf("hw_addr=%s", mac)
-	all := []string{strings.Join(h.ExtraKernelParams, " "), console, vlanID, hwAddr, syslogHost, grpcAuthority, tinkerbellTLS, workerID}
+	all := []string{console, vlanID, hwAddr, syslogHost, grpcAuthority, tinkerbellTLS, workerID, strings.Join(h.ExtraKernelParams, " ")}
 	if h.StaticIPAMEnabled {
 		all = append(all, parseIPAM(d))
 	}

--- a/smee/internal/iso/iso_test.go
+++ b/smee/internal/iso/iso_test.go
@@ -115,7 +115,7 @@ func TestPatching(t *testing.T) {
 	wantGrubCfg := `set timeout=0
 set gfxpayload=text
 menuentry 'LinuxKit ISO Image' {
-        linuxefi /kernel  facility=test console=ttyAMA0 console=ttyS0 console=tty0 console=tty1 console=ttyS1  hw_addr=de:ed:be:ef:fe:ed syslog_host=127.0.0.1:514 grpc_authority=127.0.0.1:42113 tinkerbell_tls=false worker_id=de:ed:be:ef:fe:ed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        text
+        linuxefi /kernel facility=test console=ttyAMA0 console=ttyS0 console=tty0 console=tty1 console=ttyS1  hw_addr=de:ed:be:ef:fe:ed syslog_host=127.0.0.1:514 grpc_authority=127.0.0.1:42113 tinkerbell_tls=false worker_id=de:ed:be:ef:fe:ed k1=1 k2=2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               text
         initrdefi /initrd.img
 }`
 	// This expects that testdata/output.iso exists. Run the TestCreateISO test to create it.
@@ -135,7 +135,7 @@ menuentry 'LinuxKit ISO Image' {
 		Logger:             logr.Discard(),
 		Backend:            &mockBackend{},
 		SourceISO:          u,
-		ExtraKernelParams:  []string{},
+		ExtraKernelParams:  []string{"k1=1", "k2=2"},
 		Syslog:             "127.0.0.1:514",
 		TinkServerTLS:      false,
 		TinkServerGRPCAddr: "127.0.0.1:42113",
@@ -200,7 +200,7 @@ func TestRedirectHandling(t *testing.T) {
 		Logger:             logr.Discard(),
 		Backend:            &mockBackend{},
 		SourceISO:          redirectURL,
-		ExtraKernelParams:  []string{},
+		ExtraKernelParams:  []string{"k1=1", "k2=v2"},
 		Syslog:             "127.0.0.1:514",
 		TinkServerTLS:      false,
 		TinkServerGRPCAddr: "127.0.0.1:42113",
@@ -289,7 +289,7 @@ func TestMultipleRedirects(t *testing.T) {
 		Logger:             logr.Discard(),
 		Backend:            &mockBackend{},
 		SourceISO:          redirectURL,
-		ExtraKernelParams:  []string{},
+		ExtraKernelParams:  []string{"k1=1", "k2=2"},
 		Syslog:             "127.0.0.1:514",
 		TinkServerTLS:      false,
 		TinkServerGRPCAddr: "127.0.0.1:42113",


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows full user customization of all kernel parameters. This fixes an issue with setting parameters, such as TLS settings, properly.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
