### PR TITLE
Add CA certificates to Agent container image:

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,7 +1,12 @@
+FROM alpine:3.22 AS ca-certs
+
+RUN apk --no-cache add ca-certificates
+
 FROM scratch
 
 ARG TARGETOS
 ARG TARGETARCH
 
 COPY out/tink-agent-${TARGETOS}-${TARGETARCH} /tink-agent
+COPY --from=ca-certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT [ "/tink-agent" ]


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows TLS certs from publicly trusted CAs to work when the Agent uses TLS to connect to the Tink Server. This adds < 1mb of space to the container image. It doesn't solve the issue of custom CAs or self-signed certs.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested.


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
