### PR TITLE
helm: no service when using hostNetwork

### DIFF
--- a/helm/tinkerbell/templates/service.yaml
+++ b/helm/tinkerbell/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployment.hostNetwork }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -61,3 +62,4 @@ spec:
     {{- with .Values.service.selector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

There is no need to deploy the service when we have the deployment running with `hostNetwork: true`. This just makes it confusing.