### PR TITLE
Add Global bind address

### DIFF
--- a/cmd/tinkerbell/flag/global.go
+++ b/cmd/tinkerbell/flag/global.go
@@ -17,6 +17,7 @@ type GlobalConfig struct {
 	OTELInsecure         bool
 	TrustedProxies       []netip.Prefix
 	PublicIP             netip.Addr
+	BindAddr             netip.Addr
 	EnableSmee           bool
 	EnableTootles        bool
 	EnableTinkServer     bool
@@ -46,6 +47,7 @@ func RegisterGlobal(fs *Set, gc *GlobalConfig) {
 	fs.Register(BackendKubeNamespace, ffval.NewValueDefault(&gc.BackendKubeNamespace, gc.BackendKubeNamespace))
 	fs.Register(KubeQPS, ffval.NewValueDefault(&gc.BackendKubeOptions.QPS, gc.BackendKubeOptions.QPS))
 	fs.Register(KubeBurst, ffval.NewValueDefault(&gc.BackendKubeOptions.Burst, gc.BackendKubeOptions.Burst))
+	fs.Register(BindAddr, &ntip.Addr{Addr: &gc.BindAddr})
 	fs.Register(OTELEndpoint, ffval.NewValueDefault(&gc.OTELEndpoint, gc.OTELEndpoint))
 	fs.Register(OTELInsecure, ffval.NewValueDefault(&gc.OTELInsecure, gc.OTELInsecure))
 	fs.Register(TrustedProxies, &ntip.PrefixList{PrefixList: &gc.TrustedProxies})
@@ -168,4 +170,9 @@ var EnableETCD = Config{
 var EnableCRDMigrations = Config{
 	Name:  "enable-crd-migrations",
 	Usage: "create CRDs in the cluster",
+}
+
+var BindAddr = Config{
+	Name:  "bind-address",
+	Usage: "IP address to which to bind all services",
 }

--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -138,7 +138,7 @@ func RegisterSmeeFlags(fs *Set, sc *SmeeConfig) {
 }
 
 // Convert CLI specific fields to smee.Config fields.
-func (s *SmeeConfig) Convert(trustedProxies *[]netip.Prefix, publicIP netip.Addr) {
+func (s *SmeeConfig) Convert(trustedProxies *[]netip.Prefix, publicIP netip.Addr, bindAddr netip.Addr) {
 	s.Config.IPXE.HTTPScriptServer.TrustedProxies = ntip.ToPrefixList(trustedProxies).Slice()
 	s.Config.DHCP.IPXEHTTPScript.URL.Host = func() string {
 		var addr string                                 // Defaults
@@ -202,6 +202,16 @@ func (s *SmeeConfig) Convert(trustedProxies *[]netip.Prefix, publicIP netip.Addr
 		}
 		return fmt.Sprintf("%s:%s", publicIP.String(), port)
 	}()
+
+	// Set bind addresses if bindAddr is specified.
+	if bindAddr.IsValid() {
+		// iPXE HTTP Script Server
+		s.Config.IPXE.HTTPScriptServer.BindAddr = bindAddr
+		// syslog server
+		s.Config.Syslog.BindAddr = bindAddr
+		// TFTP server
+		s.Config.TFTP.BindAddr = bindAddr
+	}
 }
 
 func macAddrFormatParser(s string) (constant.MACFormat, error) {

--- a/cmd/tinkerbell/flag/tink_server.go
+++ b/cmd/tinkerbell/flag/tink_server.go
@@ -32,8 +32,12 @@ func RegisterTinkServerFlags(fs *Set, t *TinkServerConfig) {
 }
 
 // Convert TinkServerConfig data types to tink server server.Config data types.
-func (t *TinkServerConfig) Convert() {
-	t.Config.BindAddrPort = netip.AddrPortFrom(t.BindAddr, t.BindPort)
+func (t *TinkServerConfig) Convert(bindAddr netip.Addr) {
+	addr := t.BindAddr
+	if bindAddr.IsValid() {
+		addr = bindAddr
+	}
+	t.Config.BindAddrPort = netip.AddrPortFrom(addr, t.BindPort)
 }
 
 var TinkServerBindAddr = Config{

--- a/cmd/tinkerbell/flag/tootles.go
+++ b/cmd/tinkerbell/flag/tootles.go
@@ -49,11 +49,14 @@ var TootlesLogLevel = Config{
 }
 
 // Convert converts TootlesConfig data types to tootles.Config data types.
-func (h *TootlesConfig) Convert(trustedProxies *[]netip.Prefix) {
+func (h *TootlesConfig) Convert(trustedProxies *[]netip.Prefix, bindAddr netip.Addr) {
 	// Convert h.BindAddr and h.BindPort to h.Config.BindAddrPort
 	addr, port := splitHostPort(h.Config.BindAddrPort)
 	if h.BindAddr.IsValid() {
 		addr = h.BindAddr.String()
+	}
+	if bindAddr.IsValid() {
+		addr = bindAddr.String()
 	}
 	if h.BindPort != 0 {
 		port = fmt.Sprintf("%d", h.BindPort)

--- a/helm/tinkerbell/templates/deployment.yml
+++ b/helm/tinkerbell/templates/deployment.yml
@@ -214,6 +214,8 @@ spec:
               value: {{ .Values.deployment.envs.globals.backendKubeNamespace | quote }}
             - name: TINKERBELL_BACKEND_KUBE_QPS
               value: {{ .Values.deployment.envs.globals.backendKubeQPS | quote }}
+            - name: TINKERBELL_BIND_ADDR
+              value: {{ .Values.deployment.envs.globals.bindAddr | quote }}
             - name: TINKERBELL_OTEL_ENDPOINT
               value: {{ .Values.deployment.envs.globals.otelEndpoint | quote }}
             - name: TINKERBELL_OTEL_INSECURE

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -26,6 +26,7 @@ deployment:
       backendKubeConfig: ""
       backendKubeNamespace: ""
       backendKubeQPS: 100
+      bindAddr: ""
       enableCRDMigrations: true
       enableRufioController: true
       enableSecondstar: true

--- a/secondstar/secondstar.go
+++ b/secondstar/secondstar.go
@@ -35,7 +35,7 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 	}
 	log.Info("starting ssh server", "addrPort", addrPort)
 	server := &gssh.Server{
-		Addr:             fmt.Sprintf(":%d", c.SSHPort),
+		Addr:             addrPort,
 		Handler:          internal.Handler(log, internal.NewKeyValueStore(), c.IPMITOOLPath),
 		PublicKeyHandler: internal.PubkeyAuth(c.Backend, log),
 		Banner:           "Second star to the right and straight on 'til morning\n[Use ~. to disconnect]\n",

--- a/smee/internal/ipxe/http/middleware.go
+++ b/smee/internal/ipxe/http/middleware.go
@@ -34,7 +34,7 @@ func (h *loggingMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 	r := res.Header().Get("X-Global-Logging")
 
 	if log && r == "" {
-		h.log.Info("response", "method", method, "uri", uri, "client", client, "duration", time.Since(start), "status", res.statusCode)
+		h.log.Info("response", "method", method, "uri", uri, "client", client, "duration", time.Since(start).String(), "status", res.statusCode)
 	}
 }
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This makes it simpler and easier to specify a bind address that all services will use instead of the previous method of having to set CLI flags or Env vars for all services (9 bind addrs).

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
