### PR TITLE
dhcp: add support domain name option

### DIFF
--- a/api/v1alpha1/tinkerbell/hardware.go
+++ b/api/v1alpha1/tinkerbell/hardware.go
@@ -173,6 +173,7 @@ type DHCP struct {
 	// +kubebuilder:validation:Pattern="([0-9a-f]{2}[:]){5}([0-9a-f]{2})"
 	MAC         string   `json:"mac,omitempty"`
 	Hostname    string   `json:"hostname,omitempty"`
+	DomainName  string   `json:"domain_name,omitempty"`
 	LeaseTime   int64    `json:"lease_time,omitempty"`
 	NameServers []string `json:"name_servers,omitempty"`
 	TimeServers []string `json:"time_servers,omitempty"`

--- a/crd/bases/tinkerbell.org_hardware.yaml
+++ b/crd/bases/tinkerbell.org_hardware.yaml
@@ -130,6 +130,8 @@ spec:
                             - router
                             type: object
                           type: array
+                        domain_name:
+                          type: string
                         hostname:
                           type: string
                         iface_name:

--- a/pkg/backend/kube/kube_test.go
+++ b/pkg/backend/kube/kube_test.go
@@ -261,9 +261,10 @@ func TestGetByIP(t *testing.T) {
 			NameServers: []net.IP{
 				{0x1, 0x1, 0x1, 0x1},
 			},
-			Hostname:  "sm01",
-			LeaseTime: 86400,
-			Arch:      "x86_64",
+			Hostname:   "sm01",
+			DomainName: "example.com",
+			LeaseTime:  86400,
+			Arch:       "x86_64",
 		}, wantNetboot: &data.Netboot{
 			AllowNetboot: true,
 			IPXEScriptURL: &url.URL{
@@ -359,9 +360,10 @@ func TestGetByMac(t *testing.T) {
 			NameServers: []net.IP{
 				{0x1, 0x1, 0x1, 0x1},
 			},
-			Hostname:  "sm01",
-			LeaseTime: 86400,
-			Arch:      "x86_64",
+			Hostname:   "sm01",
+			DomainName: "example.com",
+			LeaseTime:  86400,
+			Arch:       "x86_64",
 		}, wantNetboot: &data.Netboot{
 			AllowNetboot: true,
 			IPXEScriptURL: &url.URL{
@@ -483,8 +485,9 @@ var hwObject1 = v1alpha1.Hardware{
 					},
 				},
 				DHCP: &v1alpha1.DHCP{
-					Arch:     "x86_64",
-					Hostname: "sm01",
+					Arch:       "x86_64",
+					Hostname:   "sm01",
+					DomainName: "example.com",
 					IP: &v1alpha1.IP{
 						Address: "172.16.10.100",
 						Gateway: "172.16.10.1",

--- a/pkg/backend/kube/smee.go
+++ b/pkg/backend/kube/smee.go
@@ -179,6 +179,9 @@ func toDHCPData(h *v1alpha1.DHCP) (*data.DHCP, error) {
 	// hostname, optional
 	d.Hostname = h.Hostname
 
+	// domain name, optional
+	d.DomainName = h.DomainName
+
 	// lease time required
 	// Default to one week
 	d.LeaseTime = 604800


### PR DESCRIPTION
## Description

Exposes the already defined domain name option towards the hardware api to be configured.

## How Has This Been Tested?

Configure the `domain_name` option and see the option in the dhcp reply.

## How are existing users impacted? What migration steps/scripts do we need?

no impact, optional config.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
