### PR TITLE
Helm: hookos hostnetwork should be configurable like tinkerbell

### DIFF
--- a/helm/tinkerbell/templates/hookos/deployment.yaml
+++ b/helm/tinkerbell/templates/hookos/deployment.yaml
@@ -63,6 +63,7 @@ spec:
         configMap:
           defaultMode: 0700
           name: download-hook
+      hostNetwork: {{ .Values.optional.hookos.hostNetwork }}
       {{- with .Values.optional.hookos.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/helm/tinkerbell/templates/hookos/service.yaml
+++ b/helm/tinkerbell/templates/hookos/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.optional.hookos.enabled }}
+{{- if not .Values.optional.hookos.hostNetwork }}
 {{- $artifactsURL := urlParse .Values.artifactsFileServer }}
 {{- $artifactsHost :=  split ":" $artifactsURL.host }}
 {{- $artifactsIP := include "isIpAddress" $artifactsHost._0 }}
@@ -31,4 +32,5 @@ spec:
     {{- with .Values.optional.hookos.selector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -233,6 +233,7 @@ optional:
     downloadURL: https://github.com/tinkerbell/hook/releases/download/v0.11.1
     enabled: true
     extension: tar.gz # iso, tar.gz, both
+    hostNetwork: false
     image: nginx:1.27.2
     kernelVersion: both # 5.10, 6.6, both
     name: hookos


### PR DESCRIPTION
## Description

Tinkerbell can be configured to use hostNetwork in cases where a load-balancer isn't available, but hookos does not have this ability.  Nodeport could work, but would require the user to manually configure the service port number in values.yaml and then update the artifactsFileServer to use the same port.  This will simplify things for users without load-balancers because they can re-use the `7173` port.

Fixes: #

## How Has This Been Tested?

For my use case, I'm doing some testing with a single node cluster and a qemu VM similar to the metal3 quick start guide (https://book.metal3.io/quick-start).  I was able to test this by patching hookos `kubectl edit deploy hookos` and adding the `hostNetwork: true` configuration.  After doing this I was able to install an OS no the vm.  Wanted to share this solution so others can use it too.


## How are existing users impacted? What migration steps/scripts do we need?

No expected impact, the default will be `hostNetwork: false`


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
