### PR TITLE
Enable Mergify in-place checks:

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,6 +2,7 @@ merge_queue:
   max_parallel_checks: 1
 queue_rules:
   - name: default
+    batch_size: 1
     queue_conditions:
       - base=main
       - or:
@@ -16,10 +17,17 @@ queue_rules:
       - label=ready-to-merge
     merge_conditions:
       # Conditions to get out of the queue (= merged)
+      - base=main
+      - or:
+          - "#approved-reviews-by>=1"
+          - author=jacobweinstock
+      - "#changes-requested-reviews-by=0"
       - check-success=DCO
       - check-success=validation
       - check-success=build-binaries (tink-agent, cross-compile-agent, tink-agent-binaries)
       - check-success=build-binaries (tinkerbell, cross-compile, tinkerbell-binaries)
+      - label!=do-not-merge
+      - label=ready-to-merge
     merge_method: merge
     commit_message_template: |
       {{ title }} (#{{ number }})


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This is needed because the GitHub branch protection setting `Require branches to be up to date before merging` is not compatible with draft PR checks in Mergify.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
