### PR TITLE
Add nocloud datasource

### DIFF
--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -247,6 +247,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 		s.Config.Backend = b
 		h.Config.BackendEc2 = b
 		h.Config.BackendHack = b
+		h.Config.BackendNoCloud = b
 		ts.Config.Backend = b
 		ts.Config.Auto.Enrollment.Backend = b
 		ts.Config.Auto.Discovery.Backend = b
@@ -265,6 +266,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 		s.Config.Backend = b
 		h.Config.BackendEc2 = b
 		h.Config.BackendHack = b
+		h.Config.BackendNoCloud = b
 	case "pass":
 	default:
 		return fmt.Errorf("unknown backend %q", globals.Backend)

--- a/docs/technical/TOOTLES_NOCLOUD.md
+++ b/docs/technical/TOOTLES_NOCLOUD.md
@@ -87,7 +87,7 @@ The NoCloud service is automatically available at the Tinkerbell service endpoin
 
 **PXE kernel parameters:**
 ```
-ds=nocloud;seedfrom=http://<tinkerbell-ip>:7172/
+ds=nocloud;seedfrom=http://<tinkerbell-ip>:7172/nocloud/
 ```
 
 

--- a/docs/technical/TOOTLES_NOCLOUD.md
+++ b/docs/technical/TOOTLES_NOCLOUD.md
@@ -30,23 +30,15 @@ spec:
   interfaces:
     - dhcp:
         mac: b8:cb:29:98:cb:3a
+        name_servers:
+          - "1.1.1.1"
+          - "1.0.0.1"
+          - "2606:4700:4700::1111"
         # First interface
     - dhcp:
         mac: b8:cb:29:98:cb:3b
         # Second interface
 ```
-
-### Supported Bonding Modes
-
-| Mode | Name | Description |
-|------|------|-------------|
-| 0 | balance-rr | Round-robin load balancing |
-| 1 | active-backup | Active-backup fault tolerance |
-| 2 | balance-xor | XOR load balancing |
-| 3 | broadcast | Broadcast on all interfaces |
-| 4 | 802.3ad | IEEE 802.3ad LACP (requires switch support) |
-| 5 | balance-tlb | Adaptive transmit load balancing |
-| 6 | balance-alb | Adaptive load balancing |
 
 ### Generated Network Configuration
 
@@ -79,91 +71,13 @@ config:
       - type: static
         address: 192.168.1.10/24
         gateway: 192.168.1.1
-        dns_nameservers: [8.8.8.8, 8.8.4.4]
+        dns_nameservers: [1.1.1.1, 1.0.0.1]
       - type: static6
         address: 2001:db8::10/64
         gateway: 2001:db8::1
-        dns_nameservers: [2001:4860:4860::8888]
+        dns_nameservers: [2606:4700:4700::1111]
 ```
 
-### Static IP Configuration
-
-#### IPv4 Static IP
-
-Specify IPv4 addresses with netmask:
-
-```yaml
-ips:
-  - address: "192.168.1.10"
-    netmask: "255.255.255.0"    # Converted to /24
-    gateway: "192.168.1.1"
-    family: 4
-```
-
-Supported netmasks:
-- `255.255.255.0` → /24
-- `255.255.255.240` → /28
-- `255.255.255.192` → /26
-- `255.255.0.0` → /16
-- `255.0.0.0` → /8
-
-#### IPv6 Static IP
-
-Specify IPv6 addresses with CIDR prefix:
-
-```yaml
-ips:
-  - address: "2001:db8::10/64"
-    gateway: "2001:db8::1"
-    family: 6
-```
-
-#### Dual-Stack Configuration
-
-Configure both IPv4 and IPv6:
-
-```yaml
-ips:
-  - address: "192.168.1.10"
-    netmask: "255.255.255.0"
-    gateway: "192.168.1.1"
-    family: 4
-  - address: "2001:db8::10/64"
-    gateway: "2001:db8::1"
-    family: 6
-```
-
-### Bond Parameters by Mode
-
-#### Mode 4 (802.3ad LACP)
-
-```yaml
-params:
-  bond-mode: 802.3ad
-  bond-miimon: 100
-  bond-lacp_rate: fast           # LACP packet rate (slow|fast)
-  bond-xmit_hash_policy: layer3+4 # Load balancing hash policy
-  bond-ad_select: stable          # Aggregation selection
-```
-
-#### Mode 1 (active-backup)
-
-```yaml
-params:
-  bond-mode: active-backup
-  bond-miimon: 100
-  bond-primary_reselect: always
-  bond-fail_over_mac: none
-```
-
-#### Mode 5 (balance-tlb)
-
-```yaml
-params:
-  bond-mode: balance-tlb
-  bond-miimon: 100
-  bond-tlb_dynamic_lb: 1
-```
 
 ### Cloud-init Integration
 
@@ -174,14 +88,6 @@ The NoCloud service is automatically available at the Tinkerbell service endpoin
 ds=nocloud;seedfrom=http://<tinkerbell-ip>:7172/
 ```
 
-**Or in cloud-init config:**
-```yaml
-# /etc/cloud/cloud.cfg.d/99-tinkerbell.cfg
-datasource_list: [NoCloud]
-datasource:
-  NoCloud:
-    seedfrom: http://<tinkerbell-ip>:7172/
-```
 
 ## OS-Specific Notes
 
@@ -191,73 +97,9 @@ datasource:
 
 **Workaround:** Revert the patch before cloud-init can use the network-config endpoint to create netplan configuration:
 
-```bash
-# Remove the patch from cloud-init
-sudo rm /usr/lib/python3/dist-packages/cloudinit/sources/DataSourceNoCloud.py
-sudo apt reinstall cloud-init
-```
-
-Or build a custom cloud-init package without the patch, or use an upstream cloud-init build.
-
-### Rocky Linux 9.6
-
-**Known Issue:** Cloud-init correctly parses the metadata and network-config, but the sysconfig renderer fails to create the bond interface properly.
-
-**Workaround:** Manually apply the network configuration after cloud-init runs:
-
-```bash
-# Delete old DHCP connections
-nmcli connection delete "System eth0" "System eth1" 2>/dev/null || true
-
-# Restart NetworkManager to pick up generated config files
-systemctl restart NetworkManager
-```
-
-Or use a post-provisioning script to ensure the bond is properly activated.
-
 ### Requirements
 
 - cloud-init 24.4+ (for correct bond parameter naming)
 - Network interfaces must support bonding
 - For 802.3ad mode: Switch must support LACP
 - At least 2 network interfaces defined in Hardware spec
-
-### Verification
-
-Verify the bond configuration after provisioning:
-
-```bash
-# Check bond status
-cat /proc/net/bonding/bond0
-
-# Verify IP configuration
-ip addr show bond0
-
-# Verify bonding mode and parameters
-cat /sys/class/net/bond0/bonding/mode
-cat /sys/class/net/bond0/bonding/slaves
-```
-
-### Troubleshooting
-
-**Validate network-config schema:**
-```bash
-cloud-init schema --system
-```
-
-**Check cloud-init logs:**
-```bash
-tail -f /var/log/cloud-init.log
-```
-
-**Verify metadata service:**
-```bash
-curl http://<tinkerbell-ip>:7172/network-config
-```
-
-**Check for Ubuntu patch:**
-```bash
-grep -r "no-nocloud-network" /usr/lib/python3/dist-packages/cloudinit/
-```
-
-For more information on bond parameters, see the [Linux Kernel Bonding documentation](https://www.kernel.org/doc/Documentation/networking/bonding.txt).

--- a/docs/technical/TOOTLES_NOCLOUD.md
+++ b/docs/technical/TOOTLES_NOCLOUD.md
@@ -53,10 +53,12 @@ network:
     bond0phy0:
       match:
         macaddress: b8:cb:29:98:cb:3a
+      set-name: bond0phy0
       dhcp4: false
     bond0phy1:
       match:
         macaddress: b8:cb:29:98:cb:3b
+      set-name: bond0phy1
       dhcp4: false
   bonds:
     bond0:
@@ -76,7 +78,7 @@ network:
         addresses: [1.1.1.1, 1.0.0.1, 2606:4700:4700::1111]
 ```
 
-**Note:** Physical interfaces are referenced as `bond0phyX` (where X is the interface index) and matched by MAC address. No interface renaming (`set-name`) is performed - the kernel will assign actual device names based on the MAC address matching.
+**Note:** Physical interfaces are matched by MAC address and renamed to `bond0phyX` (where X is the interface index) using `set-name`. This ensures consistent interface naming across reboots.
 
 
 ### Cloud-init Integration

--- a/docs/technical/TOOTLES_NOCLOUD.md
+++ b/docs/technical/TOOTLES_NOCLOUD.md
@@ -1,0 +1,263 @@
+# Tootles - NoCloud Network Bonding
+
+The NoCloud metadata service in Tinkerbell provides network bonding configuration for bare metal servers with static IP addresses, enabling cloud-init to configure bonded interfaces during provisioning.
+
+## Network Bonding with Static IPs
+
+### Hardware Configuration
+
+Configure bonding and static IPs in your Hardware resource:
+
+```yaml
+apiVersion: tinkerbell.org/v1alpha1
+kind: Hardware
+metadata:
+  name: server-001
+spec:
+  metadata:
+    bonding_mode: 4  # 802.3ad LACP
+    instance:
+      hostname: "server001.example.com"
+      id: "b8:cb:29:98:cb:3a"
+      ips:
+        - address: "192.168.1.10"
+          netmask: "255.255.255.0"
+          gateway: "192.168.1.1"
+          family: 4
+        - address: "2001:db8::10/64"
+          gateway: "2001:db8::1"
+          family: 6
+  interfaces:
+    - dhcp:
+        mac: b8:cb:29:98:cb:3a
+        # First interface
+    - dhcp:
+        mac: b8:cb:29:98:cb:3b
+        # Second interface
+```
+
+### Supported Bonding Modes
+
+| Mode | Name | Description |
+|------|------|-------------|
+| 0 | balance-rr | Round-robin load balancing |
+| 1 | active-backup | Active-backup fault tolerance |
+| 2 | balance-xor | XOR load balancing |
+| 3 | broadcast | Broadcast on all interfaces |
+| 4 | 802.3ad | IEEE 802.3ad LACP (requires switch support) |
+| 5 | balance-tlb | Adaptive transmit load balancing |
+| 6 | balance-alb | Adaptive load balancing |
+
+### Generated Network Configuration
+
+The NoCloud service automatically generates network-config for cloud-init:
+
+```yaml
+version: 1
+config:
+  - type: physical
+    name: eno1
+    mac_address: b8:cb:29:98:cb:3a
+    mtu: 1500
+
+  - type: physical
+    name: eno2
+    mac_address: b8:cb:29:98:cb:3b
+    mtu: 1500
+
+  - type: bond
+    name: bond0
+    bond_interfaces: [eno1, eno2]
+    mtu: 1500
+    params:
+      bond-mode: 802.3ad
+      bond-miimon: 100
+      bond-lacp_rate: fast
+      bond-xmit_hash_policy: layer3+4
+      bond-ad_select: stable
+    subnets:
+      - type: static
+        address: 192.168.1.10/24
+        gateway: 192.168.1.1
+        dns_nameservers: [8.8.8.8, 8.8.4.4]
+      - type: static6
+        address: 2001:db8::10/64
+        gateway: 2001:db8::1
+        dns_nameservers: [2001:4860:4860::8888]
+```
+
+### Static IP Configuration
+
+#### IPv4 Static IP
+
+Specify IPv4 addresses with netmask:
+
+```yaml
+ips:
+  - address: "192.168.1.10"
+    netmask: "255.255.255.0"    # Converted to /24
+    gateway: "192.168.1.1"
+    family: 4
+```
+
+Supported netmasks:
+- `255.255.255.0` → /24
+- `255.255.255.240` → /28
+- `255.255.255.192` → /26
+- `255.255.0.0` → /16
+- `255.0.0.0` → /8
+
+#### IPv6 Static IP
+
+Specify IPv6 addresses with CIDR prefix:
+
+```yaml
+ips:
+  - address: "2001:db8::10/64"
+    gateway: "2001:db8::1"
+    family: 6
+```
+
+#### Dual-Stack Configuration
+
+Configure both IPv4 and IPv6:
+
+```yaml
+ips:
+  - address: "192.168.1.10"
+    netmask: "255.255.255.0"
+    gateway: "192.168.1.1"
+    family: 4
+  - address: "2001:db8::10/64"
+    gateway: "2001:db8::1"
+    family: 6
+```
+
+### Bond Parameters by Mode
+
+#### Mode 4 (802.3ad LACP)
+
+```yaml
+params:
+  bond-mode: 802.3ad
+  bond-miimon: 100
+  bond-lacp_rate: fast           # LACP packet rate (slow|fast)
+  bond-xmit_hash_policy: layer3+4 # Load balancing hash policy
+  bond-ad_select: stable          # Aggregation selection
+```
+
+#### Mode 1 (active-backup)
+
+```yaml
+params:
+  bond-mode: active-backup
+  bond-miimon: 100
+  bond-primary_reselect: always
+  bond-fail_over_mac: none
+```
+
+#### Mode 5 (balance-tlb)
+
+```yaml
+params:
+  bond-mode: balance-tlb
+  bond-miimon: 100
+  bond-tlb_dynamic_lb: 1
+```
+
+### Cloud-init Integration
+
+The NoCloud service is automatically available at the Tinkerbell service endpoint. Configure cloud-init to use it:
+
+**PXE kernel parameters:**
+```
+ds=nocloud;seedfrom=http://<tinkerbell-ip>:7172/
+```
+
+**Or in cloud-init config:**
+```yaml
+# /etc/cloud/cloud.cfg.d/99-tinkerbell.cfg
+datasource_list: [NoCloud]
+datasource:
+  NoCloud:
+    seedfrom: http://<tinkerbell-ip>:7172/
+```
+
+## OS-Specific Notes
+
+### Ubuntu 22.04 and 24.04
+
+**Known Issue:** Canonical's cloud-init distributions include `no-nocloud-network.patch` which disables network-config from the NoCloud datasource.
+
+**Workaround:** Revert the patch before cloud-init can use the network-config endpoint to create netplan configuration:
+
+```bash
+# Remove the patch from cloud-init
+sudo rm /usr/lib/python3/dist-packages/cloudinit/sources/DataSourceNoCloud.py
+sudo apt reinstall cloud-init
+```
+
+Or build a custom cloud-init package without the patch, or use an upstream cloud-init build.
+
+### Rocky Linux 9.6
+
+**Known Issue:** Cloud-init correctly parses the metadata and network-config, but the sysconfig renderer fails to create the bond interface properly.
+
+**Workaround:** Manually apply the network configuration after cloud-init runs:
+
+```bash
+# Delete old DHCP connections
+nmcli connection delete "System eth0" "System eth1" 2>/dev/null || true
+
+# Restart NetworkManager to pick up generated config files
+systemctl restart NetworkManager
+```
+
+Or use a post-provisioning script to ensure the bond is properly activated.
+
+### Requirements
+
+- cloud-init 24.4+ (for correct bond parameter naming)
+- Network interfaces must support bonding
+- For 802.3ad mode: Switch must support LACP
+- At least 2 network interfaces defined in Hardware spec
+
+### Verification
+
+Verify the bond configuration after provisioning:
+
+```bash
+# Check bond status
+cat /proc/net/bonding/bond0
+
+# Verify IP configuration
+ip addr show bond0
+
+# Verify bonding mode and parameters
+cat /sys/class/net/bond0/bonding/mode
+cat /sys/class/net/bond0/bonding/slaves
+```
+
+### Troubleshooting
+
+**Validate network-config schema:**
+```bash
+cloud-init schema --system
+```
+
+**Check cloud-init logs:**
+```bash
+tail -f /var/log/cloud-init.log
+```
+
+**Verify metadata service:**
+```bash
+curl http://<tinkerbell-ip>:7172/network-config
+```
+
+**Check for Ubuntu patch:**
+```bash
+grep -r "no-nocloud-network" /usr/lib/python3/dist-packages/cloudinit/
+```
+
+For more information on bond parameters, see the [Linux Kernel Bonding documentation](https://www.kernel.org/doc/Documentation/networking/bonding.txt).

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -292,7 +292,6 @@ func generateBondingConfigurationV2(hw v1alpha1.Hardware) (map[string]interface{
 	return ethernets, bonds
 }
 
-
 // generateBondParametersV2 creates bonding parameters (v2 format) based on bonding mode.
 // V2 format uses hyphenated names without the "bond-" prefix.
 func generateBondParametersV2(bondingMode int64) map[string]interface{} {
@@ -366,7 +365,6 @@ func generateAddressConfigV2(ips []*v1alpha1.MetadataInstanceIP, ipv4DNS []strin
 
 	return addresses, gateway4, gateway6, nameservers
 }
-
 
 func (b *Backend) hwByIP(ctx context.Context, ip string) (*v1alpha1.Hardware, error) {
 	tracer := otel.Tracer(tracerName)

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -495,7 +495,6 @@ func generateNetworkConfigV2(hw v1alpha1.Hardware) *data.NetworkConfig {
 	}
 }
 
-
 // generateBondParametersV2 creates bonding parameters (v2 format) based on bonding mode.
 // V2 format uses hyphenated names without the "bond-" prefix.
 func generateBondParametersV2(bondingMode int64) data.BondParameters {

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -208,8 +208,9 @@ func cidrFromNetmask(netmask string) string {
 // generateNetworkConfigV2 creates a NoCloud-compatible network configuration (version 2) from Hardware resource.
 // Version 2 is the modern Netplan-compatible format.
 // Only generates configuration for network bonding. For non-bonded interfaces, cloud-init handles default DHCP.
-func generateNetworkConfigV2(hw v1alpha1.Hardware) data.NetworkConfigV2 {
-	networkSpec := data.NetworkSpec{
+// Returns nil if no network configuration is needed (non-bonded interfaces use default DHCP).
+func generateNetworkConfigV2(hw v1alpha1.Hardware) *data.NetworkConfig {
+	networkSpec := data.NetworkSpecV2{
 		Version: 2,
 	}
 
@@ -221,9 +222,12 @@ func generateNetworkConfigV2(hw v1alpha1.Hardware) data.NetworkConfigV2 {
 		ethernets, bonds := generateBondingConfigurationV2(hw)
 		networkSpec.Ethernets = ethernets
 		networkSpec.Bonds = bonds
+	} else {
+		// No bonding configuration needed, return nil to use default DHCP
+		return nil
 	}
 
-	return data.NetworkConfigV2{
+	return &data.NetworkConfig{
 		Network: networkSpec,
 	}
 }

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -259,6 +259,7 @@ func generateBondingConfigurationV2(hw v1alpha1.Hardware) (map[string]interface{
 			"match": map[string]interface{}{
 				"macaddress": iface.DHCP.MAC,
 			},
+			"set-name": interfaceName,
 		}
 
 		ethernets[interfaceName] = ethernetConfig

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -110,6 +110,391 @@ func toEC2Instance(hw v1alpha1.Hardware) data.Ec2Instance {
 	return i
 }
 
+// GetNoCloudInstance returns a NoCloudInstance by calling the hwByIP method and converting the result.
+// This is a method that the Tootles service uses.
+func (b *Backend) GetNoCloudInstance(ctx context.Context, ip string) (data.NoCloudInstance, error) {
+	hw, err := b.hwByIP(ctx, ip)
+	if err != nil {
+		if errors.Is(err, errNotFound) {
+			return data.NoCloudInstance{}, ErrInstanceNotFound
+		}
+
+		return data.NoCloudInstance{}, err
+	}
+
+	return toNoCloudInstance(*hw), nil
+}
+
+// toNoCloudInstance converts a Tinkerbell Hardware resource to a NoCloudInstance.
+func toNoCloudInstance(hw v1alpha1.Hardware) data.NoCloudInstance {
+	var i data.NoCloudInstance
+
+	// Set metadata from Hardware resource
+	if hw.Spec.Metadata != nil && hw.Spec.Metadata.Instance != nil {
+		i.Metadata.InstanceID = hw.Spec.Metadata.Instance.ID
+		i.Metadata.LocalHostname = hw.Spec.Metadata.Instance.Hostname
+	}
+
+	// Set user data from Hardware resource
+	if hw.Spec.UserData != nil {
+		i.Userdata = *hw.Spec.UserData
+	}
+
+	// Generate network configuration from Hardware resource
+	i.NetworkConfig = generateNetworkConfig(hw)
+
+	return i
+}
+
+// generateNetworkConfig creates a NoCloud-compatible network configuration from Hardware resource.
+func generateNetworkConfig(hw v1alpha1.Hardware) interface{} {
+	config := map[string]interface{}{
+		"version": 1,
+		"config":  []interface{}{},
+	}
+
+	configSlice := []interface{}{}
+
+	// Check if bonding is enabled
+	bondingEnabled := hw.Spec.Metadata != nil && hw.Spec.Metadata.BondingMode > 0
+
+	switch {
+	case bondingEnabled && len(hw.Spec.Interfaces) >= 2:
+		// Generate bonding configuration
+		configSlice = generateBondingConfiguration(hw)
+	case len(hw.Spec.Interfaces) == 0:
+		// No interfaces defined - generate fallback configuration
+		if hw.Spec.Metadata != nil && hw.Spec.Metadata.Instance != nil && len(hw.Spec.Metadata.Instance.Ips) > 0 {
+			configSlice = append(configSlice, generatePhysicalInterfaceWithIPs(hw.Spec.Metadata.Instance.Ips))
+		} else {
+			// Fallback to basic DHCP configuration
+			configSlice = append(configSlice, map[string]interface{}{
+				"type": "physical",
+				"name": "eno1",
+				"subnets": []interface{}{
+					map[string]interface{}{
+						"type": "dhcp",
+					},
+				},
+			})
+		}
+	default:
+		// Generate standard physical interface configuration
+		configSlice = generatePhysicalInterfaceConfiguration(hw)
+	}
+
+	// Add DNS configuration
+	dnsConfig := map[string]interface{}{
+		"type": "nameserver",
+		"address": []string{
+			"8.8.8.8",
+			"8.8.4.4",
+			"2001:4860:4860::8888",
+			"2001:4860:4860::8844",
+		},
+	}
+	configSlice = append(configSlice, dnsConfig)
+
+	config["config"] = configSlice
+	return config
+}
+
+// generateBondingConfiguration creates bonding configuration from Hardware resource.
+func generateBondingConfiguration(hw v1alpha1.Hardware) []interface{} {
+	configSlice := []interface{}{}
+	bondInterfaces := []string{}
+
+	// Create physical interfaces for bonding (without subnets)
+	for i, iface := range hw.Spec.Interfaces {
+		interfaceName := fmt.Sprintf("eno%d", i+1)
+		bondInterfaces = append(bondInterfaces, interfaceName)
+
+		physicalConfig := map[string]interface{}{
+			"type": "physical",
+			"name": interfaceName,
+			"mtu":  1500,
+		}
+
+		// Add MAC address if available in DHCP config
+		if iface.DHCP != nil && iface.DHCP.MAC != "" {
+			physicalConfig["mac_address"] = iface.DHCP.MAC
+		}
+
+		configSlice = append(configSlice, physicalConfig)
+	}
+
+	// Create bond configuration
+	bondConfig := map[string]interface{}{
+		"type":            "bond",
+		"name":            "bond0",
+		"bond_interfaces": bondInterfaces,
+		"mtu":             1500,
+		"params":          generateBondParameters(hw.Spec.Metadata.BondingMode),
+	}
+
+	// Add IP configuration to bond
+	if hw.Spec.Metadata != nil && hw.Spec.Metadata.Instance != nil && len(hw.Spec.Metadata.Instance.Ips) > 0 {
+		bondConfig["subnets"] = generateSubnetsFromIPs(hw.Spec.Metadata.Instance.Ips)
+	} else {
+		// Default to DHCP if no static IPs
+		bondConfig["subnets"] = []interface{}{
+			map[string]interface{}{"type": "dhcp"},
+			map[string]interface{}{"type": "dhcp6"},
+		}
+	}
+
+	configSlice = append(configSlice, bondConfig)
+	return configSlice
+}
+
+// generatePhysicalInterfaceConfiguration creates standard physical interface configuration.
+func generatePhysicalInterfaceConfiguration(hw v1alpha1.Hardware) []interface{} {
+	configSlice := []interface{}{}
+
+	for i, iface := range hw.Spec.Interfaces {
+		interfaceName := fmt.Sprintf("eno%d", i+1)
+
+		physicalConfig := map[string]interface{}{
+			"type": "physical",
+			"name": interfaceName,
+			"mtu":  1500,
+		}
+
+		// Add MAC address if available
+		if iface.DHCP != nil && iface.DHCP.MAC != "" {
+			physicalConfig["mac_address"] = iface.DHCP.MAC
+		}
+
+		// Add subnets configuration based on interface settings
+		subnets := []interface{}{}
+
+		if !iface.DisableDHCP {
+			subnets = append(subnets, map[string]interface{}{
+				"type": "dhcp",
+			})
+			subnets = append(subnets, map[string]interface{}{
+				"type": "dhcp6",
+			})
+		}
+
+		if len(subnets) > 0 {
+			physicalConfig["subnets"] = subnets
+		}
+
+		configSlice = append(configSlice, physicalConfig)
+	}
+
+	// If we have metadata IPs, try to create static configuration for the first interface
+	if hw.Spec.Metadata != nil && hw.Spec.Metadata.Instance != nil && len(hw.Spec.Metadata.Instance.Ips) > 0 {
+		staticConfig := generateStaticNetworkConfig(hw.Spec.Metadata.Instance.Ips)
+		if staticConfig != nil {
+			// Replace the first interface with static configuration
+			if len(configSlice) > 0 {
+				configSlice[0] = staticConfig
+			}
+		}
+	}
+
+	return configSlice
+}
+
+// generateBondParameters creates bonding parameters based on bonding mode.
+func generateBondParameters(bondingMode int64) map[string]interface{} {
+	params := map[string]interface{}{
+		"bond-miimon": 100,
+	}
+
+	switch bondingMode {
+	case 0:
+		params["bond-mode"] = "balance-rr"
+		params["bond-use_carrier"] = 1
+	case 1:
+		params["bond-mode"] = "active-backup"
+		params["bond-primary_reselect"] = "always"
+		params["bond-fail_over_mac"] = "none"
+	case 2:
+		params["bond-mode"] = "balance-xor"
+		params["bond-xmit_hash_policy"] = "layer2"
+	case 3:
+		params["bond-mode"] = "broadcast"
+	case 4:
+		params["bond-mode"] = "802.3ad"
+		params["bond-lacp_rate"] = "fast"
+		params["bond-xmit_hash_policy"] = "layer3+4"
+		params["bond-ad_select"] = "stable"
+	case 5:
+		params["bond-mode"] = "balance-tlb"
+		params["bond-tlb_dynamic_lb"] = 1
+	case 6:
+		params["bond-mode"] = "balance-alb"
+		params["bond-rlb_update_delay"] = 0
+	default:
+		// Default to active-backup for unknown modes
+		params["bond-mode"] = "active-backup"
+		params["bond-primary_reselect"] = "always"
+	}
+
+	return params
+}
+
+// generateSubnetsFromIPs creates subnet configuration from IP metadata.
+func generateSubnetsFromIPs(ips []*v1alpha1.MetadataInstanceIP) []interface{} {
+	subnets := []interface{}{}
+
+	for _, ip := range ips {
+		switch ip.Family {
+		case 4:
+			subnet := map[string]interface{}{
+				"type":    "static",
+				"address": fmt.Sprintf("%s/%s", ip.Address, cidrFromNetmask(ip.Netmask)),
+			}
+			if ip.Gateway != "" {
+				subnet["gateway"] = ip.Gateway
+			}
+			subnet["dns_nameservers"] = []string{"8.8.8.8", "8.8.4.4"}
+			subnets = append(subnets, subnet)
+		case 6:
+			subnet := map[string]interface{}{
+				"type":    "static6",
+				"address": ip.Address,
+			}
+			if ip.Gateway != "" {
+				subnet["gateway"] = ip.Gateway
+			}
+			subnet["dns_nameservers"] = []string{"2001:4860:4860::8888"}
+			subnets = append(subnets, subnet)
+		}
+	}
+
+	// If no static IPs, fall back to DHCP
+	if len(subnets) == 0 {
+		subnets = append(subnets, map[string]interface{}{"type": "dhcp"})
+		subnets = append(subnets, map[string]interface{}{"type": "dhcp6"})
+	}
+
+	return subnets
+}
+
+// generatePhysicalInterfaceWithIPs creates a basic physical interface with IP configuration.
+func generatePhysicalInterfaceWithIPs(ips []*v1alpha1.MetadataInstanceIP) map[string]interface{} {
+	physicalConfig := map[string]interface{}{
+		"type": "physical",
+		"name": "eno1",
+		"mtu":  1500,
+	}
+
+	subnets := []interface{}{}
+
+	// Add static IP configurations
+	for _, ip := range ips {
+		switch ip.Family {
+		case 4:
+			subnet := map[string]interface{}{
+				"type":    "static",
+				"address": fmt.Sprintf("%s/%s", ip.Address, cidrFromNetmask(ip.Netmask)),
+			}
+			if ip.Gateway != "" {
+				subnet["gateway"] = ip.Gateway
+			}
+			subnet["dns_nameservers"] = []string{"8.8.8.8", "8.8.4.4"}
+			subnets = append(subnets, subnet)
+		case 6:
+			subnet := map[string]interface{}{
+				"type":    "static6",
+				"address": ip.Address, // IPv6 addresses should already include prefix
+			}
+			if ip.Gateway != "" {
+				subnet["gateway"] = ip.Gateway
+			}
+			subnet["dns_nameservers"] = []string{"2001:4860:4860::8888"}
+			subnets = append(subnets, subnet)
+		}
+	}
+
+	// If no static IPs, fall back to DHCP
+	if len(subnets) == 0 {
+		subnets = append(subnets, map[string]interface{}{
+			"type": "dhcp",
+		})
+	}
+
+	physicalConfig["subnets"] = subnets
+	return physicalConfig
+}
+
+// generateStaticNetworkConfig creates static network configuration from metadata IPs.
+func generateStaticNetworkConfig(ips []*v1alpha1.MetadataInstanceIP) map[string]interface{} {
+	if len(ips) == 0 {
+		return nil
+	}
+
+	config := map[string]interface{}{
+		"type": "physical",
+		"name": "eno1",
+		"mtu":  1500,
+	}
+
+	subnets := []interface{}{}
+
+	for _, ip := range ips {
+		switch ip.Family {
+		case 4:
+			subnet := map[string]interface{}{
+				"type":    "static",
+				"address": fmt.Sprintf("%s/%s", ip.Address, cidrFromNetmask(ip.Netmask)),
+			}
+			if ip.Gateway != "" {
+				subnet["gateway"] = ip.Gateway
+			}
+			subnet["dns_nameservers"] = []string{"8.8.8.8", "8.8.4.4"}
+			subnets = append(subnets, subnet)
+		case 6:
+			subnet := map[string]interface{}{
+				"type":    "static6",
+				"address": ip.Address,
+			}
+			if ip.Gateway != "" {
+				subnet["gateway"] = ip.Gateway
+			}
+			subnet["dns_nameservers"] = []string{"2001:4860:4860::8888"}
+			subnets = append(subnets, subnet)
+		}
+	}
+
+	if len(subnets) > 0 {
+		config["subnets"] = subnets
+		return config
+	}
+
+	return nil
+}
+
+// cidrFromNetmask converts a netmask to CIDR notation.
+// This is a simple implementation that handles common netmasks.
+func cidrFromNetmask(netmask string) string {
+	switch netmask {
+	case "255.255.255.0":
+		return "24"
+	case "255.255.0.0":
+		return "16"
+	case "255.0.0.0":
+		return "8"
+	case "255.255.255.192":
+		return "26"
+	case "255.255.255.224":
+		return "27"
+	case "255.255.255.240":
+		return "28"
+	case "255.255.255.248":
+		return "29"
+	case "255.255.255.252":
+		return "30"
+	default:
+		// Default to /24 if we can't determine the CIDR
+		return "24"
+	}
+}
+
 func (b *Backend) hwByIP(ctx context.Context, ip string) (*v1alpha1.Hardware, error) {
 	tracer := otel.Tracer(tracerName)
 	ctx, span := tracer.Start(ctx, "backend.kube.hwByIP")

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -194,7 +194,7 @@ func cidrFromNetmask(netmask string) string {
 
 		for octet > 0 {
 			setBits++
-			octet = octet & (octet - 1)
+			octet &= (octet - 1)
 		}
 	}
 
@@ -215,7 +215,11 @@ func generateNetworkConfigV2(hw v1alpha1.Hardware) interface{} {
 		},
 	}
 
-	network := config["network"].(map[string]interface{})
+	network, ok := config["network"].(map[string]interface{})
+	if !ok {
+		// This should never happen since we just created it, but satisfy the linter
+		return config
+	}
 
 	// Check if bonding is enabled
 	bondingEnabled := hw.Spec.Metadata != nil && hw.Spec.Metadata.BondingMode > 0

--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -248,8 +248,8 @@ func generateNetworkConfigV2(hw v1alpha1.Hardware) *data.NetworkConfig {
 		Version: 2,
 	}
 
-	// Check if bonding is enabled
-	bondingEnabled := hw.Spec.Metadata != nil && hw.Spec.Metadata.BondingMode > 0
+	// Check if bonding is enabled (BondingMode >= 0 is valid, mode 0 is balance-rr)
+	bondingEnabled := hw.Spec.Metadata != nil && hw.Spec.Metadata.BondingMode >= 0
 
 	if bondingEnabled && len(hw.Spec.Interfaces) >= 2 {
 		// Generate bonding configuration

--- a/pkg/backend/kube/tootles_test.go
+++ b/pkg/backend/kube/tootles_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
+	tinkerbell "github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
 )
 
 func TestCidrFromNetmask(t *testing.T) {
@@ -21,8 +21,14 @@ func TestCidrFromNetmask(t *testing.T) {
 		{"/28", "255.255.255.240", "28"},
 		{"/29", "255.255.255.248", "29"},
 		{"/30", "255.255.255.252", "30"},
-		{"Unknown defaults to /24", "255.255.128.0", "24"},
-		{"Empty defaults to /24", "", "24"},
+		{"/31", "255.255.255.254", "31"},
+		{"/32", "255.255.255.255", "32"},
+		{"/17", "255.255.128.0", "17"},
+		{"/25", "255.255.255.128", "25"},
+		{"Empty returns empty", "", ""},
+		{"Invalid format returns empty", "255.255", ""},
+		{"Invalid characters return empty", "255.255.abc.0", ""},
+		{"Out of range returns empty", "255.255.256.0", ""},
 	}
 
 	for _, tt := range tests {
@@ -33,7 +39,9 @@ func TestCidrFromNetmask(t *testing.T) {
 	}
 }
 
-func TestGenerateBondParameters(t *testing.T) {
+// V2 Tests
+
+func TestGenerateBondParametersV2(t *testing.T) {
 	tests := []struct {
 		name     string
 		mode     int64
@@ -43,94 +51,94 @@ func TestGenerateBondParameters(t *testing.T) {
 			name: "mode 0 - balance-rr",
 			mode: 0,
 			expected: map[string]interface{}{
-				"bond-mode":        "balance-rr",
-				"bond-miimon":      100,
-				"bond-use_carrier": 1,
+				"mode":                 "balance-rr",
+				"mii-monitor-interval": 100,
 			},
 		},
 		{
 			name: "mode 1 - active-backup",
 			mode: 1,
 			expected: map[string]interface{}{
-				"bond-mode":             "active-backup",
-				"bond-miimon":           100,
-				"bond-primary_reselect": "always",
-				"bond-fail_over_mac":    "none",
+				"mode":                    "active-backup",
+				"mii-monitor-interval":    100,
+				"primary-reselect-policy": "always",
+				"fail-over-mac-policy":    "none",
 			},
 		},
 		{
 			name: "mode 2 - balance-xor",
 			mode: 2,
 			expected: map[string]interface{}{
-				"bond-mode":             "balance-xor",
-				"bond-miimon":           100,
-				"bond-xmit_hash_policy": "layer2",
+				"mode":                 "balance-xor",
+				"mii-monitor-interval": 100,
+				"transmit-hash-policy": "layer2",
 			},
 		},
 		{
 			name: "mode 3 - broadcast",
 			mode: 3,
 			expected: map[string]interface{}{
-				"bond-mode":   "broadcast",
-				"bond-miimon": 100,
+				"mode":                 "broadcast",
+				"mii-monitor-interval": 100,
 			},
 		},
 		{
 			name: "mode 4 - 802.3ad",
 			mode: 4,
 			expected: map[string]interface{}{
-				"bond-mode":             "802.3ad",
-				"bond-miimon":           100,
-				"bond-lacp_rate":        "fast",
-				"bond-xmit_hash_policy": "layer3+4",
-				"bond-ad_select":        "stable",
+				"mode":                 "802.3ad",
+				"mii-monitor-interval": 100,
+				"lacp-rate":            "fast",
+				"transmit-hash-policy": "layer3+4",
+				"ad-select":            "stable",
 			},
 		},
 		{
 			name: "mode 5 - balance-tlb",
 			mode: 5,
 			expected: map[string]interface{}{
-				"bond-mode":           "balance-tlb",
-				"bond-miimon":         100,
-				"bond-tlb_dynamic_lb": 1,
+				"mode":                 "balance-tlb",
+				"mii-monitor-interval": 100,
 			},
 		},
 		{
 			name: "mode 6 - balance-alb",
 			mode: 6,
 			expected: map[string]interface{}{
-				"bond-mode":             "balance-alb",
-				"bond-miimon":           100,
-				"bond-rlb_update_delay": 0,
+				"mode":                 "balance-alb",
+				"mii-monitor-interval": 100,
 			},
 		},
 		{
 			name: "unknown mode defaults to active-backup",
 			mode: 99,
 			expected: map[string]interface{}{
-				"bond-mode":             "active-backup",
-				"bond-miimon":           100,
-				"bond-primary_reselect": "always",
+				"mode":                    "active-backup",
+				"mii-monitor-interval":    100,
+				"primary-reselect-policy": "always",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := generateBondParameters(tt.mode)
+			result := generateBondParametersV2(tt.mode)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestGenerateSubnetsFromIPs(t *testing.T) {
+func TestGenerateAddressConfigV2(t *testing.T) {
 	ipv4DNS := []string{"8.8.8.8", "8.8.4.4"}
 	ipv6DNS := []string{"2001:4860:4860::8888"}
 
 	tests := []struct {
-		name     string
-		ips      []*tinkerbell.MetadataInstanceIP
-		expected []interface{}
+		name               string
+		ips                []*tinkerbell.MetadataInstanceIP
+		expectedAddresses  []string
+		expectedGateway4   string
+		expectedGateway6   string
+		expectedNameserver []string
 	}{
 		{
 			name: "IPv4 with gateway",
@@ -142,31 +150,10 @@ func TestGenerateSubnetsFromIPs(t *testing.T) {
 					Family:  4,
 				},
 			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"type":            "static",
-					"address":         "192.168.1.10/24",
-					"gateway":         "192.168.1.1",
-					"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
-				},
-			},
-		},
-		{
-			name: "IPv4 without gateway",
-			ips: []*tinkerbell.MetadataInstanceIP{
-				{
-					Address: "192.168.1.10",
-					Netmask: "255.255.255.240",
-					Family:  4,
-				},
-			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"type":            "static",
-					"address":         "192.168.1.10/28",
-					"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
-				},
-			},
+			expectedAddresses:  []string{"192.168.1.10/24"},
+			expectedGateway4:   "192.168.1.1",
+			expectedGateway6:   "",
+			expectedNameserver: []string{"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888"},
 		},
 		{
 			name: "IPv6 with gateway",
@@ -177,33 +164,13 @@ func TestGenerateSubnetsFromIPs(t *testing.T) {
 					Family:  6,
 				},
 			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"type":            "static6",
-					"address":         "2001:db8::10/64",
-					"gateway":         "2001:db8::1",
-					"dns_nameservers": []string{"2001:4860:4860::8888"},
-				},
-			},
+			expectedAddresses:  []string{"2001:db8::10/64"},
+			expectedGateway4:   "",
+			expectedGateway6:   "2001:db8::1",
+			expectedNameserver: []string{"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888"},
 		},
 		{
-			name: "IPv6 without gateway",
-			ips: []*tinkerbell.MetadataInstanceIP{
-				{
-					Address: "2001:db8::10/64",
-					Family:  6,
-				},
-			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"type":            "static6",
-					"address":         "2001:db8::10/64",
-					"dns_nameservers": []string{"2001:4860:4860::8888"},
-				},
-			},
-		},
-		{
-			name: "Dual stack",
+			name: "Dual stack with gateways",
 			ips: []*tinkerbell.MetadataInstanceIP{
 				{
 					Address: "192.168.1.10",
@@ -217,47 +184,62 @@ func TestGenerateSubnetsFromIPs(t *testing.T) {
 					Family:  6,
 				},
 			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"type":            "static",
-					"address":         "192.168.1.10/24",
-					"gateway":         "192.168.1.1",
-					"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
-				},
-				map[string]interface{}{
-					"type":            "static6",
-					"address":         "2001:db8::10/64",
-					"gateway":         "2001:db8::1",
-					"dns_nameservers": []string{"2001:4860:4860::8888"},
-				},
-			},
+			expectedAddresses:  []string{"192.168.1.10/24", "2001:db8::10/64"},
+			expectedGateway4:   "192.168.1.1",
+			expectedGateway6:   "2001:db8::1",
+			expectedNameserver: []string{"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888"},
 		},
 		{
-			name: "No IPs - fallback to DHCP",
-			ips:  []*tinkerbell.MetadataInstanceIP{},
-			expected: []interface{}{
-				map[string]interface{}{"type": "dhcp"},
-				map[string]interface{}{"type": "dhcp6"},
+			name: "Multiple IPv4 addresses - first gateway wins",
+			ips: []*tinkerbell.MetadataInstanceIP{
+				{
+					Address: "192.168.1.10",
+					Netmask: "255.255.255.0",
+					Gateway: "192.168.1.1",
+					Family:  4,
+				},
+				{
+					Address: "10.0.0.10",
+					Netmask: "255.255.255.0",
+					Gateway: "10.0.0.1",
+					Family:  4,
+				},
 			},
+			expectedAddresses:  []string{"192.168.1.10/24", "10.0.0.10/24"},
+			expectedGateway4:   "192.168.1.1", // First gateway
+			expectedGateway6:   "",
+			expectedNameserver: []string{"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888"},
+		},
+		{
+			name:               "No IPs",
+			ips:                []*tinkerbell.MetadataInstanceIP{},
+			expectedAddresses:  []string{},
+			expectedGateway4:   "",
+			expectedGateway6:   "",
+			expectedNameserver: []string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := generateSubnetsFromIPs(tt.ips, ipv4DNS, ipv6DNS)
-			assert.Equal(t, tt.expected, result)
+			addresses, gateway4, gateway6, nameservers := generateAddressConfigV2(tt.ips, ipv4DNS, ipv6DNS)
+			assert.Equal(t, tt.expectedAddresses, addresses)
+			assert.Equal(t, tt.expectedGateway4, gateway4)
+			assert.Equal(t, tt.expectedGateway6, gateway6)
+			assert.Equal(t, tt.expectedNameserver, nameservers)
 		})
 	}
 }
 
-func TestGenerateBondingConfiguration(t *testing.T) {
+func TestGenerateBondingConfigurationV2(t *testing.T) {
 	tests := []struct {
-		name     string
-		hw       tinkerbell.Hardware
-		expected []interface{}
+		name              string
+		hw                tinkerbell.Hardware
+		validateEthernets func(t *testing.T, ethernets map[string]interface{})
+		validateBonds     func(t *testing.T, bonds map[string]interface{})
 	}{
 		{
-			name: "802.3ad bond with 2 interfaces",
+			name: "802.3ad bond with 2 interfaces and static IPs",
 			hw: tinkerbell.Hardware{
 				Spec: tinkerbell.HardwareSpec{
 					Metadata: &tinkerbell.HardwareMetadata{
@@ -270,57 +252,65 @@ func TestGenerateBondingConfiguration(t *testing.T) {
 									Gateway: "192.168.1.1",
 									Family:  4,
 								},
+								{
+									Address: "2001:db8::10/64",
+									Gateway: "2001:db8::1",
+									Family:  6,
+								},
 							},
 						},
 					},
 					Interfaces: []tinkerbell.Interface{
-						{
-							DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"},
-						},
-						{
-							DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:02"},
-						},
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"}},
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:02"}},
 					},
 				},
 			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"type":        "physical",
-					"name":        "eno1",
-					"mac_address": "aa:bb:cc:dd:ee:01",
-					"mtu":         1500,
-				},
-				map[string]interface{}{
-					"type":        "physical",
-					"name":        "eno2",
-					"mac_address": "aa:bb:cc:dd:ee:02",
-					"mtu":         1500,
-				},
-				map[string]interface{}{
-					"type":            "bond",
-					"name":            "bond0",
-					"bond_interfaces": []string{"eno1", "eno2"},
-					"mtu":             1500,
-					"params": map[string]interface{}{
-						"bond-mode":             "802.3ad",
-						"bond-miimon":           100,
-						"bond-lacp_rate":        "fast",
-						"bond-xmit_hash_policy": "layer3+4",
-						"bond-ad_select":        "stable",
-					},
-					"subnets": []interface{}{
-						map[string]interface{}{
-							"type":            "static",
-							"address":         "192.168.1.10/24",
-							"gateway":         "192.168.1.1",
-							"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
-						},
-					},
-				},
+			validateEthernets: func(t *testing.T, ethernets map[string]interface{}) {
+				t.Helper()
+				assert.Len(t, ethernets, 2)
+
+				iface1 := ethernets["bond0phy0"].(map[string]interface{})
+				assert.Equal(t, false, iface1["dhcp4"])
+				match := iface1["match"].(map[string]interface{})
+				assert.Equal(t, "aa:bb:cc:dd:ee:01", match["macaddress"])
+				_, hasSetName := iface1["set-name"]
+				assert.False(t, hasSetName, "set-name should not be present")
+
+				iface2 := ethernets["bond0phy1"].(map[string]interface{})
+				assert.Equal(t, false, iface2["dhcp4"])
+				match2 := iface2["match"].(map[string]interface{})
+				assert.Equal(t, "aa:bb:cc:dd:ee:02", match2["macaddress"])
+			},
+			validateBonds: func(t *testing.T, bonds map[string]interface{}) {
+				t.Helper()
+				bond0 := bonds["bond0"].(map[string]interface{})
+
+				// Check interfaces
+				interfaces := bond0["interfaces"].([]string)
+				assert.Equal(t, []string{"bond0phy0", "bond0phy1"}, interfaces)
+
+				// Check parameters
+				params := bond0["parameters"].(map[string]interface{})
+				assert.Equal(t, "802.3ad", params["mode"])
+				assert.Equal(t, 100, params["mii-monitor-interval"])
+				assert.Equal(t, "fast", params["lacp-rate"])
+				assert.Equal(t, "layer3+4", params["transmit-hash-policy"])
+				assert.Equal(t, "stable", params["ad-select"])
+
+				// Check addresses
+				addresses := bond0["addresses"].([]string)
+				assert.Equal(t, []string{"192.168.1.10/24", "2001:db8::10/64"}, addresses)
+
+				// Check gateways
+				assert.Equal(t, "192.168.1.1", bond0["gateway4"])
+				assert.Equal(t, "2001:db8::1", bond0["gateway6"])
+
+				// No nameservers configured in this test - nameservers field should not be set
 			},
 		},
 		{
-			name: "bond with no IPs - fallback to DHCP",
+			name: "active-backup bond with DHCP",
 			hw: tinkerbell.Hardware{
 				Spec: tinkerbell.HardwareSpec{
 					Metadata: &tinkerbell.HardwareMetadata{
@@ -332,48 +322,34 @@ func TestGenerateBondingConfiguration(t *testing.T) {
 					},
 				},
 			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"type":        "physical",
-					"name":        "eno1",
-					"mac_address": "aa:bb:cc:dd:ee:01",
-					"mtu":         1500,
-				},
-				map[string]interface{}{
-					"type":        "physical",
-					"name":        "eno2",
-					"mac_address": "aa:bb:cc:dd:ee:02",
-					"mtu":         1500,
-				},
-				map[string]interface{}{
-					"type":            "bond",
-					"name":            "bond0",
-					"bond_interfaces": []string{"eno1", "eno2"},
-					"mtu":             1500,
-					"params": map[string]interface{}{
-						"bond-mode":             "active-backup",
-						"bond-miimon":           100,
-						"bond-primary_reselect": "always",
-						"bond-fail_over_mac":    "none",
-					},
-					"subnets": []interface{}{
-						map[string]interface{}{"type": "dhcp"},
-						map[string]interface{}{"type": "dhcp6"},
-					},
-				},
+			validateEthernets: func(t *testing.T, ethernets map[string]interface{}) {
+				t.Helper()
+				assert.Len(t, ethernets, 2)
+			},
+			validateBonds: func(t *testing.T, bonds map[string]interface{}) {
+				t.Helper()
+				bond0 := bonds["bond0"].(map[string]interface{})
+
+				// Should have DHCP when no static IPs
+				assert.Equal(t, true, bond0["dhcp4"])
+
+				// Check parameters for active-backup
+				params := bond0["parameters"].(map[string]interface{})
+				assert.Equal(t, "active-backup", params["mode"])
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := generateBondingConfiguration(tt.hw)
-			assert.Equal(t, tt.expected, result)
+			ethernets, bonds := generateBondingConfigurationV2(tt.hw)
+			tt.validateEthernets(t, ethernets)
+			tt.validateBonds(t, bonds)
 		})
 	}
 }
 
-func TestGenerateNetworkConfig(t *testing.T) {
+func TestGenerateNetworkConfigV2(t *testing.T) {
 	tests := []struct {
 		name     string
 		hw       tinkerbell.Hardware
@@ -400,81 +376,194 @@ func TestGenerateNetworkConfig(t *testing.T) {
 			validate: func(t *testing.T, result interface{}) {
 				t.Helper()
 				config := result.(map[string]interface{})
-				assert.Equal(t, 1, config["version"])
-				configSlice := config["config"].([]interface{})
-				assert.Len(t, configSlice, 3) // 2 physical + 1 bond
+				network := config["network"].(map[string]interface{})
+
+				// Check version
+				assert.Equal(t, 2, network["version"])
+
+				// Check ethernets exist
+				ethernets := network["ethernets"].(map[string]interface{})
+				assert.Len(t, ethernets, 2)
+
+				// Check bonds exist
+				bonds := network["bonds"].(map[string]interface{})
+				assert.Len(t, bonds, 1)
+				assert.Contains(t, bonds, "bond0")
 			},
 		},
 		{
-			name: "bonding disabled - single interface",
-			hw: tinkerbell.Hardware{
-				Spec: tinkerbell.HardwareSpec{
-					Metadata: &tinkerbell.HardwareMetadata{
-						BondingMode: 0,
-						Instance: &tinkerbell.MetadataInstance{
-							Ips: []*tinkerbell.MetadataInstanceIP{
-								{Address: "192.168.1.10", Netmask: "255.255.255.0", Gateway: "192.168.1.1", Family: 4},
-							},
-						},
-					},
-					Interfaces: []tinkerbell.Interface{
-						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"}},
-					},
-				},
-			},
-			validate: func(t *testing.T, result interface{}) {
-				t.Helper()
-				config := result.(map[string]interface{})
-				assert.Equal(t, 1, config["version"])
-				configSlice := config["config"].([]interface{})
-				assert.Len(t, configSlice, 1) // single physical interface
-			},
-		},
-		{
-			name: "no interfaces - fallback DHCP",
+			name: "no interfaces - no network config",
 			hw: tinkerbell.Hardware{
 				Spec: tinkerbell.HardwareSpec{},
 			},
 			validate: func(t *testing.T, result interface{}) {
 				t.Helper()
 				config := result.(map[string]interface{})
-				assert.Equal(t, 1, config["version"])
-				configSlice := config["config"].([]interface{})
-				assert.Len(t, configSlice, 1)
-				item := configSlice[0].(map[string]interface{})
-				assert.Equal(t, "physical", item["type"])
+				network := config["network"].(map[string]interface{})
+
+				assert.Equal(t, 2, network["version"])
+
+				// No interfaces defined means no ethernets config
+				// Let cloud-init handle its default DHCP behavior
+				_, hasEthernets := network["ethernets"]
+				assert.False(t, hasEthernets)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := generateNetworkConfig(tt.hw)
+			result := generateNetworkConfigV2(tt.hw)
 			tt.validate(t, result)
 		})
 	}
 }
 
 func TestToNoCloudInstance(t *testing.T) {
-	hw := tinkerbell.Hardware{
-		Spec: tinkerbell.HardwareSpec{
-			Metadata: &tinkerbell.HardwareMetadata{
-				Instance: &tinkerbell.MetadataInstance{
-					ID:       "server-001",
-					Hostname: "server001.example.com",
+	tests := []struct {
+		name     string
+		hw       tinkerbell.Hardware
+		validate func(t *testing.T, instance interface{})
+	}{
+		{
+			name: "complete hardware resource",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Metadata: &tinkerbell.HardwareMetadata{
+						Instance: &tinkerbell.MetadataInstance{
+							ID:       "server-001",
+							Hostname: "server001.example.com",
+							Ips: []*tinkerbell.MetadataInstanceIP{
+								{Address: "192.168.1.10", Netmask: "255.255.255.0", Gateway: "192.168.1.1", Family: 4},
+							},
+						},
+					},
+					UserData: strPtr("#cloud-config\npackage_update: true\n"),
+					Interfaces: []tinkerbell.Interface{
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"}},
+					},
 				},
 			},
-			UserData: strPtr("#cloud-config\npackage_update: true\n"),
+			validate: func(t *testing.T, instance interface{}) {
+				t.Helper()
+				i := instance.(map[string]interface{})
+				assert.Equal(t, "server-001", i["InstanceID"])
+				assert.Equal(t, "server001.example.com", i["LocalHostname"])
+				assert.Equal(t, "#cloud-config\npackage_update: true\n", i["Userdata"])
+				assert.NotNil(t, i["NetworkConfig"])
+			},
+		},
+		{
+			name: "minimal hardware resource",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{},
+			},
+			validate: func(t *testing.T, instance interface{}) {
+				t.Helper()
+				i := instance.(map[string]interface{})
+				assert.Equal(t, "", i["InstanceID"])
+				assert.Equal(t, "", i["LocalHostname"])
+				assert.Equal(t, "", i["Userdata"])
+				assert.NotNil(t, i["NetworkConfig"])
+			},
 		},
 	}
 
-	result := toNoCloudInstance(hw)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Backend{}
+			result := b.toNoCloudInstance(tt.hw)
 
-	assert.Equal(t, "server-001", result.Metadata.InstanceID)
-	assert.Equal(t, "server001.example.com", result.Metadata.LocalHostname)
-	assert.Equal(t, "#cloud-config\npackage_update: true\n", result.Userdata)
-	assert.NotNil(t, result.NetworkConfig)
+			// Convert to map for validation
+			resultMap := map[string]interface{}{
+				"InstanceID":    result.Metadata.InstanceID,
+				"LocalHostname": result.Metadata.LocalHostname,
+				"Userdata":      result.Userdata,
+				"NetworkConfig": result.NetworkConfig,
+			}
+			tt.validate(t, resultMap)
+		})
+	}
 }
+
+
+func TestGetNameServers(t *testing.T) {
+	tests := []struct {
+		name         string
+		hw           tinkerbell.Hardware
+		expectedIPv4 []string
+		expectedIPv6 []string
+	}{
+		{
+			name: "both IPv4 and IPv6 nameservers",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Interfaces: []tinkerbell.Interface{
+						{
+							DHCP: &tinkerbell.DHCP{
+								MAC: "aa:bb:cc:dd:ee:01",
+								NameServers: []string{
+									"8.8.8.8",
+									"8.8.4.4",
+									"2001:4860:4860::8888",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIPv4: []string{"8.8.8.8", "8.8.4.4"},
+			expectedIPv6: []string{"2001:4860:4860::8888"},
+		},
+		{
+			name: "only IPv4 nameservers",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Interfaces: []tinkerbell.Interface{
+						{
+							DHCP: &tinkerbell.DHCP{
+								MAC:         "aa:bb:cc:dd:ee:01",
+								NameServers: []string{"1.1.1.1", "1.0.0.1"},
+							},
+						},
+					},
+				},
+			},
+			expectedIPv4: []string{"1.1.1.1", "1.0.0.1"},
+			expectedIPv6: nil,
+		},
+		{
+			name: "no nameservers",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Interfaces: []tinkerbell.Interface{
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"}},
+					},
+				},
+			},
+			expectedIPv4: nil,
+			expectedIPv6: nil,
+		},
+		{
+			name: "no interfaces",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{},
+			},
+			expectedIPv4: nil,
+			expectedIPv6: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipv4, ipv6 := getNameServers(tt.hw)
+			assert.Equal(t, tt.expectedIPv4, ipv4)
+			assert.Equal(t, tt.expectedIPv6, ipv6)
+		})
+	}
+}
+
+
 
 func strPtr(s string) *string {
 	return &s

--- a/pkg/backend/kube/tootles_test.go
+++ b/pkg/backend/kube/tootles_test.go
@@ -62,9 +62,9 @@ func TestGenerateBondParameters(t *testing.T) {
 			name: "mode 2 - balance-xor",
 			mode: 2,
 			expected: map[string]interface{}{
-				"bond-mode":              "balance-xor",
-				"bond-miimon":            100,
-				"bond-xmit_hash_policy":  "layer2",
+				"bond-mode":             "balance-xor",
+				"bond-miimon":           100,
+				"bond-xmit_hash_policy": "layer2",
 			},
 		},
 		{
@@ -99,8 +99,8 @@ func TestGenerateBondParameters(t *testing.T) {
 			name: "mode 6 - balance-alb",
 			mode: 6,
 			expected: map[string]interface{}{
-				"bond-mode":            "balance-alb",
-				"bond-miimon":          100,
+				"bond-mode":             "balance-alb",
+				"bond-miimon":           100,
 				"bond-rlb_update_delay": 0,
 			},
 		},
@@ -233,8 +233,8 @@ func TestGenerateSubnetsFromIPs(t *testing.T) {
 			},
 		},
 		{
-			name:     "No IPs - fallback to DHCP",
-			ips:      []*tinkerbell.MetadataInstanceIP{},
+			name: "No IPs - fallback to DHCP",
+			ips:  []*tinkerbell.MetadataInstanceIP{},
 			expected: []interface{}{
 				map[string]interface{}{"type": "dhcp"},
 				map[string]interface{}{"type": "dhcp6"},

--- a/pkg/backend/kube/tootles_test.go
+++ b/pkg/backend/kube/tootles_test.go
@@ -274,13 +274,13 @@ func TestGenerateBondingConfigurationV2(t *testing.T) {
 				assert.Equal(t, false, iface1["dhcp4"])
 				match := iface1["match"].(map[string]interface{})
 				assert.Equal(t, "aa:bb:cc:dd:ee:01", match["macaddress"])
-				_, hasSetName := iface1["set-name"]
-				assert.False(t, hasSetName, "set-name should not be present")
+				assert.Equal(t, "bond0phy0", iface1["set-name"])
 
 				iface2 := ethernets["bond0phy1"].(map[string]interface{})
 				assert.Equal(t, false, iface2["dhcp4"])
 				match2 := iface2["match"].(map[string]interface{})
 				assert.Equal(t, "aa:bb:cc:dd:ee:02", match2["macaddress"])
+				assert.Equal(t, "bond0phy1", iface2["set-name"])
 			},
 			validateBonds: func(t *testing.T, bonds map[string]interface{}) {
 				t.Helper()

--- a/pkg/backend/kube/tootles_test.go
+++ b/pkg/backend/kube/tootles_test.go
@@ -398,6 +398,7 @@ func TestGenerateNetworkConfig(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, result interface{}) {
+				t.Helper()
 				config := result.(map[string]interface{})
 				assert.Equal(t, 1, config["version"])
 				configSlice := config["config"].([]interface{})
@@ -422,6 +423,7 @@ func TestGenerateNetworkConfig(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, result interface{}) {
+				t.Helper()
 				config := result.(map[string]interface{})
 				assert.Equal(t, 1, config["version"])
 				configSlice := config["config"].([]interface{})
@@ -434,6 +436,7 @@ func TestGenerateNetworkConfig(t *testing.T) {
 				Spec: tinkerbell.HardwareSpec{},
 			},
 			validate: func(t *testing.T, result interface{}) {
+				t.Helper()
 				config := result.(map[string]interface{})
 				assert.Equal(t, 1, config["version"])
 				configSlice := config["config"].([]interface{})

--- a/pkg/backend/kube/tootles_test.go
+++ b/pkg/backend/kube/tootles_test.go
@@ -1,0 +1,478 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
+)
+
+func TestCidrFromNetmask(t *testing.T) {
+	tests := []struct {
+		name     string
+		netmask  string
+		expected string
+	}{
+		{"Class C", "255.255.255.0", "24"},
+		{"Class B", "255.255.0.0", "16"},
+		{"Class A", "255.0.0.0", "8"},
+		{"/26", "255.255.255.192", "26"},
+		{"/27", "255.255.255.224", "27"},
+		{"/28", "255.255.255.240", "28"},
+		{"/29", "255.255.255.248", "29"},
+		{"/30", "255.255.255.252", "30"},
+		{"Unknown defaults to /24", "255.255.128.0", "24"},
+		{"Empty defaults to /24", "", "24"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cidrFromNetmask(tt.netmask)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateBondParameters(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     int64
+		expected map[string]interface{}
+	}{
+		{
+			name: "mode 0 - balance-rr",
+			mode: 0,
+			expected: map[string]interface{}{
+				"bond-mode":        "balance-rr",
+				"bond-miimon":      100,
+				"bond-use_carrier": 1,
+			},
+		},
+		{
+			name: "mode 1 - active-backup",
+			mode: 1,
+			expected: map[string]interface{}{
+				"bond-mode":             "active-backup",
+				"bond-miimon":           100,
+				"bond-primary_reselect": "always",
+				"bond-fail_over_mac":    "none",
+			},
+		},
+		{
+			name: "mode 2 - balance-xor",
+			mode: 2,
+			expected: map[string]interface{}{
+				"bond-mode":              "balance-xor",
+				"bond-miimon":            100,
+				"bond-xmit_hash_policy":  "layer2",
+			},
+		},
+		{
+			name: "mode 3 - broadcast",
+			mode: 3,
+			expected: map[string]interface{}{
+				"bond-mode":   "broadcast",
+				"bond-miimon": 100,
+			},
+		},
+		{
+			name: "mode 4 - 802.3ad",
+			mode: 4,
+			expected: map[string]interface{}{
+				"bond-mode":             "802.3ad",
+				"bond-miimon":           100,
+				"bond-lacp_rate":        "fast",
+				"bond-xmit_hash_policy": "layer3+4",
+				"bond-ad_select":        "stable",
+			},
+		},
+		{
+			name: "mode 5 - balance-tlb",
+			mode: 5,
+			expected: map[string]interface{}{
+				"bond-mode":           "balance-tlb",
+				"bond-miimon":         100,
+				"bond-tlb_dynamic_lb": 1,
+			},
+		},
+		{
+			name: "mode 6 - balance-alb",
+			mode: 6,
+			expected: map[string]interface{}{
+				"bond-mode":            "balance-alb",
+				"bond-miimon":          100,
+				"bond-rlb_update_delay": 0,
+			},
+		},
+		{
+			name: "unknown mode defaults to active-backup",
+			mode: 99,
+			expected: map[string]interface{}{
+				"bond-mode":             "active-backup",
+				"bond-miimon":           100,
+				"bond-primary_reselect": "always",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateBondParameters(tt.mode)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateSubnetsFromIPs(t *testing.T) {
+	ipv4DNS := []string{"8.8.8.8", "8.8.4.4"}
+	ipv6DNS := []string{"2001:4860:4860::8888"}
+
+	tests := []struct {
+		name     string
+		ips      []*tinkerbell.MetadataInstanceIP
+		expected []interface{}
+	}{
+		{
+			name: "IPv4 with gateway",
+			ips: []*tinkerbell.MetadataInstanceIP{
+				{
+					Address: "192.168.1.10",
+					Netmask: "255.255.255.0",
+					Gateway: "192.168.1.1",
+					Family:  4,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"type":            "static",
+					"address":         "192.168.1.10/24",
+					"gateway":         "192.168.1.1",
+					"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
+				},
+			},
+		},
+		{
+			name: "IPv4 without gateway",
+			ips: []*tinkerbell.MetadataInstanceIP{
+				{
+					Address: "192.168.1.10",
+					Netmask: "255.255.255.240",
+					Family:  4,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"type":            "static",
+					"address":         "192.168.1.10/28",
+					"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
+				},
+			},
+		},
+		{
+			name: "IPv6 with gateway",
+			ips: []*tinkerbell.MetadataInstanceIP{
+				{
+					Address: "2001:db8::10/64",
+					Gateway: "2001:db8::1",
+					Family:  6,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"type":            "static6",
+					"address":         "2001:db8::10/64",
+					"gateway":         "2001:db8::1",
+					"dns_nameservers": []string{"2001:4860:4860::8888"},
+				},
+			},
+		},
+		{
+			name: "IPv6 without gateway",
+			ips: []*tinkerbell.MetadataInstanceIP{
+				{
+					Address: "2001:db8::10/64",
+					Family:  6,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"type":            "static6",
+					"address":         "2001:db8::10/64",
+					"dns_nameservers": []string{"2001:4860:4860::8888"},
+				},
+			},
+		},
+		{
+			name: "Dual stack",
+			ips: []*tinkerbell.MetadataInstanceIP{
+				{
+					Address: "192.168.1.10",
+					Netmask: "255.255.255.0",
+					Gateway: "192.168.1.1",
+					Family:  4,
+				},
+				{
+					Address: "2001:db8::10/64",
+					Gateway: "2001:db8::1",
+					Family:  6,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"type":            "static",
+					"address":         "192.168.1.10/24",
+					"gateway":         "192.168.1.1",
+					"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
+				},
+				map[string]interface{}{
+					"type":            "static6",
+					"address":         "2001:db8::10/64",
+					"gateway":         "2001:db8::1",
+					"dns_nameservers": []string{"2001:4860:4860::8888"},
+				},
+			},
+		},
+		{
+			name:     "No IPs - fallback to DHCP",
+			ips:      []*tinkerbell.MetadataInstanceIP{},
+			expected: []interface{}{
+				map[string]interface{}{"type": "dhcp"},
+				map[string]interface{}{"type": "dhcp6"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateSubnetsFromIPs(tt.ips, ipv4DNS, ipv6DNS)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateBondingConfiguration(t *testing.T) {
+	tests := []struct {
+		name     string
+		hw       tinkerbell.Hardware
+		expected []interface{}
+	}{
+		{
+			name: "802.3ad bond with 2 interfaces",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Metadata: &tinkerbell.HardwareMetadata{
+						BondingMode: 4,
+						Instance: &tinkerbell.MetadataInstance{
+							Ips: []*tinkerbell.MetadataInstanceIP{
+								{
+									Address: "192.168.1.10",
+									Netmask: "255.255.255.0",
+									Gateway: "192.168.1.1",
+									Family:  4,
+								},
+							},
+						},
+					},
+					Interfaces: []tinkerbell.Interface{
+						{
+							DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"},
+						},
+						{
+							DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:02"},
+						},
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"type":        "physical",
+					"name":        "eno1",
+					"mac_address": "aa:bb:cc:dd:ee:01",
+					"mtu":         1500,
+				},
+				map[string]interface{}{
+					"type":        "physical",
+					"name":        "eno2",
+					"mac_address": "aa:bb:cc:dd:ee:02",
+					"mtu":         1500,
+				},
+				map[string]interface{}{
+					"type":            "bond",
+					"name":            "bond0",
+					"bond_interfaces": []string{"eno1", "eno2"},
+					"mtu":             1500,
+					"params": map[string]interface{}{
+						"bond-mode":             "802.3ad",
+						"bond-miimon":           100,
+						"bond-lacp_rate":        "fast",
+						"bond-xmit_hash_policy": "layer3+4",
+						"bond-ad_select":        "stable",
+					},
+					"subnets": []interface{}{
+						map[string]interface{}{
+							"type":            "static",
+							"address":         "192.168.1.10/24",
+							"gateway":         "192.168.1.1",
+							"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "bond with no IPs - fallback to DHCP",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Metadata: &tinkerbell.HardwareMetadata{
+						BondingMode: 1,
+					},
+					Interfaces: []tinkerbell.Interface{
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"}},
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:02"}},
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"type":        "physical",
+					"name":        "eno1",
+					"mac_address": "aa:bb:cc:dd:ee:01",
+					"mtu":         1500,
+				},
+				map[string]interface{}{
+					"type":        "physical",
+					"name":        "eno2",
+					"mac_address": "aa:bb:cc:dd:ee:02",
+					"mtu":         1500,
+				},
+				map[string]interface{}{
+					"type":            "bond",
+					"name":            "bond0",
+					"bond_interfaces": []string{"eno1", "eno2"},
+					"mtu":             1500,
+					"params": map[string]interface{}{
+						"bond-mode":             "active-backup",
+						"bond-miimon":           100,
+						"bond-primary_reselect": "always",
+						"bond-fail_over_mac":    "none",
+					},
+					"subnets": []interface{}{
+						map[string]interface{}{"type": "dhcp"},
+						map[string]interface{}{"type": "dhcp6"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateBondingConfiguration(tt.hw)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateNetworkConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		hw       tinkerbell.Hardware
+		validate func(t *testing.T, result interface{})
+	}{
+		{
+			name: "bonding enabled with 2+ interfaces",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Metadata: &tinkerbell.HardwareMetadata{
+						BondingMode: 4,
+						Instance: &tinkerbell.MetadataInstance{
+							Ips: []*tinkerbell.MetadataInstanceIP{
+								{Address: "192.168.1.10", Netmask: "255.255.255.0", Gateway: "192.168.1.1", Family: 4},
+							},
+						},
+					},
+					Interfaces: []tinkerbell.Interface{
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"}},
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:02"}},
+					},
+				},
+			},
+			validate: func(t *testing.T, result interface{}) {
+				config := result.(map[string]interface{})
+				assert.Equal(t, 1, config["version"])
+				configSlice := config["config"].([]interface{})
+				assert.Len(t, configSlice, 3) // 2 physical + 1 bond
+			},
+		},
+		{
+			name: "bonding disabled - single interface",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{
+					Metadata: &tinkerbell.HardwareMetadata{
+						BondingMode: 0,
+						Instance: &tinkerbell.MetadataInstance{
+							Ips: []*tinkerbell.MetadataInstanceIP{
+								{Address: "192.168.1.10", Netmask: "255.255.255.0", Gateway: "192.168.1.1", Family: 4},
+							},
+						},
+					},
+					Interfaces: []tinkerbell.Interface{
+						{DHCP: &tinkerbell.DHCP{MAC: "aa:bb:cc:dd:ee:01"}},
+					},
+				},
+			},
+			validate: func(t *testing.T, result interface{}) {
+				config := result.(map[string]interface{})
+				assert.Equal(t, 1, config["version"])
+				configSlice := config["config"].([]interface{})
+				assert.Len(t, configSlice, 1) // single physical interface
+			},
+		},
+		{
+			name: "no interfaces - fallback DHCP",
+			hw: tinkerbell.Hardware{
+				Spec: tinkerbell.HardwareSpec{},
+			},
+			validate: func(t *testing.T, result interface{}) {
+				config := result.(map[string]interface{})
+				assert.Equal(t, 1, config["version"])
+				configSlice := config["config"].([]interface{})
+				assert.Len(t, configSlice, 1)
+				item := configSlice[0].(map[string]interface{})
+				assert.Equal(t, "physical", item["type"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateNetworkConfig(tt.hw)
+			tt.validate(t, result)
+		})
+	}
+}
+
+func TestToNoCloudInstance(t *testing.T) {
+	hw := tinkerbell.Hardware{
+		Spec: tinkerbell.HardwareSpec{
+			Metadata: &tinkerbell.HardwareMetadata{
+				Instance: &tinkerbell.MetadataInstance{
+					ID:       "server-001",
+					Hostname: "server001.example.com",
+				},
+			},
+			UserData: strPtr("#cloud-config\npackage_update: true\n"),
+		},
+	}
+
+	result := toNoCloudInstance(hw)
+
+	assert.Equal(t, "server-001", result.Metadata.InstanceID)
+	assert.Equal(t, "server001.example.com", result.Metadata.LocalHostname)
+	assert.Equal(t, "#cloud-config\npackage_update: true\n", result.Userdata)
+	assert.NotNil(t, result.NetworkConfig)
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/pkg/backend/kube/tootles_test.go
+++ b/pkg/backend/kube/tootles_test.go
@@ -486,7 +486,6 @@ func TestToNoCloudInstance(t *testing.T) {
 	}
 }
 
-
 func TestGetNameServers(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -562,8 +561,6 @@ func TestGetNameServers(t *testing.T) {
 		})
 	}
 }
-
-
 
 func strPtr(s string) *string {
 	return &s

--- a/pkg/backend/kube/tootles_test.go
+++ b/pkg/backend/kube/tootles_test.go
@@ -8,40 +8,6 @@ import (
 	"github.com/tinkerbell/tinkerbell/pkg/data"
 )
 
-func TestCidrFromNetmask(t *testing.T) {
-	tests := []struct {
-		name     string
-		netmask  string
-		expected string
-	}{
-		{"Class C", "255.255.255.0", "24"},
-		{"Class B", "255.255.0.0", "16"},
-		{"Class A", "255.0.0.0", "8"},
-		{"/26", "255.255.255.192", "26"},
-		{"/27", "255.255.255.224", "27"},
-		{"/28", "255.255.255.240", "28"},
-		{"/29", "255.255.255.248", "29"},
-		{"/30", "255.255.255.252", "30"},
-		{"/31", "255.255.255.254", "31"},
-		{"/32", "255.255.255.255", "32"},
-		{"/17", "255.255.128.0", "17"},
-		{"/25", "255.255.255.128", "25"},
-		{"Empty returns empty", "", ""},
-		{"Invalid format returns empty", "255.255", ""},
-		{"Invalid characters return empty", "255.255.abc.0", ""},
-		{"Out of range returns empty", "255.255.256.0", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := cidrFromNetmask(tt.netmask)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-// V2 Tests
-
 func TestGenerateBondParametersV2(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/backend/noop/noop.go
+++ b/pkg/backend/noop/noop.go
@@ -29,3 +29,8 @@ func (n Backend) GetHackInstance(context.Context, string) (data.HackInstance, er
 func (n Backend) GetEC2Instance(context.Context, string) (data.Ec2Instance, error) {
 	return data.Ec2Instance{}, errAlways
 }
+
+// GetNoCloudInstance exists to satisfy the nocloud.Client interface. It is not implemented.
+func (n Backend) GetNoCloudInstance(context.Context, string) (data.NoCloudInstance, error) {
+	return data.NoCloudInstance{}, errAlways
+}

--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -47,7 +47,124 @@ type LicenseActivation struct {
 type NoCloudInstance struct {
 	Userdata      string
 	Metadata      Metadata
-	NetworkConfig interface{} // YAML network configuration data
+	NetworkConfig interface{} // Network Config data (typically NetworkConfigV2)
+	// Note: Uses interface{} for flexibility in YAML marshaling. The actual structure
+	// follows the NetworkConfigV2 format defined below.
+}
+
+// NetworkConfigV2 represents a Network Config Version 2 configuration.
+// Based on https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v2.html
+type NetworkConfigV2 struct {
+	Network NetworkSpec `json:"network" yaml:"network"`
+}
+
+// NetworkSpec contains the network configuration specification.
+type NetworkSpec struct {
+	Version   int                       `json:"version" yaml:"version"`
+	Ethernets map[string]EthernetConfig `json:"ethernets,omitempty" yaml:"ethernets,omitempty"`
+	Bonds     map[string]BondConfig     `json:"bonds,omitempty" yaml:"bonds,omitempty"`
+	Bridges   map[string]BridgeConfig   `json:"bridges,omitempty" yaml:"bridges,omitempty"`
+	Vlans     map[string]VlanConfig     `json:"vlans,omitempty" yaml:"vlans,omitempty"`
+	Renderer  string                    `json:"renderer,omitempty" yaml:"renderer,omitempty"`
+}
+
+// EthernetConfig represents an ethernet device configuration.
+type EthernetConfig struct {
+	Match       *MatchConfig       `json:"match,omitempty" yaml:"match,omitempty"`
+	SetName     string             `json:"set-name,omitempty" yaml:"set-name,omitempty"`
+	Dhcp4       bool               `json:"dhcp4,omitempty" yaml:"dhcp4,omitempty"`
+	Dhcp6       bool               `json:"dhcp6,omitempty" yaml:"dhcp6,omitempty"`
+	Addresses   []string           `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	Gateway4    string             `json:"gateway4,omitempty" yaml:"gateway4,omitempty"`
+	Gateway6    string             `json:"gateway6,omitempty" yaml:"gateway6,omitempty"`
+	Nameservers *NameserversConfig `json:"nameservers,omitempty" yaml:"nameservers,omitempty"`
+	Routes      []RouteConfig      `json:"routes,omitempty" yaml:"routes,omitempty"`
+	MTU         int                `json:"mtu,omitempty" yaml:"mtu,omitempty"`
+}
+
+// BondConfig represents a bond device configuration.
+type BondConfig struct {
+	Interfaces  []string           `json:"interfaces" yaml:"interfaces"`
+	Parameters  BondParameters     `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Dhcp4       bool               `json:"dhcp4,omitempty" yaml:"dhcp4,omitempty"`
+	Dhcp6       bool               `json:"dhcp6,omitempty" yaml:"dhcp6,omitempty"`
+	Addresses   []string           `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	Gateway4    string             `json:"gateway4,omitempty" yaml:"gateway4,omitempty"`
+	Gateway6    string             `json:"gateway6,omitempty" yaml:"gateway6,omitempty"`
+	Nameservers *NameserversConfig `json:"nameservers,omitempty" yaml:"nameservers,omitempty"`
+	Routes      []RouteConfig      `json:"routes,omitempty" yaml:"routes,omitempty"`
+	MTU         int                `json:"mtu,omitempty" yaml:"mtu,omitempty"`
+}
+
+// BridgeConfig represents a bridge device configuration.
+type BridgeConfig struct {
+	Interfaces  []string           `json:"interfaces" yaml:"interfaces"`
+	Parameters  BridgeParameters   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Dhcp4       bool               `json:"dhcp4,omitempty" yaml:"dhcp4,omitempty"`
+	Dhcp6       bool               `json:"dhcp6,omitempty" yaml:"dhcp6,omitempty"`
+	Addresses   []string           `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	Gateway4    string             `json:"gateway4,omitempty" yaml:"gateway4,omitempty"`
+	Gateway6    string             `json:"gateway6,omitempty" yaml:"gateway6,omitempty"`
+	Nameservers *NameserversConfig `json:"nameservers,omitempty" yaml:"nameservers,omitempty"`
+	Routes      []RouteConfig      `json:"routes,omitempty" yaml:"routes,omitempty"`
+}
+
+// VlanConfig represents a VLAN device configuration.
+type VlanConfig struct {
+	ID          int                `json:"id" yaml:"id"`
+	Link        string             `json:"link" yaml:"link"`
+	Dhcp4       bool               `json:"dhcp4,omitempty" yaml:"dhcp4,omitempty"`
+	Dhcp6       bool               `json:"dhcp6,omitempty" yaml:"dhcp6,omitempty"`
+	Addresses   []string           `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	Gateway4    string             `json:"gateway4,omitempty" yaml:"gateway4,omitempty"`
+	Gateway6    string             `json:"gateway6,omitempty" yaml:"gateway6,omitempty"`
+	Nameservers *NameserversConfig `json:"nameservers,omitempty" yaml:"nameservers,omitempty"`
+	Routes      []RouteConfig      `json:"routes,omitempty" yaml:"routes,omitempty"`
+}
+
+// MatchConfig specifies how to match a device.
+type MatchConfig struct {
+	MACAddress string `json:"macaddress,omitempty" yaml:"macaddress,omitempty"`
+	Driver     string `json:"driver,omitempty" yaml:"driver,omitempty"`
+	Name       string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+// BondParameters contains bonding-specific parameters.
+type BondParameters struct {
+	Mode                   string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	MIIMonitorInterval     int    `json:"mii-monitor-interval,omitempty" yaml:"mii-monitor-interval,omitempty"`
+	LACPRate               string `json:"lacp-rate,omitempty" yaml:"lacp-rate,omitempty"`
+	TransmitHashPolicy     string `json:"transmit-hash-policy,omitempty" yaml:"transmit-hash-policy,omitempty"`
+	ADSelect               string `json:"ad-select,omitempty" yaml:"ad-select,omitempty"`
+	PrimaryReselectPolicy  string `json:"primary-reselect-policy,omitempty" yaml:"primary-reselect-policy,omitempty"`
+	FailOverMACPolicy      string `json:"fail-over-mac-policy,omitempty" yaml:"fail-over-mac-policy,omitempty"`
+	Primary                string `json:"primary,omitempty" yaml:"primary,omitempty"`
+	GratuitousARP          int    `json:"gratuitious-arp,omitempty" yaml:"gratuitious-arp,omitempty"`
+	PacketsPerSlave        int    `json:"packets-per-slave,omitempty" yaml:"packets-per-slave,omitempty"`
+}
+
+// BridgeParameters contains bridge-specific parameters.
+type BridgeParameters struct {
+	AgeingTime     int    `json:"ageing-time,omitempty" yaml:"ageing-time,omitempty"`
+	ForwardDelay   int    `json:"forward-delay,omitempty" yaml:"forward-delay,omitempty"`
+	HelloTime      int    `json:"hello-time,omitempty" yaml:"hello-time,omitempty"`
+	MaxAge         int    `json:"max-age,omitempty" yaml:"max-age,omitempty"`
+	Priority       int    `json:"priority,omitempty" yaml:"priority,omitempty"`
+	STP            bool   `json:"stp,omitempty" yaml:"stp,omitempty"`
+}
+
+// NameserversConfig specifies DNS nameservers and search domains.
+type NameserversConfig struct {
+	Addresses []string `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	Search    []string `json:"search,omitempty" yaml:"search,omitempty"`
+}
+
+// RouteConfig represents a routing table entry.
+type RouteConfig struct {
+	To     string `json:"to,omitempty" yaml:"to,omitempty"`
+	Via    string `json:"via,omitempty" yaml:"via,omitempty"`
+	Metric int    `json:"metric,omitempty" yaml:"metric,omitempty"`
+	Table  int    `json:"table,omitempty" yaml:"table,omitempty"`
 }
 
 // Instance is a representation of the instance metadata. Its based on the rooitio hub action

--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -139,7 +139,7 @@ type BondParameters struct {
 	PrimaryReselectPolicy string `json:"primary-reselect-policy,omitempty" yaml:"primary-reselect-policy,omitempty"`
 	FailOverMACPolicy     string `json:"fail-over-mac-policy,omitempty" yaml:"fail-over-mac-policy,omitempty"`
 	Primary               string `json:"primary,omitempty" yaml:"primary,omitempty"`
-	GratuitousARP         int    `json:"gratuitious-arp,omitempty" yaml:"gratuitious-arp,omitempty"`
+	GratuitousARP         int    `json:"gratuitous-arp,omitempty" yaml:"gratuitous-arp,omitempty"`
 	PacketsPerSlave       int    `json:"packets-per-slave,omitempty" yaml:"packets-per-slave,omitempty"`
 }
 

--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -42,6 +42,14 @@ type LicenseActivation struct {
 	State string
 }
 
+// NoCloudInstance is a struct that contains the hardware data exposed from the NoCloud API endpoints.
+// It supports network bonding and IPv6 configuration for bare metal servers.
+type NoCloudInstance struct {
+	Userdata      string
+	Metadata      Metadata
+	NetworkConfig interface{} // YAML network configuration data
+}
+
 // Instance is a representation of the instance metadata. Its based on the rooitio hub action
 // and should have just enough information for it to work.
 type HackInstance struct {

--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -47,19 +47,17 @@ type LicenseActivation struct {
 type NoCloudInstance struct {
 	Userdata      string
 	Metadata      Metadata
-	NetworkConfig interface{} // Network Config data (typically NetworkConfigV2)
-	// Note: Uses interface{} for flexibility in YAML marshaling. The actual structure
-	// follows the NetworkConfigV2 format defined below.
+	NetworkConfig *NetworkConfig // Network Config data (NetworkConfig format)
 }
 
-// NetworkConfigV2 represents a Network Config Version 2 configuration.
+// NetworkConfig represents a Network Config Version 2 configuration.
 // Based on https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v2.html
-type NetworkConfigV2 struct {
-	Network NetworkSpec `json:"network" yaml:"network"`
+type NetworkConfig struct {
+	Network NetworkSpecV2 `json:"network" yaml:"network"`
 }
 
-// NetworkSpec contains the network configuration specification.
-type NetworkSpec struct {
+// NetworkSpecV2 contains the network configuration specification.
+type NetworkSpecV2 struct {
 	Version   int                       `json:"version" yaml:"version"`
 	Ethernets map[string]EthernetConfig `json:"ethernets,omitempty" yaml:"ethernets,omitempty"`
 	Bonds     map[string]BondConfig     `json:"bonds,omitempty" yaml:"bonds,omitempty"`

--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -131,26 +131,26 @@ type MatchConfig struct {
 
 // BondParameters contains bonding-specific parameters.
 type BondParameters struct {
-	Mode                   string `json:"mode,omitempty" yaml:"mode,omitempty"`
-	MIIMonitorInterval     int    `json:"mii-monitor-interval,omitempty" yaml:"mii-monitor-interval,omitempty"`
-	LACPRate               string `json:"lacp-rate,omitempty" yaml:"lacp-rate,omitempty"`
-	TransmitHashPolicy     string `json:"transmit-hash-policy,omitempty" yaml:"transmit-hash-policy,omitempty"`
-	ADSelect               string `json:"ad-select,omitempty" yaml:"ad-select,omitempty"`
-	PrimaryReselectPolicy  string `json:"primary-reselect-policy,omitempty" yaml:"primary-reselect-policy,omitempty"`
-	FailOverMACPolicy      string `json:"fail-over-mac-policy,omitempty" yaml:"fail-over-mac-policy,omitempty"`
-	Primary                string `json:"primary,omitempty" yaml:"primary,omitempty"`
-	GratuitousARP          int    `json:"gratuitious-arp,omitempty" yaml:"gratuitious-arp,omitempty"`
-	PacketsPerSlave        int    `json:"packets-per-slave,omitempty" yaml:"packets-per-slave,omitempty"`
+	Mode                  string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	MIIMonitorInterval    int    `json:"mii-monitor-interval,omitempty" yaml:"mii-monitor-interval,omitempty"`
+	LACPRate              string `json:"lacp-rate,omitempty" yaml:"lacp-rate,omitempty"`
+	TransmitHashPolicy    string `json:"transmit-hash-policy,omitempty" yaml:"transmit-hash-policy,omitempty"`
+	ADSelect              string `json:"ad-select,omitempty" yaml:"ad-select,omitempty"`
+	PrimaryReselectPolicy string `json:"primary-reselect-policy,omitempty" yaml:"primary-reselect-policy,omitempty"`
+	FailOverMACPolicy     string `json:"fail-over-mac-policy,omitempty" yaml:"fail-over-mac-policy,omitempty"`
+	Primary               string `json:"primary,omitempty" yaml:"primary,omitempty"`
+	GratuitousARP         int    `json:"gratuitious-arp,omitempty" yaml:"gratuitious-arp,omitempty"`
+	PacketsPerSlave       int    `json:"packets-per-slave,omitempty" yaml:"packets-per-slave,omitempty"`
 }
 
 // BridgeParameters contains bridge-specific parameters.
 type BridgeParameters struct {
-	AgeingTime     int    `json:"ageing-time,omitempty" yaml:"ageing-time,omitempty"`
-	ForwardDelay   int    `json:"forward-delay,omitempty" yaml:"forward-delay,omitempty"`
-	HelloTime      int    `json:"hello-time,omitempty" yaml:"hello-time,omitempty"`
-	MaxAge         int    `json:"max-age,omitempty" yaml:"max-age,omitempty"`
-	Priority       int    `json:"priority,omitempty" yaml:"priority,omitempty"`
-	STP            bool   `json:"stp,omitempty" yaml:"stp,omitempty"`
+	AgeingTime   int  `json:"ageing-time,omitempty" yaml:"ageing-time,omitempty"`
+	ForwardDelay int  `json:"forward-delay,omitempty" yaml:"forward-delay,omitempty"`
+	HelloTime    int  `json:"hello-time,omitempty" yaml:"hello-time,omitempty"`
+	MaxAge       int  `json:"max-age,omitempty" yaml:"max-age,omitempty"`
+	Priority     int  `json:"priority,omitempty" yaml:"priority,omitempty"`
+	STP          bool `json:"stp,omitempty" yaml:"stp,omitempty"`
 }
 
 // NameserversConfig specifies DNS nameservers and search domains.

--- a/tootles/internal/frontend/nocloud/example_test.go
+++ b/tootles/internal/frontend/nocloud/example_test.go
@@ -25,43 +25,40 @@ func NewExampleClient() *ExampleClient {
 					InstanceID:    "server-001",
 					LocalHostname: "web01.example.com",
 				},
-				NetworkConfig: map[string]interface{}{
-					"version": 1,
-					"config": []interface{}{
-						map[string]interface{}{
-							"type":        "physical",
-							"name":        "eno1",
-							"mac_address": "1c:34:da:12:34:56",
-							"mtu":         1500,
-						},
-						map[string]interface{}{
-							"type":        "physical",
-							"name":        "eno2",
-							"mac_address": "1c:34:da:12:34:57",
-							"mtu":         1500,
-						},
-						map[string]interface{}{
-							"type":            "bond",
-							"name":            "bond0",
-							"bond_interfaces": []string{"eno1", "eno2"},
-							"params": map[string]interface{}{
-								"bond-mode":             "802.3ad",
-								"bond-miimon":           100,
-								"bond-lacp_rate":        "fast",
-								"bond-xmit_hash_policy": "layer3+4",
-							},
-							"subnets": []interface{}{
-								map[string]interface{}{
-									"type":            "static",
-									"address":         "192.168.1.10/24",
-									"gateway":         "192.168.1.1",
-									"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
+				NetworkConfig: &data.NetworkConfig{
+					Network: data.NetworkSpecV2{
+						Version: 2,
+						Ethernets: map[string]data.EthernetConfig{
+							"bond0phy0": {
+								Match: &data.MatchConfig{
+									MACAddress: "1c:34:da:12:34:56",
 								},
-								map[string]interface{}{
-									"type":            "static6",
-									"address":         "2001:db8::10/64",
-									"gateway":         "2001:db8::1",
-									"dns_nameservers": []string{"2001:4860:4860::8888"},
+								SetName: "bond0phy0",
+								Dhcp4:   false,
+							},
+							"bond0phy1": {
+								Match: &data.MatchConfig{
+									MACAddress: "1c:34:da:12:34:57",
+								},
+								SetName: "bond0phy1",
+								Dhcp4:   false,
+							},
+						},
+						Bonds: map[string]data.BondConfig{
+							"bond0": {
+								Interfaces: []string{"bond0phy0", "bond0phy1"},
+								Parameters: data.BondParameters{
+									Mode:               "802.3ad",
+									MIIMonitorInterval: 100,
+									LACPRate:           "fast",
+									TransmitHashPolicy: "layer3+4",
+									ADSelect:           "stable",
+								},
+								Addresses: []string{"192.168.1.10/24", "2001:db8::10/64"},
+								Gateway4:  "192.168.1.1",
+								Gateway6:  "2001:db8::1",
+								Nameservers: &data.NameserversConfig{
+									Addresses: []string{"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888"},
 								},
 							},
 						},

--- a/tootles/internal/frontend/nocloud/example_test.go
+++ b/tootles/internal/frontend/nocloud/example_test.go
@@ -1,0 +1,115 @@
+package nocloud_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tinkerbell/tinkerbell/pkg/data"
+	"github.com/tinkerbell/tinkerbell/tootles/internal/frontend/nocloud"
+)
+
+// ExampleClient demonstrates how to implement the nocloud.Client interface.
+type ExampleClient struct {
+	servers map[string]data.NoCloudInstance
+}
+
+func NewExampleClient() *ExampleClient {
+	return &ExampleClient{
+		servers: map[string]data.NoCloudInstance{
+			"192.168.1.10": {
+				Userdata: "#cloud-config\npackage_update: true\npackages:\n  - htop\n  - vim\n",
+				Metadata: data.Metadata{
+					InstanceID:    "server-001",
+					LocalHostname: "web01.example.com",
+				},
+				NetworkConfig: map[string]interface{}{
+					"version": 1,
+					"config": []interface{}{
+						map[string]interface{}{
+							"type":        "physical",
+							"name":        "eno1",
+							"mac_address": "1c:34:da:12:34:56",
+							"mtu":         1500,
+						},
+						map[string]interface{}{
+							"type":        "physical",
+							"name":        "eno2",
+							"mac_address": "1c:34:da:12:34:57",
+							"mtu":         1500,
+						},
+						map[string]interface{}{
+							"type":            "bond",
+							"name":            "bond0",
+							"bond_interfaces": []string{"eno1", "eno2"},
+							"params": map[string]interface{}{
+								"bond-mode":             "802.3ad",
+								"bond-miimon":           100,
+								"bond-lacp_rate":        "fast",
+								"bond-xmit_hash_policy": "layer3+4",
+							},
+							"subnets": []interface{}{
+								map[string]interface{}{
+									"type":            "static",
+									"address":         "192.168.1.10/24",
+									"gateway":         "192.168.1.1",
+									"dns_nameservers": []string{"8.8.8.8", "8.8.4.4"},
+								},
+								map[string]interface{}{
+									"type":            "static6",
+									"address":         "2001:db8::10/64",
+									"gateway":         "2001:db8::1",
+									"dns_nameservers": []string{"2001:4860:4860::8888"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *ExampleClient) GetNoCloudInstance(_ context.Context, ip string) (data.NoCloudInstance, error) {
+	if instance, exists := c.servers[ip]; exists {
+		return instance, nil
+	}
+	return data.NoCloudInstance{}, nocloud.ErrInstanceNotFound
+}
+
+func Example() {
+	// Create a client that can retrieve instance data
+	client := NewExampleClient()
+
+	// Create the NoCloud frontend
+	frontend := nocloud.New(client)
+
+	// Set up the router
+	router := gin.New()
+	frontend.Configure(router)
+
+	// The router now has the following endpoints configured:
+	// GET /meta-data        - Returns instance metadata in text/plain format
+	// GET /user-data        - Returns cloud-config user data in text/plain format
+	// GET /network-config   - Returns network configuration in text/yaml format
+
+	// Start the server (in a real application)
+	_ = &http.Server{
+		Addr:    ":8080",
+		Handler: router,
+	}
+
+	log.Println("NoCloud metadata API server starting on :8080")
+	log.Println("Endpoints available:")
+	log.Println("  GET /meta-data")
+	log.Println("  GET /user-data")
+	log.Println("  GET /network-config")
+
+	// In a real application you would call:
+	// server.ListenAndServe()
+
+	fmt.Println("NoCloud metadata API configured successfully")
+	// Output: NoCloud metadata API configured successfully
+}

--- a/tootles/internal/frontend/nocloud/example_test.go
+++ b/tootles/internal/frontend/nocloud/example_test.go
@@ -88,9 +88,10 @@ func Example() {
 	frontend.Configure(router)
 
 	// The router now has the following endpoints configured:
-	// GET /meta-data        - Returns instance metadata in text/plain format
-	// GET /user-data        - Returns cloud-config user data in text/plain format
-	// GET /network-config   - Returns network configuration in text/yaml format
+	// GET /nocloud/meta-data        - Returns instance metadata in text/plain format
+	// GET /nocloud/user-data        - Returns cloud-config user data in text/plain format
+	// GET /nocloud/vendor-data      - Returns vendor data in text/plain format (currently empty)
+	// GET /nocloud/network-config   - Returns network configuration in text/yaml format
 
 	// Start the server (in a real application)
 	_ = &http.Server{
@@ -100,9 +101,10 @@ func Example() {
 
 	log.Println("NoCloud metadata API server starting on :8080")
 	log.Println("Endpoints available:")
-	log.Println("  GET /meta-data")
-	log.Println("  GET /user-data")
-	log.Println("  GET /network-config")
+	log.Println("  GET /nocloud/meta-data")
+	log.Println("  GET /nocloud/user-data")
+	log.Println("  GET /nocloud/vendor-data")
+	log.Println("  GET /nocloud/network-config")
 
 	// In a real application you would call:
 	// server.ListenAndServe()

--- a/tootles/internal/frontend/nocloud/frontend.go
+++ b/tootles/internal/frontend/nocloud/frontend.go
@@ -1,0 +1,159 @@
+package nocloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tinkerbell/tinkerbell/pkg/data"
+	"github.com/tinkerbell/tinkerbell/tootles/internal/http/httperror"
+	"github.com/tinkerbell/tinkerbell/tootles/internal/http/request"
+	"gopkg.in/yaml.v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ErrInstanceNotFound indicates an instance could not be found for the given identifier.
+var ErrInstanceNotFound = errors.New("instance not found")
+
+// Client is a backend for retrieving NoCloud Instance data.
+type Client interface {
+	// GetNoCloudInstance retrieves an Instance associated with ip. If no Instance can be
+	// found, it should return ErrInstanceNotFound.
+	GetNoCloudInstance(_ context.Context, ip string) (data.NoCloudInstance, error)
+}
+
+// Frontend is a NoCloud HTTP API frontend. It is responsible for configuring routers with handlers
+// for the NoCloud metadata API.
+type Frontend struct {
+	client Client
+}
+
+// New creates a new Frontend.
+func New(client Client) Frontend {
+	return Frontend{
+		client: client,
+	}
+}
+
+// Configure configures router with the supported NoCloud metadata API endpoints.
+func (f Frontend) Configure(router gin.IRouter) {
+	// Configure NoCloud endpoints directly under the root path
+	router.GET("/meta-data", f.metaDataHandler)
+	router.GET("/user-data", f.userDataHandler)
+	router.GET("/network-config", f.networkConfigHandler)
+}
+
+// metaDataHandler handles the /meta-data endpoint.
+func (f Frontend) metaDataHandler(ctx *gin.Context) {
+	instance, err := f.getInstance(ctx, ctx.Request)
+	if err != nil {
+		var httpErr *httperror.E
+		if errors.As(err, &httpErr) {
+			_ = ctx.AbortWithError(httpErr.StatusCode, err)
+		} else {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	// Format metadata as YAML-like text output
+	output := fmt.Sprintf("instance-id: %s\nlocal-hostname: %s", instance.Metadata.InstanceID, instance.Metadata.LocalHostname)
+
+	ctx.Header("Content-Type", "text/plain")
+	ctx.String(http.StatusOK, output)
+}
+
+// userDataHandler handles the /user-data endpoint.
+func (f Frontend) userDataHandler(ctx *gin.Context) {
+	instance, err := f.getInstance(ctx, ctx.Request)
+	if err != nil {
+		var httpErr *httperror.E
+		if errors.As(err, &httpErr) {
+			_ = ctx.AbortWithError(httpErr.StatusCode, err)
+		} else {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	if instance.Userdata == "" {
+		_ = ctx.AbortWithError(http.StatusNotFound, errors.New("user-data not found"))
+		return
+	}
+
+	ctx.Header("Content-Type", "text/plain")
+	ctx.String(http.StatusOK, instance.Userdata)
+}
+
+// networkConfigHandler handles the /network-config endpoint.
+func (f Frontend) networkConfigHandler(ctx *gin.Context) {
+	instance, err := f.getInstance(ctx, ctx.Request)
+	if err != nil {
+		var httpErr *httperror.E
+		if errors.As(err, &httpErr) {
+			_ = ctx.AbortWithError(httpErr.StatusCode, err)
+		} else {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	if instance.NetworkConfig == nil {
+		// Return fallback DHCP configuration
+		fallbackConfig := map[string]interface{}{
+			"version": 1,
+			"config": []interface{}{
+				map[string]interface{}{
+					"type": "physical",
+					"name": "eno1",
+					"subnets": []interface{}{
+						map[string]interface{}{
+							"type": "dhcp",
+						},
+					},
+				},
+			},
+		}
+
+		yamlData, err := yaml.Marshal(fallbackConfig)
+		if err != nil {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to marshal fallback config: %w", err))
+			return
+		}
+
+		ctx.Header("Content-Type", "text/yaml")
+		ctx.String(http.StatusOK, string(yamlData))
+		return
+	}
+
+	yamlData, err := yaml.Marshal(instance.NetworkConfig)
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to marshal network config: %w", err))
+		return
+	}
+
+	ctx.Header("Content-Type", "text/yaml")
+	ctx.String(http.StatusOK, string(yamlData))
+}
+
+// getInstance is a framework agnostic method for retrieving Instance data based on a remote
+// address.
+func (f Frontend) getInstance(ctx context.Context, r *http.Request) (data.NoCloudInstance, error) {
+	ip, err := request.RemoteAddrIP(r)
+	if err != nil {
+		return data.NoCloudInstance{}, httperror.New(http.StatusBadRequest, "invalid remote addr")
+	}
+
+	instance, err := f.client.GetNoCloudInstance(ctx, ip)
+	if err != nil {
+		if errors.Is(err, ErrInstanceNotFound) || apierrors.IsNotFound(err) {
+			return data.NoCloudInstance{}, httperror.New(http.StatusNotFound, fmt.Sprintf("no hardware found for source ip: %s", ip))
+		}
+
+		return data.NoCloudInstance{}, httperror.Wrap(http.StatusInternalServerError, err)
+	}
+
+	return instance, nil
+}

--- a/tootles/internal/frontend/nocloud/frontend.go
+++ b/tootles/internal/frontend/nocloud/frontend.go
@@ -120,30 +120,9 @@ func (f Frontend) networkConfigHandler(ctx *gin.Context) {
 	}
 
 	if instance.NetworkConfig == nil {
-		// Return fallback DHCP configuration
-		fallbackConfig := map[string]interface{}{
-			"version": 1,
-			"config": []interface{}{
-				map[string]interface{}{
-					"type": "physical",
-					"name": "eno1",
-					"subnets": []interface{}{
-						map[string]interface{}{
-							"type": "dhcp",
-						},
-					},
-				},
-			},
-		}
-
-		yamlData, err := yaml.Marshal(fallbackConfig)
-		if err != nil {
-			_ = ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to marshal fallback config: %w", err))
-			return
-		}
-
+		// Return empty configuration
 		ctx.Header("Content-Type", "text/plain")
-		ctx.String(http.StatusOK, string(yamlData))
+		ctx.String(http.StatusOK, "")
 		return
 	}
 

--- a/tootles/internal/frontend/nocloud/frontend.go
+++ b/tootles/internal/frontend/nocloud/frontend.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tinkerbell/tinkerbell/pkg/data"
 	"github.com/tinkerbell/tinkerbell/tootles/internal/http/httperror"
 	"github.com/tinkerbell/tinkerbell/tootles/internal/http/request"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 

--- a/tootles/internal/frontend/nocloud/frontend.go
+++ b/tootles/internal/frontend/nocloud/frontend.go
@@ -42,6 +42,7 @@ func (f Frontend) Configure(router gin.IRouter) {
 	// Configure NoCloud endpoints directly under the root path
 	router.GET("/meta-data", f.metaDataHandler)
 	router.GET("/user-data", f.userDataHandler)
+	router.GET("/vendor-data", f.vendorDataHandler)
 	router.GET("/network-config", f.networkConfigHandler)
 }
 
@@ -85,6 +86,24 @@ func (f Frontend) userDataHandler(ctx *gin.Context) {
 
 	ctx.Header("Content-Type", "text/plain")
 	ctx.String(http.StatusOK, instance.Userdata)
+}
+
+// vendorDataHandler handles the /vendor-data endpoint.
+func (f Frontend) vendorDataHandler(ctx *gin.Context) {
+	_, err := f.getInstance(ctx, ctx.Request)
+	if err != nil {
+		var httpErr *httperror.E
+		if errors.As(err, &httpErr) {
+			_ = ctx.AbortWithError(httpErr.StatusCode, err)
+		} else {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	// Vendor data is not currently supported, return empty content with 200 OK
+	ctx.Header("Content-Type", "text/plain")
+	ctx.String(http.StatusOK, "")
 }
 
 // networkConfigHandler handles the /network-config endpoint.

--- a/tootles/internal/frontend/nocloud/frontend.go
+++ b/tootles/internal/frontend/nocloud/frontend.go
@@ -39,11 +39,11 @@ func New(client Client) Frontend {
 
 // Configure configures router with the supported NoCloud metadata API endpoints.
 func (f Frontend) Configure(router gin.IRouter) {
-	// Configure NoCloud endpoints directly under the root path
-	router.GET("/meta-data", f.metaDataHandler)
-	router.GET("/user-data", f.userDataHandler)
-	router.GET("/vendor-data", f.vendorDataHandler)
-	router.GET("/network-config", f.networkConfigHandler)
+	// Configure NoCloud endpoints under /nocloud prefix
+	router.GET("/nocloud/meta-data", f.metaDataHandler)
+	router.GET("/nocloud/user-data", f.userDataHandler)
+	router.GET("/nocloud/vendor-data", f.vendorDataHandler)
+	router.GET("/nocloud/network-config", f.networkConfigHandler)
 }
 
 // metaDataHandler handles the /meta-data endpoint.

--- a/tootles/internal/frontend/nocloud/frontend.go
+++ b/tootles/internal/frontend/nocloud/frontend.go
@@ -142,7 +142,7 @@ func (f Frontend) networkConfigHandler(ctx *gin.Context) {
 			return
 		}
 
-		ctx.Header("Content-Type", "text/yaml")
+		ctx.Header("Content-Type", "text/plain")
 		ctx.String(http.StatusOK, string(yamlData))
 		return
 	}
@@ -153,7 +153,7 @@ func (f Frontend) networkConfigHandler(ctx *gin.Context) {
 		return
 	}
 
-	ctx.Header("Content-Type", "text/yaml")
+	ctx.Header("Content-Type", "text/plain")
 	ctx.String(http.StatusOK, string(yamlData))
 }
 

--- a/tootles/internal/frontend/nocloud/frontend.go
+++ b/tootles/internal/frontend/nocloud/frontend.go
@@ -59,11 +59,49 @@ func (f Frontend) metaDataHandler(ctx *gin.Context) {
 		return
 	}
 
-	// Format metadata as YAML-like text output
-	output := fmt.Sprintf("instance-id: %s\nlocal-hostname: %s", instance.Metadata.InstanceID, instance.Metadata.LocalHostname)
+	// Build metadata map with all relevant fields
+	metadata := map[string]interface{}{
+		"instance-id":    instance.Metadata.InstanceID,
+		"local-hostname": instance.Metadata.LocalHostname,
+	}
+
+	// Include optional fields if they are set
+	if instance.Metadata.Hostname != "" {
+		metadata["hostname"] = instance.Metadata.Hostname
+	}
+	if instance.Metadata.IQN != "" {
+		metadata["iqn"] = instance.Metadata.IQN
+	}
+	if instance.Metadata.Plan != "" {
+		metadata["plan"] = instance.Metadata.Plan
+	}
+	if instance.Metadata.Facility != "" {
+		metadata["facility"] = instance.Metadata.Facility
+	}
+	if len(instance.Metadata.Tags) > 0 {
+		metadata["tags"] = instance.Metadata.Tags
+	}
+	if len(instance.Metadata.PublicKeys) > 0 {
+		metadata["public-keys"] = instance.Metadata.PublicKeys
+	}
+	if instance.Metadata.PublicIPv4 != "" {
+		metadata["public-ipv4"] = instance.Metadata.PublicIPv4
+	}
+	if instance.Metadata.PublicIPv6 != "" {
+		metadata["public-ipv6"] = instance.Metadata.PublicIPv6
+	}
+	if instance.Metadata.LocalIPv4 != "" {
+		metadata["local-ipv4"] = instance.Metadata.LocalIPv4
+	}
+
+	yamlData, err := yaml.Marshal(metadata)
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to marshal metadata: %w", err))
+		return
+	}
 
 	ctx.Header("Content-Type", "text/plain")
-	ctx.String(http.StatusOK, output)
+	ctx.String(http.StatusOK, string(yamlData))
 }
 
 // userDataHandler handles the /user-data endpoint.

--- a/tootles/internal/frontend/nocloud/frontend_test.go
+++ b/tootles/internal/frontend/nocloud/frontend_test.go
@@ -1,0 +1,278 @@
+package nocloud
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tinkerbell/tinkerbell/pkg/data"
+	"gopkg.in/yaml.v2"
+)
+
+// MockClient is a mock implementation of the NoCloud Client interface for testing.
+type MockClient struct {
+	instance data.NoCloudInstance
+	err      error
+}
+
+func (m *MockClient) GetNoCloudInstance(_ context.Context, _ string) (data.NoCloudInstance, error) {
+	if m.err != nil {
+		return data.NoCloudInstance{}, m.err
+	}
+	return m.instance, nil
+}
+
+func TestFrontend_metaDataHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		instance       data.NoCloudInstance
+		clientErr      error
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name: "successful metadata response",
+			instance: data.NoCloudInstance{
+				Metadata: data.Metadata{
+					InstanceID:    "server-001",
+					LocalHostname: "web01.example.com",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "instance-id: server-001\nlocal-hostname: web01.example.com",
+		},
+		{
+			name: "minimal metadata response",
+			instance: data.NoCloudInstance{
+				Metadata: data.Metadata{
+					InstanceID:    "server-002",
+					LocalHostname: "db01.example.com",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "instance-id: server-002\nlocal-hostname: db01.example.com",
+		},
+		{
+			name:           "instance not found",
+			clientErr:      ErrInstanceNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockClient{
+				instance: tt.instance,
+				err:      tt.clientErr,
+			}
+
+			frontend := New(mockClient)
+			router := gin.New()
+			frontend.Configure(router)
+
+			req := httptest.NewRequest(http.MethodGet, "/meta-data", nil)
+			req.RemoteAddr = "192.168.1.10:12345"
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedBody != "" {
+				assert.Equal(t, tt.expectedBody, strings.TrimSpace(w.Body.String()))
+				assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestFrontend_userDataHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		instance       data.NoCloudInstance
+		clientErr      error
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name: "successful user-data response",
+			instance: data.NoCloudInstance{
+				Userdata: "#cloud-config\npackage_update: true\n",
+				Metadata: data.Metadata{
+					InstanceID:    "server-001",
+					LocalHostname: "web01.example.com",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "#cloud-config\npackage_update: true\n",
+		},
+		{
+			name: "empty user-data",
+			instance: data.NoCloudInstance{
+				Userdata: "",
+				Metadata: data.Metadata{
+					InstanceID:    "server-002",
+					LocalHostname: "db01.example.com",
+				},
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "instance not found",
+			clientErr:      ErrInstanceNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockClient{
+				instance: tt.instance,
+				err:      tt.clientErr,
+			}
+
+			frontend := New(mockClient)
+			router := gin.New()
+			frontend.Configure(router)
+
+			req := httptest.NewRequest(http.MethodGet, "/user-data", nil)
+			req.RemoteAddr = "192.168.1.10:12345"
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedBody != "" {
+				assert.Equal(t, tt.expectedBody, w.Body.String())
+				assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestFrontend_networkConfigHandler(t *testing.T) {
+	bondConfig := map[string]interface{}{
+		"version": 1,
+		"config": []interface{}{
+			map[string]interface{}{
+				"type":        "physical",
+				"name":        "eno1",
+				"mac_address": "1c:34:da:12:34:56",
+				"mtu":         1500,
+			},
+			map[string]interface{}{
+				"type":        "physical",
+				"name":        "eno2",
+				"mac_address": "1c:34:da:12:34:57",
+				"mtu":         1500,
+			},
+			map[string]interface{}{
+				"type":            "bond",
+				"name":            "bond0",
+				"bond_interfaces": []string{"eno1", "eno2"},
+				"params": map[string]interface{}{
+					"bond-mode":   "802.3ad",
+					"bond-miimon": 100,
+				},
+				"subnets": []interface{}{
+					map[string]interface{}{
+						"type":    "static",
+						"address": "192.168.1.10/24",
+						"gateway": "192.168.1.1",
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		instance       data.NoCloudInstance
+		clientErr      error
+		expectedStatus int
+		validateBody   func(t *testing.T, body string)
+	}{
+		{
+			name: "successful network config response",
+			instance: data.NoCloudInstance{
+				NetworkConfig: bondConfig,
+				Metadata: data.Metadata{
+					InstanceID:    "server-001",
+					LocalHostname: "web01.example.com",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body string) {
+				t.Helper()
+				var config map[string]interface{}
+				err := yaml.Unmarshal([]byte(body), &config)
+				require.NoError(t, err)
+
+				assert.Equal(t, 1, config["version"])
+				assert.Contains(t, config, "config")
+
+				configItems := config["config"].([]interface{})
+				assert.Len(t, configItems, 3) // 2 physical + 1 bond
+			},
+		},
+		{
+			name: "fallback config when no network config",
+			instance: data.NoCloudInstance{
+				NetworkConfig: nil,
+				Metadata: data.Metadata{
+					InstanceID:    "server-002",
+					LocalHostname: "db01.example.com",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body string) {
+				t.Helper()
+				var config map[string]interface{}
+				err := yaml.Unmarshal([]byte(body), &config)
+				require.NoError(t, err)
+
+				assert.Equal(t, 1, config["version"])
+				configItems := config["config"].([]interface{})
+				assert.Len(t, configItems, 1) // fallback DHCP config
+
+				item := configItems[0].(map[interface{}]interface{})
+				assert.Equal(t, "physical", item["type"])
+				assert.Equal(t, "eno1", item["name"])
+			},
+		},
+		{
+			name:           "instance not found",
+			clientErr:      ErrInstanceNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockClient{
+				instance: tt.instance,
+				err:      tt.clientErr,
+			}
+
+			frontend := New(mockClient)
+			router := gin.New()
+			frontend.Configure(router)
+
+			req := httptest.NewRequest(http.MethodGet, "/network-config", nil)
+			req.RemoteAddr = "192.168.1.10:12345"
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.validateBody != nil {
+				assert.Equal(t, "text/yaml", w.Header().Get("Content-Type"))
+				tt.validateBody(t, w.Body.String())
+			}
+		})
+	}
+}

--- a/tootles/internal/frontend/nocloud/frontend_test.go
+++ b/tootles/internal/frontend/nocloud/frontend_test.go
@@ -75,7 +75,7 @@ func TestFrontend_metaDataHandler(t *testing.T) {
 			router := gin.New()
 			frontend.Configure(router)
 
-			req := httptest.NewRequest(http.MethodGet, "/meta-data", nil)
+			req := httptest.NewRequest(http.MethodGet, "/nocloud/meta-data", nil)
 			req.RemoteAddr = "192.168.1.10:12345"
 			w := httptest.NewRecorder()
 
@@ -139,7 +139,7 @@ func TestFrontend_userDataHandler(t *testing.T) {
 			router := gin.New()
 			frontend.Configure(router)
 
-			req := httptest.NewRequest(http.MethodGet, "/user-data", nil)
+			req := httptest.NewRequest(http.MethodGet, "/nocloud/user-data", nil)
 			req.RemoteAddr = "192.168.1.10:12345"
 			w := httptest.NewRecorder()
 
@@ -191,7 +191,7 @@ func TestFrontend_vendorDataHandler(t *testing.T) {
 			router := gin.New()
 			frontend.Configure(router)
 
-			req := httptest.NewRequest(http.MethodGet, "/vendor-data", nil)
+			req := httptest.NewRequest(http.MethodGet, "/nocloud/vendor-data", nil)
 			req.RemoteAddr = "192.168.1.10:12345"
 			w := httptest.NewRecorder()
 
@@ -314,7 +314,7 @@ func TestFrontend_networkConfigHandler(t *testing.T) {
 			router := gin.New()
 			frontend.Configure(router)
 
-			req := httptest.NewRequest(http.MethodGet, "/network-config", nil)
+			req := httptest.NewRequest(http.MethodGet, "/nocloud/network-config", nil)
 			req.RemoteAddr = "192.168.1.10:12345"
 			w := httptest.NewRecorder()
 

--- a/tootles/internal/frontend/nocloud/frontend_test.go
+++ b/tootles/internal/frontend/nocloud/frontend_test.go
@@ -322,7 +322,7 @@ func TestFrontend_networkConfigHandler(t *testing.T) {
 
 			assert.Equal(t, tt.expectedStatus, w.Code)
 			if tt.validateBody != nil {
-				assert.Equal(t, "text/yaml", w.Header().Get("Content-Type"))
+				assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
 				tt.validateBody(t, w.Body.String())
 			}
 		})

--- a/tootles/internal/frontend/nocloud/frontend_test.go
+++ b/tootles/internal/frontend/nocloud/frontend_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tinkerbell/tinkerbell/pkg/data"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // MockClient is a mock implementation of the NoCloud Client interface for testing.
@@ -239,7 +239,7 @@ func TestFrontend_networkConfigHandler(t *testing.T) {
 				configItems := config["config"].([]interface{})
 				assert.Len(t, configItems, 1) // fallback DHCP config
 
-				item := configItems[0].(map[interface{}]interface{})
+				item := configItems[0].(map[string]interface{})
 				assert.Equal(t, "physical", item["type"])
 				assert.Equal(t, "eno1", item["name"])
 			},

--- a/tootles/tootles.go
+++ b/tootles/tootles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tinkerbell/tinkerbell/tootles/internal/frontend/ec2"
 	"github.com/tinkerbell/tinkerbell/tootles/internal/frontend/hack"
+	"github.com/tinkerbell/tinkerbell/tootles/internal/frontend/nocloud"
 	"github.com/tinkerbell/tinkerbell/tootles/internal/http"
 	"github.com/tinkerbell/tinkerbell/tootles/internal/metrics"
 	"github.com/tinkerbell/tinkerbell/tootles/internal/middleware"
@@ -21,6 +22,7 @@ import (
 type Config struct {
 	BackendEc2     ec2.Client
 	BackendHack    hack.Client
+	BackendNoCloud nocloud.Client
 	TrustedProxies string
 	DebugMode      bool
 	BindAddrPort   string
@@ -68,6 +70,11 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 	fe.Configure(router)
 
 	hack.Configure(router, c.BackendHack)
+
+	if c.BackendNoCloud != nil {
+		nfe := nocloud.New(c.BackendNoCloud)
+		nfe.Configure(router)
+	}
 
 	return http.Serve(ctx, log, c.BindAddrPort, router)
 }


### PR DESCRIPTION

  ## Description

  Adds NoCloud metadata service to tootles for cloud-init network bonding support on bare metal. Generates network-config from Hardware CRD that cloud-init can use to configure bonded interfaces with static IPs during provisioning.

https://docs.cloud-init.io/en/24.2/reference/datasources/nocloud.html

  Includes:
  - NoCloud frontend (`/meta-data`, `/user-data`, `/network-config` endpoints)
  - Support for all bonding modes (0-6: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb)
  - Correct parameter naming for cloud-init 24.2+ (underscores: `bond-lacp_rate`, `bond-xmit_hash_policy`, etc.)
  - IPv4/IPv6 static IP configuration
  - Backend implementation for kube and noop
  - Tests and documentation

  Fixes: #

  ## How Has This Been Tested?

  - Unit tests pass (`make test`, `make lint`)
  - Integration tested on Rocky Linux 9.6, Ubuntu 22.04, and Ubuntu 24.04
  - Verified schema validation with `cloud-init schema --system`
  - Tested 802.3ad mode with static IPv4 on bare metal with LACP-enabled switch
  - Documented OS-specific issues in `docs/technical/TOOTLES_NOCLOUD.md`:
    - Ubuntu 22.04/24.04 needs `no-nocloud-network.patch` reverted
    - Rocky 9.6 sysconfig renderer needs NetworkManager restart

  ## How are existing users impacted? What migration steps/scripts do we need?

  No impact. This is opt-in - NoCloud endpoints only respond when requested. EC2 and Hack metadata services unchanged. No migration needed.

  Usage:
  ```yaml
  spec:
    metadata:
      bonding_mode: 4  # 802.3ad
      instance:
        ips:
          - address: "192.168.1.10"
            netmask: "255.255.255.0"
            gateway: "192.168.1.1"
            family: 4

  Kernel parameter: ds=nocloud;seedfrom=http://<tinkerbell-ip>:7172/

  See docs/technical/TOOTLES_NOCLOUD.md for details.

  Checklist:

  I have:

  - updated the documentation and/or roadmap (if required)
  - added unit or e2e tests
  - provided instructions on how to upgrade