### PR TITLE
tootles: introduce `/tootles/instanceID/:instanceID/2009-04-04` metadata prefix endpoint

### DIFF
--- a/cmd/tinkerbell/flag/tootles.go
+++ b/cmd/tinkerbell/flag/tootles.go
@@ -18,7 +18,8 @@ type TootlesConfig struct {
 }
 
 var KubeIndexesTootles = map[kube.IndexType]kube.Index{
-	kube.IndexTypeIPAddr: kube.Indexes[kube.IndexTypeIPAddr],
+	kube.IndexTypeIPAddr:     kube.Indexes[kube.IndexTypeIPAddr],
+	kube.IndexTypeInstanceID: kube.Indexes[kube.IndexTypeInstanceID],
 }
 
 func RegisterTootlesFlags(fs *Set, h *TootlesConfig) {

--- a/pkg/backend/kube/index.go
+++ b/pkg/backend/kube/index.go
@@ -15,6 +15,7 @@ const (
 	IndexTypeMachineName     IndexType = "machine.metadata.name"
 	IndexTypeWorkflowAgentID IndexType = WorkflowByAgentID
 	IndexTypeHardwareAgentID IndexType = HardwareByAgentID
+	IndexTypeInstanceID      IndexType = InstanceIDIndex
 )
 
 // Indexes that are currently known.
@@ -48,6 +49,11 @@ var Indexes = map[IndexType]Index{
 		Obj:          &tinkerbell.Hardware{},
 		Field:        HardwareByAgentID,
 		ExtractValue: HardwareByAgentIDFunc,
+	},
+	IndexTypeInstanceID: {
+		Obj:          &tinkerbell.Hardware{},
+		Field:        InstanceIDIndex,
+		ExtractValue: InstanceIDFunc,
 	},
 }
 
@@ -143,4 +149,14 @@ func HardwareByAgentIDFunc(obj client.Object) []string {
 		return []string{}
 	}
 	return []string{hw.Spec.AgentID}
+}
+
+// InstanceIDIndex is an index used with a controller-runtime client to lookup hardware by its metadata instance id.
+const InstanceIDIndex = ".Spec.Metadata.Instance.ID" // #nosec G101
+func InstanceIDFunc(obj client.Object) []string {
+	hw, ok := obj.(*tinkerbell.Hardware)
+	if !ok {
+		return nil
+	}
+	return []string{hw.Spec.Metadata.Instance.ID}
 }

--- a/pkg/backend/noop/noop.go
+++ b/pkg/backend/noop/noop.go
@@ -29,3 +29,8 @@ func (n Backend) GetHackInstance(context.Context, string) (data.HackInstance, er
 func (n Backend) GetEC2Instance(context.Context, string) (data.Ec2Instance, error) {
 	return data.Ec2Instance{}, errAlways
 }
+
+// GetEC2InstanceByInstanceID exists to satisfy the ec2.Client interface. It is not implemented.
+func (n Backend) GetEC2InstanceByInstanceID(context.Context, string) (data.Ec2Instance, error) {
+	return data.Ec2Instance{}, errAlways
+}

--- a/tootles/internal/frontend/ec2/frontend.go
+++ b/tootles/internal/frontend/ec2/frontend.go
@@ -24,6 +24,9 @@ type Client interface {
 	// GetEC2Instance retrieves an Instance associated with ip. If no Instance can be
 	// found, it should return ErrInstanceNotFound.
 	GetEC2Instance(_ context.Context, ip string) (data.Ec2Instance, error)
+	// GetEC2InstanceByInstanceID retrieves an Instance by its Metadata Instance ID. If no Instance can be
+	// found, it should return ErrInstanceNotFound.
+	GetEC2InstanceByInstanceID(_ context.Context, instanceID string) (data.Ec2Instance, error)
 }
 
 // Frontend is an EC2 HTTP API frontend. It is responsible for configuring routers with handlers
@@ -46,26 +49,7 @@ func (f Frontend) Configure(router gin.IRouter) {
 	// Setup the 2009-04-04 API path prefix and use a trailing slash route helper to patch
 	// equivalent trailing slash routes.
 	v20090404 := ginutil.TrailingSlashRouteHelper{IRouter: router.Group("/2009-04-04")}
-
-	dataEndpointBinder := func(router gin.IRouter, endpoint string, filter filterFunc) {
-		router.GET(endpoint, func(ctx *gin.Context) {
-			instance, err := f.getInstance(ctx, ctx.Request)
-			if err != nil {
-				// If there's an error containing an http status code, use that status code else
-				// assume its an internal server error.
-				var httpErr *httperror.E
-				if errors.As(err, &httpErr) {
-					_ = ctx.AbortWithError(httpErr.StatusCode, err)
-				} else {
-					_ = ctx.AbortWithError(http.StatusInternalServerError, err)
-				}
-
-				return
-			}
-
-			ctx.String(http.StatusOK, filter(instance))
-		})
-	}
+	v20090404viaInstanceID := ginutil.TrailingSlashRouteHelper{IRouter: router.Group("/tootles/instanceID/:instanceID/2009-04-04")}
 
 	// Create a static route builder that we can add all data routes to which are the basis for
 	// all static routes.
@@ -74,11 +58,20 @@ func (f Frontend) Configure(router gin.IRouter) {
 	// Configure all dynamic routes. Dynamic routes are anything that requires retrieving a specific
 	// instance and returning data from it.
 	for _, r := range dataRoutes {
-		dataEndpointBinder(v20090404, r.Endpoint, r.Filter)
+		v20090404.GET(r.Endpoint, func(ctx *gin.Context) {
+			instance, getInstanceErr := f.getInstanceViaIP(ctx, ctx.Request)
+			f.writeInstanceDataOrErrToHTTP(ctx, getInstanceErr, r.Filter(instance))
+		})
+
+		v20090404viaInstanceID.GET(r.Endpoint, func(ctx *gin.Context) {
+			instance, getInstanceErr := f.getInstanceViaInstanceID(ctx)
+			f.writeInstanceDataOrErrToHTTP(ctx, getInstanceErr, r.Filter(instance))
+		})
+
 		staticRoutes.FromEndpoint(r.Endpoint)
 	}
 
-	staticEndpointBinder := func(router gin.IRouter, endpoint string, childEndpoints []string) {
+	staticEndpointBinder := func(router ginutil.TrailingSlashRouteHelper, endpoint string, childEndpoints []string) {
 		router.GET(endpoint, func(ctx *gin.Context) {
 			ctx.String(http.StatusOK, join(childEndpoints))
 		})
@@ -86,12 +79,31 @@ func (f Frontend) Configure(router gin.IRouter) {
 
 	for _, r := range staticRoutes.Build() {
 		staticEndpointBinder(v20090404, r.Endpoint, r.Children)
+		staticEndpointBinder(v20090404viaInstanceID, r.Endpoint, r.Children)
 	}
 }
 
-// getInstance is a framework agnostic method for retrieving Instance data based on a remote
-// address.
-func (f Frontend) getInstance(ctx context.Context, r *http.Request) (data.Ec2Instance, error) {
+// Shared across IP and instanceID-based routes.
+func (f Frontend) writeInstanceDataOrErrToHTTP(ctx *gin.Context, getInstanceErr error, filteredInstanceData string) {
+	if getInstanceErr != nil {
+		// If there's an error containing an http status code, use that status code else assume it is an internal server error.
+		var httpErr *httperror.E
+		if errors.As(getInstanceErr, &httpErr) {
+			_ = ctx.AbortWithError(httpErr.StatusCode, getInstanceErr)
+		} else {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, getInstanceErr)
+		}
+
+		return
+	}
+	// Simply output the filtered instance data with a 200 OK status code.
+	ctx.String(http.StatusOK, filteredInstanceData)
+}
+
+// getInstanceViaIP is a framework-agnostic method for retrieving Instance data based on a remote
+// address. Normal IP based lookup. SNAT, proxies, externalTrafficPolicy:Cluster, possibly
+// misconfigured X-Forwarded-For headers, etc. are all in play here.
+func (f Frontend) getInstanceViaIP(ctx context.Context, r *http.Request) (data.Ec2Instance, error) {
 	ip, err := request.RemoteAddrIP(r)
 	if err != nil {
 		return data.Ec2Instance{}, httperror.New(http.StatusBadRequest, "invalid remote addr")
@@ -105,6 +117,24 @@ func (f Frontend) getInstance(ctx context.Context, r *http.Request) (data.Ec2Ins
 
 		// TODO(chrisdoherty4) What happens when multiple Instance could be returned? What
 		// is the behavior of GetEC2Instance?
+		return data.Ec2Instance{}, httperror.Wrap(http.StatusInternalServerError, err)
+	}
+
+	return instance, nil
+}
+
+// getInstanceViaInstanceID is a gin-specific method for retrieving Instance data based the instance ID included in the request path.
+func (f Frontend) getInstanceViaInstanceID(ctx *gin.Context) (data.Ec2Instance, error) {
+	instanceID := ctx.Param("instanceID")
+	if strings.TrimSpace(instanceID) == "" {
+		return data.Ec2Instance{}, httperror.New(http.StatusNotFound, "instanceID not looked up as it is invalid")
+	}
+
+	instance, err := f.client.GetEC2InstanceByInstanceID(ctx, instanceID)
+	if err != nil {
+		if errors.Is(err, ErrInstanceNotFound) || apierrors.IsNotFound(err) {
+			return data.Ec2Instance{}, httperror.New(http.StatusNotFound, fmt.Sprintf("no hardware found for instanceID: '%s'", instanceID))
+		}
 		return data.Ec2Instance{}, httperror.Wrap(http.StatusInternalServerError, err)
 	}
 

--- a/tootles/internal/frontend/ec2/frontend_mock_test.go
+++ b/tootles/internal/frontend/ec2/frontend_mock_test.go
@@ -45,7 +45,22 @@ func (m *MockClient) GetEC2Instance(arg0 context.Context, ip string) (data.Ec2In
 }
 
 // GetEC2Instance indicates an expected call of GetEC2Instance.
-func (mr *MockClientMockRecorder) GetEC2Instance(arg0, ip interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetEC2Instance(arg0, ip any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEC2Instance", reflect.TypeOf((*MockClient)(nil).GetEC2Instance), arg0, ip)
+}
+
+// GetEC2InstanceByInstanceID mocks base method.
+func (m *MockClient) GetEC2InstanceByInstanceID(arg0 context.Context, instanceID string) (data.Ec2Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEC2InstanceByInstanceID", arg0, instanceID)
+	ret0, _ := ret[0].(data.Ec2Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEC2InstanceByInstanceID indicates an expected call of GetEC2InstanceByInstanceID.
+func (mr *MockClientMockRecorder) GetEC2InstanceByInstanceID(arg0, instanceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEC2InstanceByInstanceID", reflect.TypeOf((*MockClient)(nil).GetEC2InstanceByInstanceID), arg0, instanceID)
 }

--- a/tootles/tootles.go
+++ b/tootles/tootles.go
@@ -69,5 +69,9 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 
 	hack.Configure(router, c.BackendHack)
 
+	// Log all registered routes
+	for _, r := range router.Routes() {
+		log.Info(fmt.Sprintf("[ROUTE] %s %s", r.Method, r.Path))
+	}
 	return http.Serve(ctx, log, c.BindAddrPort, router)
 }


### PR DESCRIPTION
#### tootles: introduce `/tootles/instanceID/:instanceID/2009-04-04` metadata prefix endpoint

- tootles: log all gin Routes during startup
  Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
- tootles: introduce `/tootles/instanceID/:instanceID/2009-04-04` metadata prefix endpoint
  - using Hardware CRD's .Metadata.Instance.ID, one can now get info out of tootles without needing a stable IP address
  - in cloud-init.cfg: `metadata_urls: ["http://<tootlesHost>:50061/tootles/instanceID/<instanceId>"]`
  - introduce `GetEC2InstanceByInstanceID()` member for Client interface
      - add indexed lookup via `.Spec.Metadata.Instance.ID` for kube backend's impl via `hwByInstanceID()`
      - no-op impl for noop backend
  - frontend: extract method `writeInstanceDataOrErrToHTTP()`
    - call it from both IP-based and instanceId-based route groupings
  - some maintenance tasks missing from Makefile:
      - ran gofumpt
        - `go install mvdan.cc/gofumpt@latest`
        - `gofumpt -l -w .`
      - updated tootles' frontend_mock_test.go
        - `go install go.uber.org/mock/mockgen@latest`
        - `cd tootles/internal/frontend/ec2`
        - `mockgen -source=frontend.go > frontend_mock_test.go`
  Signed-off-by: Ricardo Pardini <ricardo@pardini.net>