### PR TITLE
Add netmaskToPrefix template function

### DIFF
--- a/tink/controller/internal/workflow/template_funcs.go
+++ b/tink/controller/internal/workflow/template_funcs.go
@@ -2,12 +2,15 @@ package workflow
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 )
 
 // templateFuncs defines the custom functions available to workflow templates.
 var templateFuncs = map[string]interface{}{
-	"formatPartition": formatPartition,
+	"formatPartition":       formatPartition,
+	"netmaskToPrefixLength": netmaskToPrefixLength,
 }
 
 // formatPartition formats a device path with partition for the device type. If it receives an
@@ -29,4 +32,24 @@ func formatPartition(dev string, partition int) string {
 		return fmt.Sprintf("%v%v", dev, partition)
 	}
 	return dev
+}
+
+// netmaskToPrefixLength converts a netmask (e.g. 255.255.255.0) to prefix length (e.g. 24).
+// Returns an error if the netmask is invalid or not IPv4.
+func netmaskToPrefixLength(netmask string) (string, error) {
+	// Parse the netmask
+	ip := net.ParseIP(netmask)
+	if ip == nil {
+		return "", fmt.Errorf("invalid netmask format: %s", netmask)
+	}
+
+	// Convert to IPv4
+	ipv4 := ip.To4()
+	if ipv4 == nil {
+		return "", fmt.Errorf("netmask must be IPv4: %s", netmask)
+	}
+
+	// Count the number of 1 bits in the netmask
+	ones, _ := net.IPMask(ipv4).Size()
+	return strconv.Itoa(ones), nil
 }

--- a/tink/controller/internal/workflow/template_funcs_test.go
+++ b/tink/controller/internal/workflow/template_funcs_test.go
@@ -1,0 +1,167 @@
+package workflow
+
+import (
+	"testing"
+)
+
+func TestNetmaskToPrefixLength(t *testing.T) {
+	tests := []struct {
+		name      string
+		netmask   string
+		want      string
+		wantError bool
+	}{
+		{
+			name:      "valid /24 netmask",
+			netmask:   "255.255.255.0",
+			want:      "24",
+			wantError: false,
+		},
+		{
+			name:      "valid /16 netmask",
+			netmask:   "255.255.0.0",
+			want:      "16",
+			wantError: false,
+		},
+		{
+			name:      "valid /8 netmask",
+			netmask:   "255.0.0.0",
+			want:      "8",
+			wantError: false,
+		},
+		{
+			name:      "valid /32 netmask",
+			netmask:   "255.255.255.255",
+			want:      "32",
+			wantError: false,
+		},
+		{
+			name:      "valid /0 netmask",
+			netmask:   "0.0.0.0",
+			want:      "0",
+			wantError: false,
+		},
+		{
+			name:      "valid /28 netmask",
+			netmask:   "255.255.255.240",
+			want:      "28",
+			wantError: false,
+		},
+		{
+			name:      "valid /30 netmask",
+			netmask:   "255.255.255.252",
+			want:      "30",
+			wantError: false,
+		},
+		{
+			name:      "invalid netmask format",
+			netmask:   "invalid",
+			want:      "",
+			wantError: true,
+		},
+		{
+			name:      "empty netmask",
+			netmask:   "",
+			want:      "",
+			wantError: true,
+		},
+		{
+			name:      "incomplete netmask",
+			netmask:   "255.255.255",
+			want:      "",
+			wantError: true,
+		},
+		{
+			name:      "out of range values",
+			netmask:   "256.255.255.0",
+			want:      "",
+			wantError: true,
+		},
+		{
+			name:      "IPv6 address",
+			netmask:   "::1",
+			want:      "",
+			wantError: true,
+		},
+		{
+			name:      "IPv6 full address",
+			netmask:   "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			want:      "",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := netmaskToPrefixLength(tt.netmask)
+			if (err != nil) != tt.wantError {
+				t.Errorf("netmaskToPrefixLength() error = %v, wantError %v", err, tt.wantError)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("netmaskToPrefixLength() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPartition(t *testing.T) {
+	tests := []struct {
+		name      string
+		dev       string
+		partition int
+		want      string
+	}{
+		{
+			name:      "nvme device partition 1",
+			dev:       "/dev/nvme0n1",
+			partition: 1,
+			want:      "/dev/nvme0n1p1",
+		},
+		{
+			name:      "nvme device partition 2",
+			dev:       "/dev/nvme0n1",
+			partition: 2,
+			want:      "/dev/nvme0n1p2",
+		},
+		{
+			name:      "sda device partition 1",
+			dev:       "/dev/sda",
+			partition: 1,
+			want:      "/dev/sda1",
+		},
+		{
+			name:      "vda device partition 1",
+			dev:       "/dev/vda",
+			partition: 1,
+			want:      "/dev/vda1",
+		},
+		{
+			name:      "xvda device partition 1",
+			dev:       "/dev/xvda",
+			partition: 1,
+			want:      "/dev/xvda1",
+		},
+		{
+			name:      "hda device partition 1",
+			dev:       "/dev/hda",
+			partition: 1,
+			want:      "/dev/hda1",
+		},
+		{
+			name:      "unknown device returns unchanged",
+			dev:       "/dev/unknown",
+			partition: 1,
+			want:      "/dev/unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatPartition(tt.dev, tt.partition)
+			if got != tt.want {
+				t.Errorf("formatPartition() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds netmaskToPrefixLength template function to convert netmask notation (e.g., "255.255.255.0") to prefix (e.g., "24").

The function is available in workflow template contexts and will cause template rendering to fail on error. This template function can be handy when using template to configure static IPAM files using tools such as netplan or network manager.

<!--- Please describe what this PR is going to change -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
