### PR TITLE
Add missing Helm values

### DIFF
--- a/docs/technical/REFERENCES.md
+++ b/docs/technical/REFERENCES.md
@@ -207,3 +207,13 @@ Environment Variables:
 ```bash
 export TINKERBELL_TINK_CONTROLLER_REFERENCE_ALLOW_LIST_RULES='{"reference":{"resource":["hardware"]}}|{"reference":{"resource":["workflows"]}}'
 ```
+
+Helm Values:
+
+- `deployment.envs.tinkController.referenceAllowListRules`
+- `deployment.envs.tinkController.referenceDenyListRules`
+
+```yaml
+--set-json 'deployment.envs.tinkController.referenceAllowListRules={"reference":{"resource":["secrets"]}}'
+--set-json 'deployment.envs.tinkController.referenceDenyListRules={"reference":{"resource":["pods"]}}'
+```

--- a/helm/tinkerbell/templates/deployment.yaml
+++ b/helm/tinkerbell/templates/deployment.yaml
@@ -81,9 +81,13 @@ spec:
             - name: TINKERBELL_TINK_CONTROLLER_PROBE_ADDR
               value: {{ .Values.deployment.envs.tinkController.probeAddr | quote }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_ALLOW_LIST_RULES
-              value: {{ .Values.deployment.envs.tinkController.referenceAllowListRules | quote }}
+            {{- if .Values.deployment.envs.tinkController.referenceAllowListRules }}
+              value: {{ .Values.deployment.envs.tinkController.referenceAllowListRules | toJson | quote }}
+            {{- end }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_DENY_LIST_RULES
-              value: {{ .Values.deployment.envs.tinkController.referenceDenyListRules | quote }}
+            {{- if .Values.deployment.envs.tinkController.referenceDenyListRules }}
+              value: {{ .Values.deployment.envs.tinkController.referenceDenyListRules | toJson | quote }}
+            {{- end }}
           # TINK SERVER
             - name: TINKERBELL_TINK_SERVER_BIND_ADDR
               value: {{ .Values.deployment.envs.tinkServer.bindAddr | quote }}

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -109,8 +109,8 @@ deployment:
       logLevel: 0
       metricsAddr: ""
       probeAddr: ""
-      referenceAllowListRules: ""
-      referenceDenyListRules: ""
+      referenceAllowListRules: {}
+      referenceDenyListRules: {}
     tinkServer:
       autoDiscoveryAutoEnrollmentEnabled: false
       autoDiscoveryEnabled: false


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This adds the Helm values for the following missing CLI flags.

- `--tink-controller-reference-allow-list-rules`
- `--tink-controller-reference-deny-list-rules`

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
