### PR TITLE
fix(agent): include WWN and SerialNumber in block device attributes

### DIFF
--- a/tink/agent/internal/transport/grpc/attributes.go
+++ b/tink/agent/internal/transport/grpc/attributes.go
@@ -44,6 +44,8 @@ func ToProto(a *data.AgentAttributes) *proto.AgentAttributes {
 			PhysicalBlockSize: block.PhysicalBlockSize,
 			Vendor:            block.Vendor,
 			Model:             block.Model,
+			Wwn:               block.WWN,
+			SerialNumber:      block.SerialNumber,
 		})
 	}
 


### PR DESCRIPTION
The agent's gRPC transport layer was not including WWN (World Wide Name) and SerialNumber fields when converting block device attributes to protobuf format, even though:
- The data structures support these fields
- The protobuf schema includes them
- The attribute collection code gathers them from ghw
- The server-side conversion expects them

This resulted in WWN and SerialNumber being lost during transmission from agent to server, causing them to be absent from Hardware CRD annotations and unavailable for workflow rule matching.

This fix adds the missing field mappings in the ToProto() function to ensure WWN and SerialNumber are transmitted to the Tink server.

Related to PR tinkerbell/tinkerbell#342 which added WWN support but missed updating the agent's gRPC transport layer.

## Description

<!--- Please describe what this PR is going to change -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
