### PR TITLE
build: migrate build system to GoReleaser

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,8 +13,8 @@ queue_rules:
       - "#changes-requested-reviews-by=0"
       - check-success=DCO
       - check-success=validation
-      - check-success=build-binaries (tink-agent, cross-compile-agent, tink-agent-binaries)
-      - check-success=build-binaries (tinkerbell, cross-compile, tinkerbell-binaries)
+      - check-success=generate
+      - check-success=build-publish-container-images
       - label!=do-not-merge
       - label=ready-to-merge
     merge_conditions:
@@ -26,8 +26,8 @@ queue_rules:
       - "#changes-requested-reviews-by=0"
       - check-success=DCO
       - check-success=validation
-      - check-success=build-binaries (tink-agent, cross-compile-agent, tink-agent-binaries)
-      - check-success=build-binaries (tinkerbell, cross-compile, tinkerbell-binaries)
+      - check-success=generate
+      - check-success=build-publish-container-images
       - label!=do-not-merge
       - label=ready-to-merge
       # This extra condition forces draft PR mode (prevents in-place checks)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,59 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/${{ github.repository }}
   CGO_ENABLED: 0
-  GO_VERSION: "1.26"
+  GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          args: --timeout=10m
+          version: v2.11.2
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          install-only: true
+          version: v2.11.2
+
+      - name: Run go mod tidy
+        run: go mod tidy
+
+      - name: Generate code and format
+        run: make generate
+
+      - name: Check for changes
+        run: git diff --compact-summary --exit-code
+
+      - name: Check for new files
+        run: |
+          if git status --porcelain | grep -qE '^(\?\?|A )'; then
+            echo "Error: new files present (untracked or staged)" >&2
+            exit 1
+          fi
+
   validation:
     runs-on: ubuntu-latest
     steps:
@@ -26,71 +76,44 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: false
+          go-version-file: 'go.mod'
 
-      - name: Restore Go cache
-        uses: actions/cache/restore@v5
+      - name: Run Tests
+        if: always()
+        run: go tool gotestsum --junitfile junit.xml -- -coverprofile=coverage.txt -covermode=atomic -race -count=1 -v ./...
+        env:
+          CGO_ENABLED: 1
+
+      - name: Generate HTML coverage report
+        if: always()
+        run: go tool cover -html=coverage.txt -o coverage.html
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
+          name: coverage-report
           path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            ${{ runner.os }}-go-
+            coverage.txt
+            coverage.html
+            junit.xml
 
-      - name: Fix no space errors and Fetch Deps
-        run: |
-          # fixes "write /run/user/<uid>/<nonce>: no space left on device" error
-          sudo mount -o remount,size=3G "/run/user/$(id -u)" || true
-          go mod download
-
-      - name: Generate UI assets
-        run: make ui-generate
-
-      - name: Run all CI checks, linting, tests, etc
-        run: make ci TEST_ARGS="-count=1"
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: upload to codecov
-        uses: codecov/codecov-action@v6
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Trim Go cache
-        if: ${{ github.ref == 'refs/heads/main' }}
-        shell: bash
-        # As the go command works, it either creates build cache files or touches
-        # ones it uses at most once an hour. When it trims the cache, it trims
-        # files that have not been modified/touched in 5+ days.
-        # To keep our saved cache lean, trim all files except ones that were just
-        # created/touched as part of this run.
-        run: |
-          find ~/.cache/go-build -type f -mmin +90 -delete
-
-      - name: Set Go cache date
-        shell: bash
-        run: echo "GO_CACHE_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-
-      - name: Save Go cache
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/cache/save@v5
+        uses: codecov/codecov-action@v5
         with:
-          # Caches both the downloaded modules and the compiled build cache.
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          # Save to eg Linux-go-$hash-YYYY-MM-DD to keep the cache fresh
-          key: "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ env.GO_CACHE_DATE }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   validate-helm-chart:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
+        uses: actions/checkout@v5
 
       - name: install helm
         uses: Azure/setup-helm@v5
@@ -100,162 +123,16 @@ jobs:
       - name: Lint and Template Helm chart
         run: make helm-lint helm-template
 
-  build-binaries:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - name: tinkerbell
-            make-target: cross-compile
-            artifact-name: tinkerbell-binaries
-          - name: tink-agent
-            make-target: cross-compile-agent
-            artifact-name: tink-agent-binaries
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: false
-
-      - name: Restore Go cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            ${{ runner.os }}-go-
-
-      - name: Fix no space errors and Fetch Deps
-        run: |
-          # fixes "write /run/user/<uid>/<nonce>: no space left on device" error
-          sudo mount -o remount,size=3G "/run/user/$(id -u)" || true
-          go mod download
-
-      - name: Generate UI assets
-        run: make ui-generate
-
-      - name: Compile binaries for ${{ matrix.name }}
-        run: make ${{ matrix.make-target }}
-
-      - name: Upload binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.artifact-name }}
-          path: |
-            out/${{ matrix.name }}-*
-          if-no-files-found: error
-
-  build-embedded-binaries:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - make-target: cross-compile-embedded-amd64
-            artifact-name: tinkerbell-embedded-linux-amd64
-            goarch: amd64
-          - make-target: cross-compile-embedded-arm64
-            artifact-name: tinkerbell-embedded-linux-arm64
-            goarch: arm64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: false
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}-
-            ${{ runner.os }}-gomod-
-
-      - name: Restore Go build cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-gobuild-${{ env.GO_VERSION }}-${{ matrix.goarch }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gobuild-${{ env.GO_VERSION }}-${{ matrix.goarch }}-${{ hashFiles('**/go.sum') }}-
-            ${{ runner.os }}-gobuild-${{ env.GO_VERSION }}-${{ matrix.goarch }}-
-
-      - name: Fix no space errors and Fetch Deps
-        run: |
-          # fixes "write /run/user/<uid>/<nonce>: no space left on device" error
-          sudo mount -o remount,size=3G "/run/user/$(id -u)" || true
-          go mod download
-
-      - name: Generate UI assets
-        run: make ui-generate
-
-      - name: Compile embedded binary (${{ matrix.goarch }})
-        run: make ${{ matrix.make-target }}
-
-      - name: Trim Go cache
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: find ~/.cache/go-build -type f -mmin +90 -delete
-
-      - name: Set Go cache date
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: echo "GO_CACHE_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-
-      - name: Save Go module cache
-        if: ${{ github.ref == 'refs/heads/main' && matrix.goarch == 'amd64' }}
-        uses: actions/cache/save@v5
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}-${{ env.GO_CACHE_DATE }}
-
-      - name: Save Go build cache
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-gobuild-${{ env.GO_VERSION }}-${{ matrix.goarch }}-${{ hashFiles('**/go.sum') }}-${{ env.GO_CACHE_DATE }}
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.artifact-name }}
-          path: out/tinkerbell-embedded-linux-*
-          if-no-files-found: error
-          retention-days: 1
-
   build-publish-container-images:
     runs-on: ubuntu-latest
-    if: |
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/tags/v')
     needs:
+      - lint
+      - generate
       - validation
-      - build-binaries
-    strategy:
-      matrix:
-        include:
-          - artifact_name: tinkerbell-binaries
-            image_name: ghcr.io/tinkerbell/tinkerbell
-            make-target: build-push-image
-          - artifact_name: tink-agent-binaries
-            image_name: ghcr.io/tinkerbell/tink-agent
-            make-target: build-push-image-agent
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -263,38 +140,66 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # Add support for more platforms with QEMU (optional)
-      # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v3
+        if: |
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/tags/v')
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        if: |
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/tags/v')
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
 
       - name: Login to ghcr.io
         uses: docker/login-action@v4
+        if: |
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/tags/v')
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download binaries
-        uses: actions/download-artifact@v8
+      - name: Install Cosign
+        if: |
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Set up GoReleaser environment variables
+        id: goreleaser-env
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "args=release --clean" >> "$GITHUB_OUTPUT"
+            echo "IS_RELEASE=true" >> "$GITHUB_ENV"
+          elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
+            echo "args=release --clean --skip=validate" >> "$GITHUB_OUTPUT"
+            echo "IS_RELEASE=false" >> "$GITHUB_ENV"
+          else
+            echo "args=build --clean --skip=validate" >> "$GITHUB_OUTPUT"
+            echo "IS_RELEASE=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          name: ${{ matrix.artifact_name }}
-          path: ./out
-          merge-multiple: true
-      # Artifact upload doesn't preserve permissions so we need to fix them.
-      - name: Fix permissions
-        run: chmod +x out/*
-
-      - name: Prepare build environment
-        run: make prepare-buildx
-
-      - name: Build and publish container images
-        run: make ${{ matrix.make-target }}
+          version: latest
+          args: "${{ steps.goreleaser-env.outputs.args }}"
         env:
-          IMAGE_NAME: ${{ matrix.image_name }}
-          IMAGE_NAME_AGENT: ${{ matrix.image_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: tinkerbell
+          path: dist/*
 
   package-publish-helm-chart:
     runs-on: ubuntu-latest
@@ -304,6 +209,10 @@ jobs:
     needs:
       - validate-helm-chart
       - build-publish-container-images
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -311,23 +220,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # Go is needed to get the VERSION in the Makefile which is used in the Helm packaging
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: false
-
-      - name: Restore Go cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
 
       - name: Login to ghcr.io
         uses: docker/login-action@v4
@@ -343,47 +239,3 @@ jobs:
 
       - name: Package and publish the Helm chart
         run: make helm-publish
-
-  release-notes:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs:
-      - package-publish-helm-chart
-      - build-embedded-binaries
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Download embedded amd64 binary
-        uses: actions/download-artifact@v8
-        with:
-          name: tinkerbell-embedded-linux-amd64
-          path: ./out
-          merge-multiple: true
-
-      - name: Download embedded arm64 binary
-        uses: actions/download-artifact@v8
-        with:
-          name: tinkerbell-embedded-linux-arm64
-          path: ./out
-          merge-multiple: true
-
-      # Artifact upload doesn't preserve permissions so we need to fix them.
-      - name: Fix permissions
-        run: chmod +x out/tinkerbell-*
-
-      - name: Generate checksums
-        run: cd out && sha256sum tinkerbell-embedded-linux-amd64 tinkerbell-embedded-linux-arm64 > checksums-embedded.txt
-
-      - name: Publish Changelog to GitHub
-        uses: ncipollo/release-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifactErrorsFailBuild: true
-          generateReleaseNotes: true
-          draft: true
-          prerelease: true
-          artifacts: "out/tinkerbell-embedded-linux-*,out/checksums-embedded.txt"

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+junit.xml
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
@@ -26,6 +27,8 @@ go.work.sum
 
 # local binaries
 out/
+bin/
+dist/
 /tinkerbell
 
 # Go coverage profile
@@ -49,3 +52,6 @@ ui/node_modules/
 ui/out/
 .DS_Store
 Thumbs.db
+
+# Github
+.github/instructions/*.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,133 @@
+version: 2
+
+env:
+  - REGISTRY={{ envOrDefault "REGISTRY" "ghcr.io" }}
+  - IS_RELEASE={{ envOrDefault "IS_RELEASE" "false" }}
+
+git:
+  ignore_tags:
+    - api/v*
+    - legacy-tink-v*
+
+builds:
+  - id: tinkerbell
+    env: ["CGO_ENABLED=0"]
+    main: ./cmd/tinkerbell
+    binary: tinkerbell
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    no_unique_dist_dir: false
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+    skip: false
+
+  - id: tinkerbell-embedded
+    env: ["CGO_ENABLED=0"]
+    main: ./cmd/tinkerbell
+    binary: tinkerbell-embedded
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - embedded
+    no_unique_dist_dir: false
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+    skip: false
+
+  - id: tink-agent
+    env: ["CGO_ENABLED=0"]
+    main: ./cmd/agent
+    binary: tink-agent
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    no_unique_dist_dir: false
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+    skip: false
+
+upx:
+  - enabled: true
+    ids:
+      - tinkerbell
+      - tinkerbell-embedded
+      - tink-agent
+    compress: best
+    lzma: true
+
+checksum:
+  name_template: "{{ .ArtifactName }}-checksums.txt"
+  split: true
+
+release:
+  disable: true
+
+snapshot:
+  version_template: "{{ .Version }}-next"
+
+changelog:
+  disable: '{{ if eq .Env.IS_RELEASE "true" }}false{{ else }}true{{ end }}'
+
+dockers_v2:
+  - id: tinkerbell
+    dockerfile: Dockerfile.tinkerbell
+    images:
+      - '{{ .Env.REGISTRY }}/{{ envOrDefault "IMAGE_NAME" (trimsuffix (trimprefix .GitURL "https://github.com/") ".git") }}'
+    tags:
+      - '{{ if eq .Env.IS_RELEASE "true" }}v{{ .Version }}{{ end }}'
+      - "{{ if .IsNightly }}edge{{ end }}"
+      - "{{ if not .IsNightly }}latest{{ end }}"
+      - '{{ if eq .Branch "main" }}sha-{{ .ShortCommit }}{{ end }}'
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.name": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "v{{.Version}}"
+      "org.opencontainers.image.source": "{{.GitURL}}"
+
+  - id: tinkerbell-embedded
+    dockerfile: Dockerfile.tinkerbell
+    build_args:
+      BINARY: tinkerbell-embedded
+    images:
+      - '{{ .Env.REGISTRY }}/{{ envOrDefault "IMAGE_NAME" (trimsuffix (trimprefix .GitURL "https://github.com/") ".git") }}'
+    tags:
+      - '{{ if eq .Env.IS_RELEASE "true" }}v{{ .Version }}-embedded{{ end }}'
+      - "{{ if .IsNightly }}edge{{ else }}latest{{ end }}-embedded"
+      - '{{ if eq .Branch "main" }}embedded-sha-{{ .ShortCommit }}{{ end }}'
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.name": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "v{{.Version}}-embedded"
+      "org.opencontainers.image.source": "{{.GitURL}}"
+
+  - id: tink-agent
+    dockerfile: Dockerfile.agent
+    images:
+      - '{{ .Env.REGISTRY }}/{{ trimsuffix (envOrDefault "IMAGE_NAME" (trimsuffix (trimprefix .GitURL "https://github.com/") ".git")) .ProjectName }}tink-agent'
+    tags:
+      - '{{ if eq .Env.IS_RELEASE "true" }}v{{ .Version }}{{ end }}'
+      - "{{ if .IsNightly }}edge{{ else }}latest{{ end }}"
+      - '{{ if eq .Branch "main" }}sha-{{ .ShortCommit }}{{ end }}'
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.name": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "v{{.Version}}"
+      "org.opencontainers.image.source": "{{.GitURL}}"
+
+docker_signs:
+  - cmd: cosign
+    args:
+      - "sign"
+      - "--yes"
+      - "${artifact}@${digest}"

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -7,6 +7,6 @@ FROM scratch
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY out/tink-agent-${TARGETOS}-${TARGETARCH} /tink-agent
+COPY ${TARGETOS}/${TARGETARCH}/tink-agent /tink-agent
 COPY --from=ca-certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT [ "/tink-agent" ]

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ ifeq ($(LOCAL_ARCH),x86_64)
 else ifeq ($(LOCAL_ARCH),aarch64)
 	LOCAL_ARCH_ALT := arm64
 endif
-HELM_REPO_NAME ?= ghcr.io/tinkerbell/charts
+GITHUB_REPOSITORY_OWNER ?= tinkerbell
+HELM_REPO_NAME ?= ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts
 
 ########### Tools variables ###########
 # Tool versions
@@ -47,6 +48,15 @@ PROTOC_GEN_GO_VER      := v1.36.7 # must be in sync with the version in buf.gen.
 UPX_VER 			   := 4.2.4
 GODEPGRAPH_VER 	       := v0.0.0-20240411160502-0f324ca7e282
 GOLANGCI_LINT_VERSION  := v2.11.2
+
+GORELEASER_VER := v2.12.2
+GORELEASER_BIN := goreleaser
+
+# Directories.
+TOOLS_BIN_DIR := $(abspath bin)
+
+# goreleaser binary (versioned)
+GORELEASER := $(TOOLS_BIN_DIR)/$(GORELEASER_BIN)-$(GORELEASER_VER)
 
 
 # Tool fully qualified paths (FQP)
@@ -70,8 +80,14 @@ all: help
 help: ## Print this help
 	@grep --no-filename -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/:.*##/·/' | sort | column -ts '·' -c 120
 
-build: out/tinkerbell ## Build the Tinkerbell binary
+build: $(GORELEASER) ## Build the Tinkerbell and Tink Agent binaries using GoReleaser
+	$(GORELEASER) build --clean --auto-snapshot
+
 build-agent: out/tink-agent ## Build the Tink Agent binary
+
+.PHONY: cross-compile
+cross-compile: $(GORELEASER) ## Compile for all architectures via GoReleaser
+	$(GORELEASER) build --clean --auto-snapshot
 
 TEST_PKG ?=
 TEST_PKGS :=
@@ -223,7 +239,7 @@ prepare-buildx: ## Prepare the buildx environment.
 	docker buildx create --name tinkerbell-multiarch --use --driver docker-container || true
 
 .PHONY: image
-image: cross-compile ## Build the Tinkerbell container image
+image: cross-compile ## Build the Tinkerbell container image (local)
 	docker build -t $(IMAGE_NAME) -f Dockerfile.tinkerbell .
 
 .PHONY: build-push-image
@@ -231,18 +247,27 @@ build-push-image: ## Build and push the container image for both Amd64 and Arm64
 	docker buildx build --platform linux/amd64,linux/arm64 --push -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest -f Dockerfile.tinkerbell .
 
 .PHONY: image-agent
-image-agent: cross-compile-agent ## Build the Tink Agent container image
+image-agent: cross-compile-agent ## Build the Tink Agent container image (local)
 	docker build -t $(IMAGE_NAME_AGENT) -f Dockerfile.agent .
 
 .PHONY: build-push-image-agent
 build-push-image-agent: ## Build and push the container image for both Amd64 and Arm64 architectures.
 	docker buildx build --platform linux/amd64,linux/arm64 --push -t $(IMAGE_NAME_AGENT):$(VERSION) -t $(IMAGE_NAME_AGENT):latest -f Dockerfile.agent .
 
+.PHONY: build-image
+build-image: $(GORELEASER) ## Build container images using GoReleaser (requires Docker daemon)
+	$(GORELEASER) release --clean --skip=validate --skip=sign --auto-snapshot
+
+.PHONY: build-image-push
+build-image-push: $(GORELEASER) ## Build and push container images using GoReleaser
+	$(GORELEASER) release --clean --skip=validate --skip=sign ${GORELEASER_EXTRA_FLAGS}
+
 ######### Build container images - end   #########
 
 .PHONY: clean
 clean: ## Remove all cross compiled Tinkerbell binaries
 	rm -f out/tinkerbell out/tinkerbell-linux-amd64 out/tinkerbell-linux-arm64
+	rm -rf dist
 
 .PHONY: clean-agent
 clean-agent: ## Remove all cross compiled Tink Agent binaries
@@ -288,7 +313,12 @@ $(GODEPGRAPH_FQP):
 	@mv $(TOOLS_DIR)/godepgraph $(GODEPGRAPH_FQP)
 
 .PHONY: tools
-tools: $(GOIMPORTS_FQP) $(CONTROLLER_GEN_FQP) $(PROTOC_GEN_GO_GRPC_FQP) $(PROTOC_GEN_GO_FQP) $(BUF_FQP) $(UPX_FQP) $(GODEPGRAPH_FQP) ## Install all tools
+tools: $(GOIMPORTS_FQP) $(CONTROLLER_GEN_FQP) $(PROTOC_GEN_GO_GRPC_FQP) $(PROTOC_GEN_GO_FQP) $(BUF_FQP) $(UPX_FQP) $(GODEPGRAPH_FQP) $(GORELEASER) ## Install all tools
+
+$(GORELEASER):
+	mkdir -p $(TOOLS_BIN_DIR)
+	GOBIN=$(TOOLS_BIN_DIR) go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VER)
+	@mv $(TOOLS_BIN_DIR)/goreleaser $(GORELEASER)
 
 ############## Linting ##############
 .PHONY: lint


### PR DESCRIPTION
## Description

Migrate the build pipeline to [GoReleaser](https://goreleaser.com/) for unified, reproducible binary and container image builds across all platforms.

**This PR has been scoped down** based on reviewer feedback. The original changes have been split into three focused PRs:

| PR | Scope |
|----|-------|
| **This PR (#549)** | GoReleaser build system (`.goreleaser.yaml`, CI workflow, Makefile build targets, Dockerfile paths) |
| [#682](https://github.com/tinkerbell/tinkerbell/pull/682) | Move tooling to `go.mod` tool directives; unify formatting with `golangci-lint` |
| [#683](https://github.com/tinkerbell/tinkerbell/pull/683) | Static/distroless Docker images with compiled ipmitool |

---

### Changes in this PR

**`.goreleaser.yaml`** (new)
- Build `tinkerbell`, `tinkerbell-embedded` (build tag: `embedded`), and `tink-agent` for `linux/amd64` and `linux/arm64` with `CGO_ENABLED=0`.
- UPX compression (`best+lzma`) for all binaries.
- Per-artifact checksums.
- Docker images built from `Dockerfile.tinkerbell` / `Dockerfile.agent` with OCI labels.
- Branch-aware tagging: `v{{ .Version }}` on tags, `sha-{{ .ShortCommit }}` on main, `edge` for nightly.
- Cosign image signing (`docker_signs`).
- `git.ignore_tags` filters `api/v*` and `legacy-tink-v*` tags.
- `release.disable: true` — GoReleaser handles the full release when `IS_RELEASE=true`.

**`Makefile`**
- Add `GORELEASER_VER`, `GORELEASER` binary path (`bin/goreleaser-<ver>`).
- Add `GITHUB_REPOSITORY_OWNER` variable so forks publish charts to their own registry.
- Replace `build: out/tinkerbell` with `goreleaser build --auto-snapshot`.
- Add `cross-compile` alias for backward compatibility.
- Add `build-image` and `build-image-push` targets using GoReleaser.
- **Preserve** `image`, `image-agent`, `prepare-buildx`, `build-push-image*` targets for local Docker builds without a registry push (addresses reviewer concern about losing local image builds).
- Add `$(GORELEASER)` install recipe alongside existing tools.
- Update `clean` to also remove `dist/`.
- Remove `GIT_TAG` block — GoReleaser derives the version from git tags.

**`.github/workflows/ci.yaml`**
- **Fixes reviewer concern**: Build job now runs on **all PRs**, not just `main`/tags.
  - On PRs: `goreleaser build` (compiles binaries, no Docker push)
  - On `main`: `goreleaser release --skip=validate` (builds + pushes images)
  - On tags: `goreleaser release` (full release with changelog + signing)
- Docker login, QEMU, Buildx, Cosign only installed when actually pushing.
- Remove `build-binaries` matrix job, manual artifact upload/download, and `release-notes` job.
- Add `generate` job to verify code generation is up-to-date on every PR.
- Upload GoReleaser `dist/` artifacts for inspection.

**`Dockerfile.agent`**
- Update `COPY` path from `out/tink-agent-${TARGETOS}-${TARGETARCH}` to `${TARGETOS}/${TARGETARCH}/tink-agent` to match GoReleaser `dist/` layout.

**`.github/mergify.yml`**
- Update check-success conditions to reference new CI job names (`build-publish-container-images`, `generate`).

**`.gitignore`**
- Add `bin/`, `dist/`, `junit.xml`.

---

### Addressing reviewer comments

| Comment | Response |
|---------|----------|
| "Build job only runs on main and tags — need early error detection on PRs" | Fixed: `build-publish-container-images` now runs on all PRs. On PRs it runs `goreleaser build` (binaries only), so compilation is validated before merging. |
| "We are losing local image builds" | Fixed: `make image` and `make image-agent` (direct `docker build`) are preserved alongside the new `make build-image` (GoReleaser). |
| "Not using `make` targets in CI" | Fixed: `generate` job uses `make generate`. |
| "`-X main.version={{.Version}} -X main.commit=...`" | These ldflags are required by GoReleaser for SBOM generation and Cosign signing metadata. They complement `pkg/build` — GoReleaser injects the actual version at release time. |
| "`api/go.mod` must be its own module" | Reverted: `api/go.mod` is untouched in this PR. |

---

## How Has This Been Tested?

- `goreleaser build --clean --auto-snapshot` builds binaries for both `amd64` and `arm64`.
- `goreleaser release --clean --skip=validate --skip=sign --auto-snapshot` builds Docker images locally.
- `make build` and `make cross-compile` work as expected.

## Checklist

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade