### PR TITLE
Add configurable MaxConcurrentReconciles to all controllers

### DIFF
--- a/cmd/tinkerbell/flag/rufio.go
+++ b/cmd/tinkerbell/flag/rufio.go
@@ -18,6 +18,7 @@ func RegisterRufioFlags(fs *Set, t *RufioConfig) {
 	fs.Register(RufioControllerProbeAddr, &netip.AddrPort{AddrPort: &t.Config.ProbeAddr})
 	fs.Register(RufioBMCConnectTimeout, ffval.NewValueDefault(&t.Config.BMCConnectTimeout, t.Config.BMCConnectTimeout))
 	fs.Register(RufioPowerCheckInterval, ffval.NewValueDefault(&t.Config.PowerCheckInterval, t.Config.PowerCheckInterval))
+	fs.Register(RufioMaxConcurrentReconciles, ffval.NewValueDefault(&t.Config.MaxConcurrentReconciles, t.Config.MaxConcurrentReconciles))
 	fs.Register(RufioLogLevel, ffval.NewValueDefault(&t.LogLevel, t.LogLevel))
 }
 
@@ -54,4 +55,9 @@ var RufioPowerCheckInterval = Config{
 var RufioLogLevel = Config{
 	Name:  "rufio-log-level",
 	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
+}
+
+var RufioMaxConcurrentReconciles = Config{
+	Name:  "rufio-max-concurrent-reconciles",
+	Usage: "maximum number of concurrent reconciles for rufio controllers",
 }

--- a/cmd/tinkerbell/flag/tink_controller.go
+++ b/cmd/tinkerbell/flag/tink_controller.go
@@ -17,6 +17,7 @@ func RegisterTinkControllerFlags(fs *Set, t *TinkControllerConfig) {
 	fs.Register(TinkControllerLeaderElectionNamespace, ffval.NewValueDefault(&t.Config.LeaderElectionNamespace, t.Config.LeaderElectionNamespace))
 	fs.Register(TinkControllerMetricsAddr, &netip.AddrPort{AddrPort: &t.Config.MetricsAddr})
 	fs.Register(TinkControllerProbeAddr, &netip.AddrPort{AddrPort: &t.Config.ProbeAddr})
+	fs.Register(TinkControllerMaxConcurrentReconciles, ffval.NewValueDefault(&t.Config.MaxConcurrentReconciles, t.Config.MaxConcurrentReconciles))
 	fs.Register(TinkControllerLogLevel, ffval.NewValueDefault(&t.LogLevel, t.LogLevel))
 	fs.Register(TinkControllerReferenceAllowListRules, delimitedlist.New(&t.Config.ReferenceAllowListRules, '|'))
 	fs.Register(TinkControllerReferenceDenyListRules, delimitedlist.New(&t.Config.ReferenceDenyListRules, '|'))
@@ -55,4 +56,9 @@ var TinkControllerReferenceAllowListRules = Config{
 var TinkControllerReferenceDenyListRules = Config{
 	Name:  "tink-controller-reference-deny-list-rules",
 	Usage: "rules for which Hardware Reference objects are not accessible to Templates, defaults to deny all",
+}
+
+var TinkControllerMaxConcurrentReconciles = Config{
+	Name:  "tink-controller-max-concurrent-reconciles",
+	Usage: "maximum number of concurrent reconciles for tink controller",
 }

--- a/helm/tinkerbell/templates/deployment.yaml
+++ b/helm/tinkerbell/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: {{ .Values.deployment.envs.rufio.bmcConnectTimeout | quote }}
             - name: TINKERBELL_RUFIO_POWER_CHECK_INTERVAL
               value: {{ .Values.deployment.envs.rufio.powerCheckInterval | quote }}
+            - name: TINKERBELL_RUFIO_MAX_CONCURRENT_RECONCILES
+              value: {{ .Values.deployment.envs.rufio.maxConcurrentReconciles | quote }}
           # TINK CONTROLLER
             - name: TINKERBELL_TINK_CONTROLLER_ENABLE_LEADER_ELECTION
               value: {{ .Values.deployment.envs.tinkController.enableLeaderElection | quote }}
@@ -80,6 +82,8 @@ spec:
               value: {{ .Values.deployment.envs.tinkController.metricsAddr | quote }}
             - name: TINKERBELL_TINK_CONTROLLER_PROBE_ADDR
               value: {{ .Values.deployment.envs.tinkController.probeAddr | quote }}
+            - name: TINKERBELL_TINK_CONTROLLER_MAX_CONCURRENT_RECONCILES
+              value: {{ .Values.deployment.envs.tinkController.maxConcurrentReconciles | quote }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_ALLOW_LIST_RULES
             {{- if .Values.deployment.envs.tinkController.referenceAllowListRules }}
               value: {{ .Values.deployment.envs.tinkController.referenceAllowListRules | toJson | quote }}

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -47,6 +47,7 @@ deployment:
       leaderElectionNamespace: ""
       logLevel: 0
       metricsAddr: ""
+      maxConcurrentReconciles: 1
       powerCheckInterval: "30m0s"
       probeAddr: ""
     secondstar:
@@ -108,6 +109,7 @@ deployment:
       leaderElectionNamespace: ""
       logLevel: 0
       metricsAddr: ""
+      maxConcurrentReconciles: 1
       probeAddr: ""
       referenceAllowListRules: {}
       referenceDenyListRules: {}

--- a/rufio/internal/controller/job.go
+++ b/rufio/internal/controller/job.go
@@ -27,6 +27,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
@@ -223,7 +224,7 @@ func (r *JobReconciler) patchStatus(ctx context.Context, job *bmc.Job, patch cli
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *JobReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *JobReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opts ctrlcontroller.Options) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&bmc.Task{},
@@ -234,6 +235,7 @@ func (r *JobReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&bmc.Job{}).
 		Watches(
 			&bmc.Task{},

--- a/rufio/internal/controller/machine.go
+++ b/rufio/internal/controller/machine.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // MachineReconciler reconciles a Machine object.
@@ -218,8 +219,9 @@ func retrieveHMACSecrets(ctx context.Context, c client.Client, hmacSecrets bmc.H
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager, opts ctrlcontroller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&bmc.Machine{}).
 		Complete(r)
 }

--- a/rufio/internal/controller/task.go
+++ b/rufio/internal/controller/task.go
@@ -27,6 +27,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 const powerActionRequeueAfter = 3 * time.Second
@@ -293,8 +294,9 @@ func (r *TaskReconciler) patchStatus(ctx context.Context, task *bmc.Task, patch 
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *TaskReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *TaskReconciler) SetupWithManager(mgr ctrl.Manager, opts ctrlcontroller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&bmc.Task{}).
 		Complete(r)
 }

--- a/rufio/rufio.go
+++ b/rufio/rufio.go
@@ -39,6 +39,7 @@ type Config struct {
 	ProbeAddr               netip.AddrPort
 	BMCConnectTimeout       time.Duration
 	PowerCheckInterval      time.Duration
+	MaxConcurrentReconciles int
 }
 
 type Option func(*Config)
@@ -93,7 +94,8 @@ func WithLeaderElectionNamespace(namespace string) Option {
 
 func NewConfig(opts ...Option) *Config {
 	defaults := &Config{
-		EnableLeaderElection: true,
+		EnableLeaderElection:    true,
+		MaxConcurrentReconciles: 1,
 	}
 
 	for _, opt := range opts {
@@ -121,7 +123,7 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 	controllerruntime.SetLogger(log)
 	clog.SetLogger(log)
 
-	mgr, err := controller.NewManager(c.Client, options, c.PowerCheckInterval)
+	mgr, err := controller.NewManager(c.Client, options, c.PowerCheckInterval, c.MaxConcurrentReconciles)
 	if err != nil {
 		return err
 	}

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -93,9 +94,10 @@ func NewReconciler(client ctrlclient.Client, dc dynamicClient, opts ...Option) *
 	return d
 }
 
-func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr manager.Manager, opts controller.Options) error {
 	return ctrl.
 		NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&v1alpha1.Workflow{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Description
Add MaxConcurrentReconciles config option to rufio and tink controllers with CLI flags for runtime configuration. Defaults to 1.

<!--- Please describe what this PR is going to change -->

Fixes: #
Forward port the https://github.com/tinkerbell/rufio/pull/312/changes to mono-repo and extend the idea to tink-controllers.. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
