### PR TITLE
Add DNS configuration for containerd runtime:

### DIFF
--- a/tink/agent/internal/runtime/containerd/dns.go
+++ b/tink/agent/internal/runtime/containerd/dns.go
@@ -1,0 +1,294 @@
+package containerd
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	// resolvConfPath is the default host resolv.conf path.
+	resolvConfPath = "/etc/resolv.conf"
+	// systemdResolvedPath is the systemd-resolved upstream resolv.conf.
+	// When the host uses systemd-resolved, its /etc/resolv.conf points to
+	// 127.0.0.53 which is not reachable from a container network namespace.
+	// In that case we read the upstream resolv.conf instead.
+	systemdResolvedPath = "/run/systemd/resolve/resolv.conf"
+)
+
+// fallbackNameservers are used when the host has no reachable nameservers
+// (e.g. all are localhost and we're in an isolated network namespace, or
+// /etc/resolv.conf is unreadable). Google Public DNS, IPv4 and IPv6.
+var fallbackNameservers = []string{"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888", "2001:4860:4860::8844"}
+
+// truncateHostname returns the first 12 characters of id, matching the
+// nerdctl/Docker convention for deriving a short hostname from a container ID.
+func truncateHostname(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}
+
+// dnsFiles holds paths to generated DNS configuration files that should be
+// bind-mounted into a container. The caller is responsible for cleaning up
+// the directory after the container exits.
+type dnsFiles struct {
+	dir        string
+	resolvConf string
+	hosts      string
+	hostname   string
+}
+
+// cleanup removes all generated DNS files.
+func (d *dnsFiles) cleanup() error {
+	if d == nil || d.dir == "" {
+		return nil
+	}
+	return os.RemoveAll(d.dir)
+}
+
+// prepareDNSFiles creates the temp directory and writes resolv.conf. The hosts
+// and hostname files are created as empty placeholders so the bind-mount paths
+// exist at container creation time. Call setHostname after the container is
+// created to populate them with the container's hostname.
+//
+// allowLocalhostDNS should be true for host-network containers where
+// localhost resolvers (e.g. systemd-resolved on 127.0.0.53) are reachable.
+func prepareDNSFiles(allowLocalhostDNS bool) (*dnsFiles, error) {
+	dir, err := os.MkdirTemp("", "tink-dns-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DNS temp dir: %w", err)
+	}
+
+	df := &dnsFiles{dir: dir}
+
+	// Build resolv.conf — this doesn't depend on the container ID.
+	df.resolvConf = filepath.Join(dir, "resolv.conf")
+	if err := buildResolvConf(df.resolvConf, allowLocalhostDNS); err != nil {
+		_ = df.cleanup()
+		return nil, fmt.Errorf("failed to build resolv.conf: %w", err)
+	}
+
+	// Create empty placeholder files for hosts and hostname so the bind-mount
+	// source paths exist when the container spec is applied. The actual content
+	// is written by setHostname() after the container is created.
+	df.hosts = filepath.Join(dir, "hosts")
+	if err := os.WriteFile(df.hosts, []byte{}, 0o644); err != nil { //nolint:gosec // G306: DNS files must be world-readable inside the container
+		_ = df.cleanup()
+		return nil, fmt.Errorf("failed to create hosts placeholder: %w", err)
+	}
+
+	df.hostname = filepath.Join(dir, "hostname")
+	if err := os.WriteFile(df.hostname, []byte{}, 0o644); err != nil { //nolint:gosec // G306: DNS files must be world-readable inside the container
+		_ = df.cleanup()
+		return nil, fmt.Errorf("failed to create hostname placeholder: %w", err)
+	}
+
+	return df, nil
+}
+
+// setHostname populates the hosts and hostname files. For host-network
+// containers (useHostNetwork=true), the full hostname is used without
+// truncation and the host's /etc/hosts is copied so the container behaves
+// like a host process. For isolated-network containers, the hostname is
+// truncated to 12 characters (matching nerdctl/Docker convention) and a
+// minimal hosts file is generated.
+func (d *dnsFiles) setHostname(name string, useHostNetwork bool) error {
+	if d == nil {
+		return nil
+	}
+
+	if useHostNetwork {
+		return d.setHostnameHost(name)
+	}
+	return d.setHostnameIsolated(name)
+}
+
+// setHostnameHost populates DNS files for host-network containers. The host's
+// /etc/hosts is copied directly and the full hostname is used without truncation.
+func (d *dnsFiles) setHostnameHost(name string) error {
+	// Copy the host's /etc/hosts so the container sees the same entries.
+	hostContent, err := os.ReadFile("/etc/hosts")
+	if err != nil {
+		// Fall back to generating a hosts file if we can't read the host's.
+		if err := buildHosts(d.hosts, name); err != nil {
+			return fmt.Errorf("failed to write hosts: %w", err)
+		}
+	} else {
+		if err := os.WriteFile(d.hosts, hostContent, 0o644); err != nil { //nolint:gosec // G306: DNS files must be world-readable inside the container
+			return fmt.Errorf("failed to copy host /etc/hosts: %w", err)
+		}
+	}
+	// Use the full hostname without truncation.
+	if err := os.WriteFile(d.hostname, []byte(name+"\n"), 0o644); err != nil { //nolint:gosec // G306: DNS files must be world-readable inside the container
+		return fmt.Errorf("failed to write hostname: %w", err)
+	}
+	return nil
+}
+
+// setHostnameIsolated populates DNS files for isolated-network containers.
+// The hostname is truncated to 12 characters (matching nerdctl/Docker convention).
+func (d *dnsFiles) setHostnameIsolated(name string) error {
+	if err := buildHosts(d.hosts, truncateHostname(name)); err != nil {
+		return fmt.Errorf("failed to write hosts: %w", err)
+	}
+	if err := os.WriteFile(d.hostname, []byte(truncateHostname(name)+"\n"), 0o644); err != nil { //nolint:gosec // G306: DNS files must be world-readable inside the container
+		return fmt.Errorf("failed to write hostname: %w", err)
+	}
+	return nil
+}
+
+// dnsSpecOpts returns OCI spec options that bind-mount the generated DNS
+// files into the container.
+func dnsSpecOpts(df *dnsFiles) []oci.SpecOpts {
+	return []oci.SpecOpts{
+		withBindMount(df.resolvConf, "/etc/resolv.conf"),
+		withBindMount(df.hosts, "/etc/hosts"),
+		withBindMount(df.hostname, "/etc/hostname"),
+	}
+}
+
+// withBindMount returns an OCI spec option that adds a bind mount.
+func withBindMount(src, dest string) oci.SpecOpts {
+	return oci.WithMounts([]specs.Mount{
+		{
+			Destination: dest,
+			Type:        "bind",
+			Source:      src,
+			Options:     []string{"bind", "rprivate", "rw"},
+		},
+	})
+}
+
+// buildResolvConf reads the host's resolv.conf and writes a container-safe
+// resolv.conf to dst. When allowLocalhostDNS is false, localhost nameservers
+// are filtered out (they are unreachable from an isolated network namespace)
+// and public DNS fallbacks are substituted if no nameservers remain.
+// When allowLocalhostDNS is true (host-network mode), localhost nameservers
+// are preserved since they are reachable from the host network namespace.
+func buildResolvConf(dst string, allowLocalhostDNS bool) error {
+	hostResolvConf := resolvConfPath
+
+	// Detect systemd-resolved: if /etc/resolv.conf points to 127.0.0.53,
+	// and we are filtering localhost, read the upstream config instead.
+	if !allowLocalhostDNS {
+		if content, err := os.ReadFile(resolvConfPath); err == nil {
+			for _, ns := range parseNameservers(string(content)) {
+				if ns == "127.0.0.53" {
+					if _, err := os.Stat(systemdResolvedPath); err == nil {
+						hostResolvConf = systemdResolvedPath
+					}
+					break
+				}
+			}
+		}
+	}
+
+	content, err := os.ReadFile(hostResolvConf)
+	if err != nil {
+		// If we can't read any resolv.conf, write a minimal one with public DNS.
+		return writeResolvConf(dst, fallbackNameservers, nil, nil)
+	}
+
+	nameservers, searchDomains, options := parseResolvConf(string(content))
+
+	if !allowLocalhostDNS {
+		// Filter out localhost nameservers — they are unreachable from a
+		// container's isolated network namespace.
+		var filtered []string
+		for _, ns := range nameservers {
+			if isLocalhost(ns) {
+				continue
+			}
+			filtered = append(filtered, ns)
+		}
+
+		// If all nameservers were localhost, fall back to public DNS.
+		if len(filtered) == 0 {
+			filtered = fallbackNameservers
+		}
+		nameservers = filtered
+	}
+
+	return writeResolvConf(dst, nameservers, searchDomains, options)
+}
+
+// parseResolvConf extracts nameservers, search domains, and options from
+// resolv.conf content.
+func parseResolvConf(content string) (nameservers, searchDomains, options []string) {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "nameserver":
+			nameservers = append(nameservers, fields[1])
+		case "search":
+			searchDomains = append(searchDomains, fields[1:]...)
+		case "options":
+			options = append(options, fields[1:]...)
+		}
+	}
+	return nameservers, searchDomains, options
+}
+
+// parseNameservers is a quick helper that extracts just the nameservers.
+func parseNameservers(content string) []string {
+	ns, _, _ := parseResolvConf(content)
+	return ns
+}
+
+// isLocalhost returns true if the IP string is a loopback address.
+func isLocalhost(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return parsed.IsLoopback()
+}
+
+// writeResolvConf writes a resolv.conf file with the given parameters.
+func writeResolvConf(path string, nameservers, searchDomains, options []string) error {
+	var b strings.Builder
+	b.WriteString("# Generated by tink-agent for container DNS\n")
+	if len(searchDomains) > 0 {
+		b.WriteString("search " + strings.Join(searchDomains, " ") + "\n")
+	}
+	for _, ns := range nameservers {
+		b.WriteString("nameserver " + ns + "\n")
+	}
+	if len(options) > 0 {
+		b.WriteString("options " + strings.Join(options, " ") + "\n")
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644) //nolint:gosec // G306: resolv.conf must be world-readable inside the container
+}
+
+// buildHosts writes a minimal /etc/hosts with localhost entries and the
+// given hostname mapped to its loopback address. The caller is responsible
+// for any hostname truncation before calling this function.
+func buildHosts(dst, hostname string) error {
+	var b strings.Builder
+	b.WriteString("# Generated by tink-agent\n")
+	b.WriteString("127.0.0.1\tlocalhost\n")
+	b.WriteString("::1\t\tlocalhost ip6-localhost ip6-loopback\n")
+	b.WriteString("fe00::0\t\tip6-localnet\n")
+	b.WriteString("ff00::0\t\tip6-mcastprefix\n")
+	b.WriteString("ff02::1\t\tip6-allnodes\n")
+	b.WriteString("ff02::2\t\tip6-allrouters\n")
+	b.WriteString("127.0.0.1\t" + hostname + "\n")
+	b.WriteString("::1\t\t" + hostname + "\n")
+	return os.WriteFile(dst, []byte(b.String()), 0o644) //nolint:gosec // G306: hosts file must be world-readable inside the container
+}

--- a/tink/agent/internal/runtime/containerd/dns_test.go
+++ b/tink/agent/internal/runtime/containerd/dns_test.go
@@ -1,0 +1,331 @@
+package containerd
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParseResolvConf(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantNS     []string
+		wantSearch []string
+		wantOpts   []string
+	}{
+		{
+			name: "standard resolv.conf",
+			content: `nameserver 8.8.8.8
+nameserver 8.8.4.4
+search example.com corp.example.com
+options ndots:5 timeout:2
+`,
+			wantNS:     []string{"8.8.8.8", "8.8.4.4"},
+			wantSearch: []string{"example.com", "corp.example.com"},
+			wantOpts:   []string{"ndots:5", "timeout:2"},
+		},
+		{
+			name: "with comments and empty lines",
+			content: `# This is a comment
+; Another comment
+
+nameserver 10.0.0.1
+search local
+`,
+			wantNS:     []string{"10.0.0.1"},
+			wantSearch: []string{"local"},
+			wantOpts:   nil,
+		},
+		{
+			name: "systemd-resolved",
+			content: `nameserver 127.0.0.53
+options edns0 trust-ad
+search .
+`,
+			wantNS:     []string{"127.0.0.53"},
+			wantSearch: []string{"."},
+			wantOpts:   []string{"edns0", "trust-ad"},
+		},
+		{
+			name:       "empty",
+			content:    "",
+			wantNS:     nil,
+			wantSearch: nil,
+			wantOpts:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, search, opts := parseResolvConf(tt.content)
+			if !slices.Equal(ns, tt.wantNS) {
+				t.Errorf("nameservers = %v, want %v", ns, tt.wantNS)
+			}
+			if !slices.Equal(search, tt.wantSearch) {
+				t.Errorf("search = %v, want %v", search, tt.wantSearch)
+			}
+			if !slices.Equal(opts, tt.wantOpts) {
+				t.Errorf("options = %v, want %v", opts, tt.wantOpts)
+			}
+		})
+	}
+}
+
+func TestIsLocalhost(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"127.0.0.53", true},
+		{"127.0.1.1", true},
+		{"::1", true},
+		{"8.8.8.8", false},
+		{"10.0.0.1", false},
+		{"192.168.1.1", false},
+		{"not-an-ip", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			got := isLocalhost(tt.ip)
+			if got != tt.want {
+				t.Errorf("isLocalhost(%q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildResolvConf(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "resolv.conf")
+
+	err := buildResolvConf(dst, false)
+	if err != nil {
+		t.Fatalf("buildResolvConf() error = %v", err)
+	}
+
+	content, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading generated resolv.conf: %v", err)
+	}
+
+	s := string(content)
+
+	// Verify it has at least one nameserver line
+	if !strings.Contains(s, "nameserver ") {
+		t.Error("generated resolv.conf has no nameserver lines")
+	}
+
+	// Verify no localhost nameservers
+	ns, _, _ := parseResolvConf(s)
+	for _, n := range ns {
+		if isLocalhost(n) {
+			t.Errorf("generated resolv.conf contains localhost nameserver: %s", n)
+		}
+	}
+}
+
+func TestBuildResolvConfAllowLocalhost(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "resolv.conf")
+
+	err := buildResolvConf(dst, true)
+	if err != nil {
+		t.Fatalf("buildResolvConf(allowLocalhostDNS=true) error = %v", err)
+	}
+
+	content, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading generated resolv.conf: %v", err)
+	}
+
+	s := string(content)
+
+	// Verify it has at least one nameserver line
+	if !strings.Contains(s, "nameserver ") {
+		t.Error("generated resolv.conf has no nameserver lines")
+	}
+}
+
+func TestWriteResolvConf(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "resolv.conf")
+
+	err := writeResolvConf(dst,
+		[]string{"1.1.1.1", "8.8.8.8"},
+		[]string{"example.com", "local"},
+		[]string{"ndots:5"},
+	)
+	if err != nil {
+		t.Fatalf("writeResolvConf() error = %v", err)
+	}
+
+	content, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "nameserver 1.1.1.1\n") {
+		t.Error("missing nameserver 1.1.1.1")
+	}
+	if !strings.Contains(s, "nameserver 8.8.8.8\n") {
+		t.Error("missing nameserver 8.8.8.8")
+	}
+	if !strings.Contains(s, "search example.com local\n") {
+		t.Error("missing search domains")
+	}
+	if !strings.Contains(s, "options ndots:5\n") {
+		t.Error("missing options")
+	}
+}
+
+func TestBuildHosts(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "hosts")
+
+	// buildHosts no longer truncates; callers pass the final hostname.
+	err := buildHosts(dst, "my-container")
+	if err != nil {
+		t.Fatalf("buildHosts() error = %v", err)
+	}
+
+	content, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "127.0.0.1\tlocalhost\n") {
+		t.Error("missing localhost entry")
+	}
+	if !strings.Contains(s, "::1\t\tlocalhost") {
+		t.Error("missing ipv6 localhost entry")
+	}
+	if !strings.Contains(s, "127.0.0.1\tmy-container\n") {
+		t.Errorf("missing or incorrect IPv4 hostname entry, got:\n%s", s)
+	}
+	if !strings.Contains(s, "::1\t\tmy-container\n") {
+		t.Errorf("missing or incorrect IPv6 hostname entry, got:\n%s", s)
+	}
+}
+
+func TestPrepareDNSFiles(t *testing.T) {
+	df, err := prepareDNSFiles(false)
+	if err != nil {
+		t.Fatalf("prepareDNSFiles() error = %v", err)
+	}
+	defer func() {
+		if err := df.cleanup(); err != nil {
+			t.Errorf("cleanup error: %v", err)
+		}
+	}()
+
+	// Verify all files exist
+	for _, f := range []string{df.resolvConf, df.hosts, df.hostname} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected file %s to exist: %v", f, err)
+		}
+	}
+
+	// Before setHostname, files should be empty placeholders
+	content, err := os.ReadFile(df.hosts)
+	if err != nil {
+		t.Fatalf("reading hosts: %v", err)
+	}
+	if len(content) != 0 {
+		t.Errorf("hosts should be empty before setHostname, got %q", string(content))
+	}
+
+	// After setHostname with isolated networking, hostname is truncated to 12 chars
+	if err := df.setHostname("test-container-id-12345", false); err != nil {
+		t.Fatalf("setHostname() error = %v", err)
+	}
+	hostContent, err := os.ReadFile(df.hostname)
+	if err != nil {
+		t.Fatalf("reading hostname: %v", err)
+	}
+	if got := strings.TrimSpace(string(hostContent)); got != "test-contain" {
+		t.Errorf("hostname = %q, want %q", got, "test-contain")
+	}
+}
+
+func TestSetHostnameHostNetwork(t *testing.T) {
+	df, err := prepareDNSFiles(true)
+	if err != nil {
+		t.Fatalf("prepareDNSFiles() error = %v", err)
+	}
+	defer func() { _ = df.cleanup() }()
+
+	// Host network mode: full hostname, no truncation
+	if err := df.setHostname("my-real-hostname", true); err != nil {
+		t.Fatalf("setHostname() error = %v", err)
+	}
+
+	// Hostname file should have the full hostname, not truncated
+	hostContent, err := os.ReadFile(df.hostname)
+	if err != nil {
+		t.Fatalf("reading hostname: %v", err)
+	}
+	if got := strings.TrimSpace(string(hostContent)); got != "my-real-hostname" {
+		t.Errorf("hostname = %q, want %q", got, "my-real-hostname")
+	}
+}
+
+func TestDNSFilesCleanup(t *testing.T) {
+	df, err := prepareDNSFiles(false)
+	if err != nil {
+		t.Fatalf("prepareDNSFiles() error = %v", err)
+	}
+
+	dir := df.dir
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("temp dir should exist: %v", err)
+	}
+
+	if err := df.cleanup(); err != nil {
+		t.Fatalf("cleanup() error = %v", err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("temp dir should have been removed after cleanup")
+	}
+}
+
+func TestDNSFilesCleanupNil(t *testing.T) {
+	// nil dnsFiles should be safe to call cleanup on
+	var df *dnsFiles
+	if err := df.cleanup(); err != nil {
+		t.Errorf("cleanup on nil dnsFiles should not error: %v", err)
+	}
+}
+
+func TestGenerateID(t *testing.T) {
+	id, err := generateID()
+	if err != nil {
+		t.Fatalf("generateID() error = %v", err)
+	}
+	// Should be 64 hex characters (32 bytes)
+	if len(id) != 64 {
+		t.Errorf("generateID() length = %d, want 64", len(id))
+	}
+	// Should be valid hex
+	for _, c := range id {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			t.Errorf("generateID() contains non-hex character: %c", c)
+		}
+	}
+	// Should be unique
+	id2, err := generateID()
+	if err != nil {
+		t.Fatalf("generateID() second call error = %v", err)
+	}
+	if id == id2 {
+		t.Error("generateID() should produce unique IDs")
+	}
+}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Containerd does not automatically mount /etc/resolv.conf, /etc/hosts,
or /etc/hostname into containers. Without these files, containers
cannot resolve DNS names, breaking workflows that need network access.
    
This adds a DNS file generation pipeline (modeled after nerdctl) that:
- Reads the host resolv.conf and detects systemd-resolved
- Filters localhost nameservers for isolated network namespaces
- Falls back to public DNS (Google IPv4 + IPv6) when needed
- Preserves localhost DNS for host-network containers
- Generates /etc/hosts with proper localhost and hostname entries
- Copies the host /etc/hosts for host-network mode
- Uses a random container ID (64-char hex) matching nerdctl convention
- Sets nerdctl labels for inspect/ps compatibility

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
