### PR TITLE
Set the klog use the structured logger:

### DIFF
--- a/rufio/rufio.go
+++ b/rufio/rufio.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/tinkerbell/tinkerbell/rufio/internal/controller"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -122,6 +123,7 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 
 	controllerruntime.SetLogger(log)
 	clog.SetLogger(log)
+	klog.SetLogger(log)
 
 	mgr, err := controller.NewManager(c.Client, options, c.PowerCheckInterval, c.MaxConcurrentReconciles)
 	if err != nil {

--- a/tink/controller/controller.go
+++ b/tink/controller/controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -129,6 +130,7 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 
 	controllerruntime.SetLogger(log)
 	clog.SetLogger(log)
+	klog.SetLogger(log)
 
 	wfOpts := []workflow.Option{}
 	if len(c.ReferenceAllowListRules) > 0 {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
There were some log lines that were not using the structured logger as all others do. This was coming from the client-go's leader election code.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
