### PR TITLE
Use existing log-level flag to disable logging:

### DIFF
--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -174,7 +174,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 		return e
 	}
 
-	log := getLogger(false, globals.LogLevel)
+	log := getLogger(globals.LogLevel)
 	cliLog := log.WithName("cli")
 	cliLog.Info("starting tinkerbell",
 		"version", build.GitRevision(),
@@ -364,7 +364,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			return nil
 		}
 		ll := ternary((s.LogLevel != 0), s.LogLevel, globals.LogLevel)
-		if err := s.Config.Start(ctx, getLogger(s.NoLog, ll).WithName("smee")); err != nil {
+		if err := s.Config.Start(ctx, getLogger(ll).WithName("smee")); err != nil {
 			return fmt.Errorf("failed to start smee service: %w", err)
 		}
 		return nil
@@ -377,7 +377,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			return nil
 		}
 		ll := ternary((h.LogLevel != 0), h.LogLevel, globals.LogLevel)
-		if err := h.Config.Start(ctx, getLogger(h.NoLog, ll).WithName("tootles")); err != nil {
+		if err := h.Config.Start(ctx, getLogger(ll).WithName("tootles")); err != nil {
 			return fmt.Errorf("failed to start tootles service: %w", err)
 		}
 		return nil
@@ -390,7 +390,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			return nil
 		}
 		ll := ternary((ts.LogLevel != 0), ts.LogLevel, globals.LogLevel)
-		if err := ts.Config.Start(ctx, getLogger(ts.NoLog, ll).WithName("tink-server")); err != nil {
+		if err := ts.Config.Start(ctx, getLogger(ll).WithName("tink-server")); err != nil {
 			return fmt.Errorf("failed to start tink server service: %w", err)
 		}
 		return nil
@@ -403,7 +403,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			return nil
 		}
 		ll := ternary((tc.LogLevel != 0), tc.LogLevel, globals.LogLevel)
-		if err := tc.Config.Start(ctx, getLogger(tc.NoLog, ll).WithName("tink-controller")); err != nil {
+		if err := tc.Config.Start(ctx, getLogger(ll).WithName("tink-controller")); err != nil {
 			return fmt.Errorf("failed to start tink controller service: %w", err)
 		}
 		return nil
@@ -416,7 +416,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			return nil
 		}
 		ll := ternary((rc.LogLevel != 0), rc.LogLevel, globals.LogLevel)
-		if err := rc.Config.Start(ctx, getLogger(rc.NoLog, ll).WithName("rufio")); err != nil {
+		if err := rc.Config.Start(ctx, getLogger(ll).WithName("rufio")); err != nil {
 			return fmt.Errorf("failed to start rufio service: %w", err)
 		}
 		return nil
@@ -429,7 +429,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			return nil
 		}
 		ll := ternary((ssc.LogLevel != 0), ssc.LogLevel, globals.LogLevel)
-		if err := ssc.Config.Start(ctx, getLogger(ssc.NoLog, ll).WithName("secondstar")); err != nil {
+		if err := ssc.Config.Start(ctx, getLogger(ll).WithName("secondstar")); err != nil {
 			return fmt.Errorf("failed to start secondstar service: %w", err)
 		}
 		return nil
@@ -442,7 +442,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 			return nil
 		}
 		ll := ternary((uic.LogLevel != 0), uic.LogLevel, globals.LogLevel)
-		if err := uic.Config.Start(ctx, getLogger(uic.NoLog, ll).WithName("ui")); err != nil {
+		if err := uic.Config.Start(ctx, getLogger(ll).WithName("ui")); err != nil {
 			return fmt.Errorf("failed to start ui service: %w", err)
 		}
 		return nil
@@ -514,9 +514,9 @@ func enabledIndexes(smeeEnabled, tootlesEnabled, tinkServerEnabled, secondStarEn
 }
 
 // getLogger returns a logger based on the configuration.
-// If noLog is true, returns a logger that discards all output.
-func getLogger(noLog bool, level int) logr.Logger {
-	if noLog {
+// If level is negative, returns a logger that discards all output.
+func getLogger(level int) logr.Logger {
+	if level < 0 {
 		return logr.Discard()
 	}
 	return defaultLogger(level)

--- a/cmd/tinkerbell/flag/global.go
+++ b/cmd/tinkerbell/flag/global.go
@@ -80,7 +80,7 @@ func RegisterEmbeddedGlobals(fs *Set, gc *GlobalConfig) {
 // are used to create objects that are used by multiple services.
 var LogLevelConfig = Config{
 	Name:  "log-level",
-	Usage: "the higher the number the more verbose",
+	Usage: "the higher the number the more verbose, a negative number disables logging",
 }
 
 // BackendConfig flags.

--- a/cmd/tinkerbell/flag/rufio.go
+++ b/cmd/tinkerbell/flag/rufio.go
@@ -9,7 +9,6 @@ import (
 type RufioConfig struct {
 	Config   *rufio.Config
 	LogLevel int
-	NoLog    bool
 }
 
 func RegisterRufioFlags(fs *Set, t *RufioConfig) {
@@ -21,7 +20,6 @@ func RegisterRufioFlags(fs *Set, t *RufioConfig) {
 	fs.Register(RufioPowerCheckInterval, ffval.NewValueDefault(&t.Config.PowerCheckInterval, t.Config.PowerCheckInterval))
 	fs.Register(RufioMaxConcurrentReconciles, ffval.NewValueDefault(&t.Config.MaxConcurrentReconciles, t.Config.MaxConcurrentReconciles))
 	fs.Register(RufioLogLevel, ffval.NewValueDefault(&t.LogLevel, t.LogLevel))
-	fs.Register(RufioNoLog, ffval.NewValueDefault(&t.NoLog, t.NoLog))
 }
 
 var RufioControllerEnableLeaderElection = Config{
@@ -56,15 +54,10 @@ var RufioPowerCheckInterval = Config{
 
 var RufioLogLevel = Config{
 	Name:  "rufio-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
+	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
 }
 
 var RufioMaxConcurrentReconciles = Config{
 	Name:  "rufio-max-concurrent-reconciles",
 	Usage: "maximum number of concurrent reconciles for rufio controllers",
-}
-
-var RufioNoLog = Config{
-	Name:  "rufio-no-log",
-	Usage: "disable all logging output for Rufio service",
 }

--- a/cmd/tinkerbell/flag/secondstar.go
+++ b/cmd/tinkerbell/flag/secondstar.go
@@ -10,7 +10,6 @@ type SecondStarConfig struct {
 	Config      *secondstar.Config
 	HostKeyPath string
 	LogLevel    int
-	NoLog       bool
 }
 
 var KubeIndexesSecondStar = map[kube.IndexType]kube.Index{
@@ -24,7 +23,6 @@ func RegisterSecondStarFlags(fs *Set, ssc *SecondStarConfig) {
 	fs.Register(SecondStarIPMIToolPath, ffval.NewValueDefault(&ssc.Config.IPMITOOLPath, ssc.Config.IPMITOOLPath))
 	fs.Register(SecondStarIdleTimeout, ffval.NewValueDefault(&ssc.Config.IdleTimeout, ssc.Config.IdleTimeout))
 	fs.Register(SecondStarLogLevel, ffval.NewValueDefault(&ssc.LogLevel, ssc.LogLevel))
-	fs.Register(SecondStarNoLog, ffval.NewValueDefault(&ssc.NoLog, ssc.NoLog))
 }
 
 var SecondStarPort = Config{
@@ -49,12 +47,7 @@ var SecondStarIdleTimeout = Config{
 
 var SecondStarLogLevel = Config{
 	Name:  "secondstar-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
-}
-
-var SecondStarNoLog = Config{
-	Name:  "secondstar-no-log",
-	Usage: "disable all logging output for SecondStar service",
+	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
 }
 
 func (ssc *SecondStarConfig) Convert() error {

--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -25,7 +25,6 @@ type SmeeConfig struct {
 	// The cmd package is responsible for putting the fields back together into a url.URL for use in service package configs.
 	DHCPIPXEScript URLBuilder
 	LogLevel       int
-	NoLog          bool
 }
 
 var KubeIndexesSmee = map[kube.IndexType]kube.Index{
@@ -130,7 +129,6 @@ func RegisterSmeeFlags(fs *Set, sc *SmeeConfig) {
 
 	// Log level
 	fs.Register(SmeeLogLevel, ffval.NewValueDefault(&sc.LogLevel, sc.LogLevel))
-	fs.Register(SmeeNoLog, ffval.NewValueDefault(&sc.NoLog, sc.NoLog))
 
 	// Syslog Flags
 	fs.Register(SyslogEnabled, ffval.NewValueDefault(&sc.Config.Syslog.Enabled, sc.Config.Syslog.Enabled))
@@ -475,12 +473,7 @@ var TinkServerInsecureTLS = Config{
 
 var SmeeLogLevel = Config{
 	Name:  "smee-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
-}
-
-var SmeeNoLog = Config{
-	Name:  "smee-no-log",
-	Usage: "disable all logging output for Smee service",
+	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
 }
 
 var DHCPEnableNetbootOptions = Config{

--- a/cmd/tinkerbell/flag/tink_controller.go
+++ b/cmd/tinkerbell/flag/tink_controller.go
@@ -10,7 +10,6 @@ import (
 type TinkControllerConfig struct {
 	Config   *controller.Config
 	LogLevel int
-	NoLog    bool
 }
 
 func RegisterTinkControllerFlags(fs *Set, t *TinkControllerConfig) {
@@ -20,7 +19,6 @@ func RegisterTinkControllerFlags(fs *Set, t *TinkControllerConfig) {
 	fs.Register(TinkControllerProbeAddr, &netip.AddrPort{AddrPort: &t.Config.ProbeAddr})
 	fs.Register(TinkControllerMaxConcurrentReconciles, ffval.NewValueDefault(&t.Config.MaxConcurrentReconciles, t.Config.MaxConcurrentReconciles))
 	fs.Register(TinkControllerLogLevel, ffval.NewValueDefault(&t.LogLevel, t.LogLevel))
-	fs.Register(TinkControllerNoLog, ffval.NewValueDefault(&t.NoLog, t.NoLog))
 	fs.Register(TinkControllerReferenceAllowListRules, delimitedlist.New(&t.Config.ReferenceAllowListRules, '|'))
 	fs.Register(TinkControllerReferenceDenyListRules, delimitedlist.New(&t.Config.ReferenceDenyListRules, '|'))
 }
@@ -47,12 +45,7 @@ var TinkControllerLeaderElectionNamespace = Config{
 
 var TinkControllerLogLevel = Config{
 	Name:  "tink-controller-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
-}
-
-var TinkControllerNoLog = Config{
-	Name:  "tink-controller-no-log",
-	Usage: "disable all logging output for Tink Controller service",
+	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
 }
 
 var TinkControllerReferenceAllowListRules = Config{

--- a/cmd/tinkerbell/flag/tink_server.go
+++ b/cmd/tinkerbell/flag/tink_server.go
@@ -14,7 +14,6 @@ type TinkServerConfig struct {
 	BindAddr netip.Addr
 	BindPort uint16
 	LogLevel int
-	NoLog    bool
 }
 
 var KubeIndexesTinkServer = map[kube.IndexType]kube.Index{
@@ -26,7 +25,6 @@ func RegisterTinkServerFlags(fs *Set, t *TinkServerConfig) {
 	fs.Register(TinkServerBindAddr, &ntip.Addr{Addr: &t.BindAddr})
 	fs.Register(TinkServerBindPort, ffval.NewValueDefault(&t.BindPort, t.BindPort))
 	fs.Register(TinkServerLogLevel, ffval.NewValueDefault(&t.LogLevel, t.LogLevel))
-	fs.Register(TinkServerNoLog, ffval.NewValueDefault(&t.NoLog, t.NoLog))
 	fs.Register(TinkServerAutoEnrollmentEnabled, ffval.NewValueDefault(&t.Config.Auto.Enrollment.Enabled, t.Config.Auto.Enrollment.Enabled))
 	fs.Register(TinkerbellAutoDiscoveryEnabled, ffval.NewValueDefault(&t.Config.Auto.Discovery.Enabled, t.Config.Auto.Discovery.Enabled))
 	fs.Register(TinkerbellAutoDiscoveryAutoEnrollmentEnabled, ffval.NewValueDefault(&t.Config.Auto.Discovery.EnrollmentEnabled, t.Config.Auto.Discovery.EnrollmentEnabled))
@@ -54,12 +52,7 @@ var TinkServerBindPort = Config{
 
 var TinkServerLogLevel = Config{
 	Name:  "tink-server-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
-}
-
-var TinkServerNoLog = Config{
-	Name:  "tink-server-no-log",
-	Usage: "disable all logging output for Tink Server service",
+	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
 }
 
 var TinkServerAutoEnrollmentEnabled = Config{

--- a/cmd/tinkerbell/flag/tootles.go
+++ b/cmd/tinkerbell/flag/tootles.go
@@ -15,7 +15,6 @@ type TootlesConfig struct {
 	BindAddr netip.Addr
 	BindPort int
 	LogLevel int
-	NoLog    bool
 }
 
 var KubeIndexesTootles = map[kube.IndexType]kube.Index{
@@ -28,7 +27,6 @@ func RegisterTootlesFlags(fs *Set, h *TootlesConfig) {
 	fs.Register(TootlesBindPort, ffval.NewValueDefault(&h.BindPort, h.BindPort))
 	fs.Register(TootlesDebugMode, ffval.NewValueDefault(&h.Config.DebugMode, h.Config.DebugMode))
 	fs.Register(TootlesLogLevel, ffval.NewValueDefault(&h.LogLevel, h.LogLevel))
-	fs.Register(TootlesNoLog, ffval.NewValueDefault(&h.NoLog, h.NoLog))
 	fs.Register(TootlesInstanceEndpoint, ffval.NewValueDefault(&h.Config.InstanceEndpoint, h.Config.InstanceEndpoint))
 }
 
@@ -49,12 +47,7 @@ var TootlesDebugMode = Config{
 
 var TootlesLogLevel = Config{
 	Name:  "tootles-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
-}
-
-var TootlesNoLog = Config{
-	Name:  "tootles-no-log",
-	Usage: "disable all logging output for Tootles service",
+	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
 }
 
 var TootlesInstanceEndpoint = Config{

--- a/cmd/tinkerbell/flag/ui.go
+++ b/cmd/tinkerbell/flag/ui.go
@@ -13,7 +13,6 @@ type UIConfig struct {
 	Config   *ui.Config
 	BindAddr netip.Addr
 	LogLevel int
-	NoLog    bool
 }
 
 // RegisterUIFlags registers UI service flags with the flag set.
@@ -22,7 +21,6 @@ func RegisterUIFlags(fs *Set, h *UIConfig) {
 	fs.Register(UIBindPort, ffval.NewValueDefault(&h.Config.BindPort, h.Config.BindPort))
 	fs.Register(UIDebugMode, ffval.NewValueDefault(&h.Config.DebugMode, h.Config.DebugMode))
 	fs.Register(UILogLevel, ffval.NewValueDefault(&h.LogLevel, h.LogLevel))
-	fs.Register(UINoLog, ffval.NewValueDefault(&h.NoLog, h.NoLog))
 	fs.Register(UIURLPrefix, ffval.NewValueDefault(&h.Config.URLPrefix, h.Config.URLPrefix))
 	fs.Register(UIEnableAutoLogin, ffval.NewValueDefault(&h.Config.EnableAutoLogin, h.Config.EnableAutoLogin))
 }
@@ -44,12 +42,7 @@ var UIDebugMode = Config{
 
 var UILogLevel = Config{
 	Name:  "ui-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level",
-}
-
-var UINoLog = Config{
-	Name:  "ui-no-log",
-	Usage: "disable all logging output for UI service",
+	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
 }
 
 var UIURLPrefix = Config{


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This removes the extra cli flag, which wasn't plumbed into the helm chart anyway. A negative log level disables the logging.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
