### PR TITLE
Use AgentID from hardware object if set in iPXE script as worker_id

### DIFF
--- a/pkg/backend/kube/smee.go
+++ b/pkg/backend/kube/smee.go
@@ -59,7 +59,7 @@ func (b *Backend) GetByMac(ctx context.Context, mac net.HardwareAddr) (data.Hard
 		return data.Hardware{}, err
 	}
 
-	result := data.Hardware{DHCP: d, Netboot: n}
+	result := data.Hardware{DHCP: d, Netboot: n, AgentID: hardwareList.Items[0].Spec.AgentID}
 
 	if i.Isoboot != nil && i.Isoboot.SourceISO != "" {
 		si, err := url.Parse(i.Isoboot.SourceISO)
@@ -131,7 +131,7 @@ func (b *Backend) GetByIP(ctx context.Context, ip net.IP) (data.Hardware, error)
 	span.SetAttributes(n.EncodeToAttributes()...)
 	span.SetStatus(codes.Ok, "")
 
-	return data.Hardware{DHCP: d, Netboot: n}, nil
+	return data.Hardware{DHCP: d, Netboot: n, AgentID: hardwareList.Items[0].Spec.AgentID}, nil
 }
 
 // toDHCPData converts a v1alpha1.DHCP to a data.DHCP data structure.

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -12,6 +12,8 @@ import (
 
 // Hardware is the combination of structs that hold all the data about a piece of hardware.
 type Hardware struct {
+	// Holds the assigned AgentID from the hardware object
+	AgentID string
 	// DHCP holds the DHCP headers and options to be set in a DHCP handler response.
 	// This is the API between a DHCP handler and a backend.
 	DHCP *DHCP

--- a/smee/internal/ipxe/script/ipxe.go
+++ b/smee/internal/ipxe/script/ipxe.go
@@ -48,7 +48,7 @@ type info struct {
 	MACAddress    net.HardwareAddr
 	Arch          string
 	VLANID        string
-	WorkflowID    string
+	AgentID       string
 	Facility      string
 	IPXEScript    string
 	IPXEScriptURL *url.URL
@@ -91,7 +91,7 @@ func getByMac(ctx context.Context, mac net.HardwareAddr, br BackendReader) (info
 		MACAddress:    d.MACAddress,
 		Arch:          d.Arch,
 		VLANID:        d.VLANID,
-		WorkflowID:    d.MACAddress.String(),
+		AgentID:       hw.AgentID,
 		Facility:      n.Facility,
 		IPXEScript:    n.IPXEScript,
 		IPXEScriptURL: n.IPXEScriptURL,
@@ -122,7 +122,7 @@ func getByIP(ctx context.Context, ip net.IP, br BackendReader) (info, error) {
 		MACAddress:    d.MACAddress,
 		Arch:          d.Arch,
 		VLANID:        d.VLANID,
-		WorkflowID:    d.MACAddress.String(),
+		AgentID:       hw.AgentID,
 		Facility:      n.Facility,
 		IPXEScript:    n.IPXEScript,
 		IPXEScriptURL: n.IPXEScriptURL,
@@ -294,10 +294,10 @@ func (h *Handler) defaultScript(span trace.Span, hw info) (string, error) {
 	if arch == "" {
 		arch = "x86_64"
 	}
-	// The worker ID will default to the mac address or use the one specified.
+	// The worker ID will default to the mac address or use the one specified in the hardware object
 	wID := mac.String()
-	if hw.WorkflowID != "" {
-		wID = hw.WorkflowID
+	if hw.AgentID != "" {
+		wID = hw.AgentID
 	}
 
 	auto := Hook{


### PR DESCRIPTION
## Description

Uses the agentID from the hardware object as worker ID if set. Otherwise fall back to the MAC address

Fixes: #425

## How Has This Been Tested?
Add unit test


## How are existing users impacted? What migration steps/scripts do we need?

No migration for users needed


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
