### PR TITLE
Fix tailwindcss pinning issue:

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -40,11 +40,11 @@ ui-install-deps: $(UI_TEMPL_FQP) $(UI_BUN_FQP) ## Install UI dependencies (bun p
 
 .PHONY: ui-css
 ui-css: $(UI_BUN_FQP) ## Build UI CSS
-	(cd ui && $(UI_BUN_FQP) x @tailwindcss/cli -i assets/css/input.css -o assets/css/output.css --minify)
+	(cd ui && $(UI_BUN_FQP) run tailwindcss -i assets/css/input.css -o assets/css/output.css --minify)
 
 .PHONY: ui-css-watch
 ui-css-watch: $(UI_BUN_FQP) ## Watch and rebuild UI CSS on changes
-	(cd ui && $(UI_BUN_FQP) x @tailwindcss/cli -i assets/css/input.css -o assets/css/output.css --watch)
+	(cd ui && $(UI_BUN_FQP) run tailwindcss -i assets/css/input.css -o assets/css/output.css --watch)
 
 .PHONY: ui-templ
 ui-templ: $(UI_TEMPL_FQP) ## Generate templ templates


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Use `bun run` instead of `bun x` for tailwindcss. `bun x` (like `npx`) resolves packages from the registry independently of what is locally installed, so it downloads the latest @tailwindcss/cli instead of using the version pinned in package.json and bun.lock. This causes the generated output.css to embed a newer tailwindcss version comment, making the CI dirty-tree check fail.

`bun run` executes the binary from node_modules/.bin, which is installed by bun install from the pinned `@tailwindcss/cli` version.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
