### PR TITLE
Add additional RBAC role rules to chart:

### DIFF
--- a/helm/tinkerbell/templates/_helpers.tpl
+++ b/helm/tinkerbell/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Ensure a value is a JSON array. Fails on nil or non-array input.
+- slice/array: use as-is
+- nil/missing: fail with an error (required field)
+- anything else: fail with a type error
+Usage: {{ include "tinkerbell.toJsonArray" .apiGroups }}
+*/}}
+{{- define "tinkerbell.toJsonArray" -}}
+{{- if kindIs "slice" . -}}
+  {{- . | toJson -}}
+{{- else if kindIs "invalid" . -}}
+  {{- fail "required field is nil/missing in rbac.additionalRoleRules entry (apiGroups, resources, and verbs are required and must be arrays)" -}}
+{{- else -}}
+  {{- fail (printf "expected an array but got %s: %v" (kindOf .) .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render an optional RBAC field as a JSON array. Skips nil/missing values.
+- slice/array: render as JSON array
+- nil/missing: output nothing (caller uses 'with' or checks result)
+- anything else: fail with a type error
+Usage: {{ include "tinkerbell.toOptionalJsonArray" .resourceNames }}
+*/}}
+{{- define "tinkerbell.toOptionalJsonArray" -}}
+{{- if kindIs "slice" . -}}
+  {{- . | toJson -}}
+{{- else if not (kindIs "invalid" .) -}}
+  {{- fail (printf "expected an array but got %s: %v" (kindOf .) .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/tinkerbell/templates/role.yaml
+++ b/helm/tinkerbell/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.rbac.type }}
 metadata:
   name: {{ .Values.rbac.name }}-role
-  {{- if eq .Values.rbac.type "Role"  }}
+  {{- if eq .Values.rbac.type "Role" }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 rules:
@@ -30,3 +30,21 @@ rules:
   - apiGroups: ["bmc.tinkerbell.org"]
     resources: ["jobs/finalizers", "machines/finalizers", "tasks/finalizers"]
     verbs: ["update"]
+  {{- range .Values.rbac.additionalRoleRules }}
+  {{- if and (hasKey . "resources") (hasKey . "nonResourceURLs") }}
+    {{- fail "rbac.additionalRoleRules: a rule must not specify both 'resources' and 'nonResourceURLs' (they are mutually exclusive per Kubernetes RBAC PolicyRule)" }}
+  {{- end }}
+  {{- if not (or (hasKey . "resources") (hasKey . "nonResourceURLs")) }}
+    {{- fail "rbac.additionalRoleRules: each rule must specify either 'resources' or 'nonResourceURLs'" }}
+  {{- end }}
+  - {{- if hasKey . "resources" }}
+    apiGroups: {{ include "tinkerbell.toJsonArray" .apiGroups }}
+    resources: {{ include "tinkerbell.toJsonArray" .resources }}
+    {{- with (include "tinkerbell.toOptionalJsonArray" .resourceNames) }}
+    resourceNames: {{ . }}
+    {{- end }}
+    {{- else }}
+    nonResourceURLs: {{ include "tinkerbell.toJsonArray" .nonResourceURLs }}
+    {{- end }}
+    verbs: {{ include "tinkerbell.toJsonArray" .verbs }}
+  {{- end }}

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -181,6 +181,15 @@ deployment:
 name: tinkerbell
 publicIP:
 rbac:
+  additionalRoleRules: []
+  # Resource-based rule example:
+  # - apiGroups: [""]             # Required. API groups ("" = core group).
+  #   resources: ["configmaps"]   # Required. Resource types.
+  #   verbs: ["get", "list"]      # Required. Allowed operations.
+  #   resourceNames: ["my-cm"]    # Optional. Restrict to specific resource names.
+  # Non-resource URL rule example:
+  # - nonResourceURLs: ["/healthz"] # Required. Non-resource URL paths.
+  #   verbs: ["get"]                # Required. Allowed operations.
   name: tinkerbell
   type: ClusterRole # or Role
   secrets:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows users to add rules during helm install. This is helpful when users know they will have Hardware References that need RBAC that is not included by default. This means users don't need an additional command or yaml file to update the Tinkerbell rbac.

Fixes: #587

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
