### PR TITLE
Add toYaml and fromYaml workflow template functions:

### DIFF
--- a/tink/controller/internal/workflow/pre.go
+++ b/tink/controller/internal/workflow/pre.go
@@ -246,7 +246,7 @@ func templateActions(actions []bmc.Action, hw *v1alpha1.Hardware) ([]bmc.Action,
 // templateString executes a Go template string with the provided data.
 func templateString(tmplStr string, data templateData) (string, error) {
 	// Use Sprig hermetic functions for template operations (includes replace, etc.)
-	tmpl, err := template.New("action").Funcs(sprig.HermeticTxtFuncMap()).Parse(tmplStr)
+	tmpl, err := template.New("action").Funcs(sprig.HermeticTxtFuncMap()).Funcs(templateFuncs).Parse(tmplStr)
 	if err != nil {
 		return "", err
 	}

--- a/tink/controller/internal/workflow/template_funcs_test.go
+++ b/tink/controller/internal/workflow/template_funcs_test.go
@@ -1,8 +1,298 @@
 package workflow
 
 import (
+	"reflect"
+	"strings"
 	"testing"
+	"text/template"
+
+	"sigs.k8s.io/yaml"
 )
+
+func TestToYaml(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   interface{}
+		wantErr bool
+		// validate checks the YAML output structurally rather than by exact string.
+		validate func(t *testing.T, yamlStr string)
+	}{
+		{
+			name:  "simple map",
+			input: map[string]interface{}{"name": "bob", "age": 25},
+			validate: func(t *testing.T, yamlStr string) {
+				t.Helper()
+				var got map[string]interface{}
+				if err := yaml.Unmarshal([]byte(yamlStr), &got); err != nil {
+					t.Fatalf("failed to unmarshal toYaml output: %v", err)
+				}
+				if got["name"] != "bob" {
+					t.Errorf("name = %v, want bob", got["name"])
+				}
+			},
+		},
+		{
+			name: "nested map",
+			input: map[string]interface{}{
+				"person": map[string]interface{}{
+					"name": "alice",
+					"address": map[string]interface{}{
+						"city": "wonderland",
+					},
+				},
+			},
+			validate: func(t *testing.T, yamlStr string) {
+				t.Helper()
+				if !strings.Contains(yamlStr, "city: wonderland") {
+					t.Errorf("output missing 'city: wonderland', got: %q", yamlStr)
+				}
+				if !strings.Contains(yamlStr, "name: alice") {
+					t.Errorf("output missing 'name: alice', got: %q", yamlStr)
+				}
+			},
+		},
+		{
+			name:  "slice",
+			input: []string{"a", "b", "c"},
+			validate: func(t *testing.T, yamlStr string) {
+				t.Helper()
+				var got []string
+				if err := yaml.Unmarshal([]byte(yamlStr), &got); err != nil {
+					t.Fatalf("failed to unmarshal toYaml output: %v", err)
+				}
+				if !reflect.DeepEqual(got, []string{"a", "b", "c"}) {
+					t.Errorf("got %v, want [a b c]", got)
+				}
+			},
+		},
+		{
+			name:  "nil input",
+			input: nil,
+			validate: func(t *testing.T, yamlStr string) {
+				t.Helper()
+				if strings.TrimSpace(yamlStr) != "null" {
+					t.Errorf("got %q, want 'null'", yamlStr)
+				}
+			},
+		},
+		{
+			name:  "empty map",
+			input: map[string]interface{}{},
+			validate: func(t *testing.T, yamlStr string) {
+				t.Helper()
+				if strings.TrimSpace(yamlStr) != "{}" {
+					t.Errorf("got %q, want '{}'", yamlStr)
+				}
+			},
+		},
+		{
+			name:  "string value",
+			input: "hello",
+			validate: func(t *testing.T, yamlStr string) {
+				t.Helper()
+				if strings.TrimSpace(yamlStr) != "hello" {
+					t.Errorf("got %q, want 'hello'", yamlStr)
+				}
+			},
+		},
+		{
+			name:    "unmarshalable type (channel)",
+			input:   make(chan int),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toYaml(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("toYaml() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, got)
+			}
+		})
+	}
+}
+
+func TestFromYaml(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		validate func(t *testing.T, result interface{})
+	}{
+		{
+			name:  "simple yaml map",
+			input: "name: bob\nage: 25",
+			validate: func(t *testing.T, result interface{}) {
+				t.Helper()
+				m, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatalf("expected map, got %T", result)
+				}
+				if m["name"] != "bob" {
+					t.Errorf("name = %v, want bob", m["name"])
+				}
+			},
+		},
+		{
+			name:  "yaml array",
+			input: "- a\n- b\n- c",
+			validate: func(t *testing.T, result interface{}) {
+				t.Helper()
+				s, ok := result.([]interface{})
+				if !ok {
+					t.Fatalf("expected slice, got %T", result)
+				}
+				if len(s) != 3 {
+					t.Errorf("len = %d, want 3", len(s))
+				}
+			},
+		},
+		{
+			name:  "nested yaml",
+			input: "person:\n  name: alice",
+			validate: func(t *testing.T, result interface{}) {
+				t.Helper()
+				m, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatalf("expected map, got %T", result)
+				}
+				if _, ok := m["person"]; !ok {
+					t.Error("missing key 'person'")
+				}
+			},
+		},
+		{
+			name:    "invalid yaml",
+			input:   ":\n  :\n  - :\n  invalid:: yaml:: content",
+			wantErr: true,
+		},
+		{
+			name:    "empty string returns error",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fromYaml(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fromYaml() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, got)
+			}
+		})
+	}
+}
+
+func TestToYamlRoundTrip(t *testing.T) {
+	original := map[string]interface{}{
+		"name": "test",
+		"items": []interface{}{
+			"one",
+			"two",
+		},
+	}
+
+	yamlStr, err := toYaml(original)
+	if err != nil {
+		t.Fatalf("toYaml() error = %v", err)
+	}
+
+	result, err := fromYaml(yamlStr)
+	if err != nil {
+		t.Fatalf("fromYaml() error = %v", err)
+	}
+
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", result)
+	}
+	if m["name"] != "test" {
+		t.Errorf("round trip: name = %v, want %v", m["name"], "test")
+	}
+}
+
+func TestToYamlInTemplate(t *testing.T) {
+	// Test that toYaml works correctly when called from a Go template.
+	tmpl, err := template.New("test").Funcs(template.FuncMap{
+		"toYaml": toYaml,
+	}).Parse(`{{ .data | toYaml }}`)
+	if err != nil {
+		t.Fatalf("template parse error: %v", err)
+	}
+
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"key": "value",
+			"nested": map[string]interface{}{
+				"inner": "data",
+			},
+		},
+	}
+
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execute error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "key: value") {
+		t.Errorf("template output missing 'key: value', got: %q", got)
+	}
+	if !strings.Contains(got, "inner: data") {
+		t.Errorf("template output missing 'inner: data', got: %q", got)
+	}
+}
+
+func TestToYamlInTemplateError(t *testing.T) {
+	// Test that toYaml errors halt template execution.
+	tmpl, err := template.New("test").Funcs(template.FuncMap{
+		"toYaml": toYaml,
+	}).Parse(`{{ .data | toYaml }}`)
+	if err != nil {
+		t.Fatalf("template parse error: %v", err)
+	}
+
+	data := map[string]interface{}{
+		"data": make(chan int), // un-marshalable
+	}
+
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err == nil {
+		t.Fatal("expected template execution to fail for un-marshalable type, but it succeeded")
+	}
+}
+
+func TestFromYamlInTemplate(t *testing.T) {
+	// Test that fromYaml works correctly when called from a Go template.
+	tmpl, err := template.New("test").Funcs(template.FuncMap{
+		"fromYaml": fromYaml,
+	}).Parse(`{{ $m := fromYaml .yamlStr }}{{ $m.name }}`)
+	if err != nil {
+		t.Fatalf("template parse error: %v", err)
+	}
+
+	data := map[string]interface{}{
+		"yamlStr": "name: alice\nage: 30",
+	}
+
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execute error: %v", err)
+	}
+
+	got := buf.String()
+	if got != "alice" {
+		t.Errorf("fromYaml in template = %q, want %q", got, "alice")
+	}
+}
 
 func TestNetmaskToPrefixLength(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Workflow templates can now serialize objects to YAML and parse YAML strings, enabling cloud-init NoCloud datasource usage and other YAML generation directly from templates.

Functions are registered in both template rendering paths:
- renderTemplateHardware (workflow-level templates)
- templateString (action-level templates in customboot)

Fixes: #577

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
