### PR TITLE
feat(tootles): Expose individual network interfaces on metadata endpoint

### DIFF
--- a/pkg/backend/kube/tootles.go
+++ b/pkg/backend/kube/tootles.go
@@ -106,6 +106,22 @@ func toEC2Instance(hw v1alpha1.Hardware) data.Ec2Instance {
 		}
 	}
 
+	// Populate network interfaces from the hardware spec.
+	for _, iface := range hw.Spec.Interfaces {
+		if iface.DHCP == nil || iface.DHCP.MAC == "" {
+			continue
+		}
+		ni := data.NetworkInterface{
+			MAC: iface.DHCP.MAC,
+		}
+		if iface.DHCP.IP != nil {
+			ni.IP = iface.DHCP.IP.Address
+			ni.Netmask = iface.DHCP.IP.Netmask
+			ni.Gateway = iface.DHCP.IP.Gateway
+		}
+		i.Metadata.Interfaces = append(i.Metadata.Interfaces, ni)
+	}
+
 	if hw.Spec.Metadata != nil && hw.Spec.Metadata.Facility != nil {
 		i.Metadata.Plan = hw.Spec.Metadata.Facility.PlanSlug
 		i.Metadata.Facility = hw.Spec.Metadata.Facility.FacilityCode

--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -26,6 +26,15 @@ type Metadata struct {
 	PublicIPv6      string
 	LocalIPv4       string
 	OperatingSystem OperatingSystem
+	Interfaces      []NetworkInterface
+}
+
+// NetworkInterface represents a single network interface from the hardware spec.
+type NetworkInterface struct {
+	MAC     string
+	IP      string
+	Netmask string
+	Gateway string
 }
 
 // OperatingSystem is part of Metadata.

--- a/tootles/internal/frontend/ec2/frontend.go
+++ b/tootles/internal/frontend/ec2/frontend.go
@@ -75,18 +75,119 @@ func (f Frontend) Configure(router gin.IRouter) {
 		staticRoutes.FromEndpoint(r.Endpoint)
 	}
 
+	// Network interface attribute names exposed per MAC address.
+	networkInterfaceAttributes := []string{"gateway", "local-ipv4", "mac", "netmask"}
+
 	staticEndpointBinder := func(router ginutil.TrailingSlashRouteHelper, endpoint string, childEndpoints []string) {
 		router.GET(endpoint, func(ctx *gin.Context) {
 			ctx.String(http.StatusOK, join(childEndpoints))
 		})
 	}
 
+	// Add network interface paths to the static route builder so parent listings include
+	// "network/", "interfaces/", and "macs/" with trailing slashes indicating navigability.
+	// We use a placeholder child under macs so the builder recognizes macs as a parent.
+	// The generated static route for /meta-data/network/interfaces/macs is skipped below
+	// because the MAC listing is handled by a dynamic handler.
+	for _, attr := range networkInterfaceAttributes {
+		staticRoutes.FromEndpoint("/meta-data/network/interfaces/macs/_/" + attr)
+	}
+
 	for _, r := range staticRoutes.Build() {
+		// Skip the placeholder route - the MAC listing is dynamic (per-instance).
+		if r.Endpoint == "/meta-data/network/interfaces/macs/_" || r.Endpoint == "/meta-data/network/interfaces/macs" {
+			continue
+		}
 		staticEndpointBinder(v20090404, r.Endpoint, r.Children)
 		if f.instanceEndpoint {
 			staticEndpointBinder(v20090404viaInstanceID, r.Endpoint, r.Children)
 		}
 	}
+
+	// Network interface dynamic routes.
+	// These follow the EC2 convention: /meta-data/network/interfaces/macs/<mac>/<attribute>
+
+	// List all MAC addresses.
+	macListHandler := func(getInstance func(*gin.Context) (data.Ec2Instance, error)) gin.HandlerFunc {
+		return func(ctx *gin.Context) {
+			instance, err := getInstance(ctx)
+			if err != nil {
+				f.writeInstanceDataOrErrToHTTP(ctx, err, "")
+				return
+			}
+			var macs []string
+			for _, iface := range instance.Metadata.Interfaces {
+				macs = append(macs, iface.MAC+"/")
+			}
+			ctx.String(http.StatusOK, join(macs))
+		}
+	}
+
+	// List available attributes for a MAC.
+	macAttrListHandler := func(ctx *gin.Context) {
+		ctx.String(http.StatusOK, join(networkInterfaceAttributes))
+	}
+
+	// Return a specific attribute for a MAC.
+	macAttrHandler := func(getInstance func(*gin.Context) (data.Ec2Instance, error), attr string) gin.HandlerFunc {
+		return func(ctx *gin.Context) {
+			instance, err := getInstance(ctx)
+			if err != nil {
+				f.writeInstanceDataOrErrToHTTP(ctx, err, "")
+				return
+			}
+			mac := ctx.Param("mac")
+			iface, found := findInterface(instance.Metadata.Interfaces, mac)
+			if !found {
+				ctx.String(http.StatusNotFound, "interface not found")
+				return
+			}
+			var value string
+			switch attr {
+			case "mac":
+				value = iface.MAC
+			case "local-ipv4":
+				value = iface.IP
+			case "netmask":
+				value = iface.Netmask
+			case "gateway":
+				value = iface.Gateway
+			}
+			ctx.String(http.StatusOK, value)
+		}
+	}
+
+	getInstanceViaIPFunc := func(ctx *gin.Context) (data.Ec2Instance, error) {
+		return f.getInstanceViaIP(ctx, ctx.Request)
+	}
+	getInstanceViaInstanceIDFunc := func(ctx *gin.Context) (data.Ec2Instance, error) {
+		return f.getInstanceViaInstanceID(ctx)
+	}
+
+	// Register network interface routes for IP-based access.
+	v20090404.GET("/meta-data/network/interfaces/macs", macListHandler(getInstanceViaIPFunc))
+	v20090404.GET("/meta-data/network/interfaces/macs/:mac", macAttrListHandler)
+	for _, attr := range networkInterfaceAttributes {
+		v20090404.GET("/meta-data/network/interfaces/macs/:mac/"+attr, macAttrHandler(getInstanceViaIPFunc, attr))
+	}
+
+	// Register network interface routes for instance ID-based access.
+	if f.instanceEndpoint {
+		v20090404viaInstanceID.GET("/meta-data/network/interfaces/macs", macListHandler(getInstanceViaInstanceIDFunc))
+		v20090404viaInstanceID.GET("/meta-data/network/interfaces/macs/:mac", macAttrListHandler)
+		for _, attr := range networkInterfaceAttributes {
+			v20090404viaInstanceID.GET("/meta-data/network/interfaces/macs/:mac/"+attr, macAttrHandler(getInstanceViaInstanceIDFunc, attr))
+		}
+	}
+}
+
+func findInterface(interfaces []data.NetworkInterface, mac string) (data.NetworkInterface, bool) {
+	for _, iface := range interfaces {
+		if iface.MAC == mac {
+			return iface, true
+		}
+	}
+	return data.NetworkInterface{}, false
 }
 
 // Shared across IP and instanceID-based routes.

--- a/tootles/internal/frontend/ec2/frontend_test.go
+++ b/tootles/internal/frontend/ec2/frontend_test.go
@@ -351,12 +351,23 @@ instance-id
 iqn
 local-hostname
 local-ipv4
+network/
 operating-system/
 plan
 public-ipv4
 public-ipv6
 public-keys
 tags`,
+		},
+		{
+			Name:     "MetadataNetwork",
+			Endpoint: "/2009-04-04/meta-data/network",
+			Expect:   `interfaces/`,
+		},
+		{
+			Name:     "MetadataNetworkInterfaces",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces",
+			Expect:   `macs/`,
 		},
 		{
 			Name:     "MetadataOperatingSystem",
@@ -414,6 +425,117 @@ func validate(t *testing.T, router *gin.Engine, endpoint string, expect string) 
 
 	if w.Body.String() != expect {
 		t.Fatalf("\nExpected: %s;\nReceived: %s;\n(Endpoint=%s)", expect, w.Body.String(), endpoint)
+	}
+}
+
+func TestFrontendNetworkInterfaceEndpoints(t *testing.T) {
+	testInstance := data.Ec2Instance{
+		Metadata: data.Metadata{
+			Interfaces: []data.NetworkInterface{
+				{
+					MAC:     "aa:bb:cc:dd:ee:f0",
+					IP:      "10.0.0.1",
+					Netmask: "255.255.255.0",
+					Gateway: "10.0.0.254",
+				},
+				{
+					MAC:     "aa:bb:cc:dd:ee:f1",
+					IP:      "192.168.1.1",
+					Netmask: "255.255.255.0",
+					Gateway: "192.168.1.254",
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		Name     string
+		Endpoint string
+		Expect   string
+	}{
+		{
+			Name:     "ListMACs",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces/macs",
+			Expect:   "aa:bb:cc:dd:ee:f0/\naa:bb:cc:dd:ee:f1/",
+		},
+		{
+			Name:     "ListAttrsForMAC",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces/macs/aa:bb:cc:dd:ee:f0",
+			Expect:   "gateway\nlocal-ipv4\nmac\nnetmask",
+		},
+		{
+			Name:     "MACAttribute",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces/macs/aa:bb:cc:dd:ee:f0/mac",
+			Expect:   "aa:bb:cc:dd:ee:f0",
+		},
+		{
+			Name:     "LocalIPv4Attribute",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces/macs/aa:bb:cc:dd:ee:f0/local-ipv4",
+			Expect:   "10.0.0.1",
+		},
+		{
+			Name:     "NetmaskAttribute",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces/macs/aa:bb:cc:dd:ee:f0/netmask",
+			Expect:   "255.255.255.0",
+		},
+		{
+			Name:     "GatewayAttribute",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces/macs/aa:bb:cc:dd:ee:f0/gateway",
+			Expect:   "10.0.0.254",
+		},
+		{
+			Name:     "SecondInterfaceIP",
+			Endpoint: "/2009-04-04/meta-data/network/interfaces/macs/aa:bb:cc:dd:ee:f1/local-ipv4",
+			Expect:   "192.168.1.1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			client := ec2.NewMockClient(ctrl)
+			client.EXPECT().
+				GetEC2Instance(gomock.Any(), gomock.Any()).
+				Return(testInstance, nil).
+				AnyTimes()
+
+			router := gin.New()
+
+			fe := ec2.New(client, false)
+			fe.Configure(router)
+
+			validate(t, router, tc.Endpoint, tc.Expect)
+			validate(t, router, tc.Endpoint+"/", tc.Expect)
+		})
+	}
+}
+
+func TestFrontendNetworkInterfaceNotFound(t *testing.T) {
+	testInstance := data.Ec2Instance{
+		Metadata: data.Metadata{
+			Interfaces: []data.NetworkInterface{
+				{MAC: "aa:bb:cc:dd:ee:f0"},
+			},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	client := ec2.NewMockClient(ctrl)
+	client.EXPECT().
+		GetEC2Instance(gomock.Any(), gomock.Any()).
+		Return(testInstance, nil)
+
+	router := gin.New()
+	fe := ec2.New(client, false)
+	fe.Configure(router)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/2009-04-04/meta-data/network/interfaces/macs/ff:ff:ff:ff:ff:ff/mac", nil)
+	r.RemoteAddr = "10.10.10.10:0"
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("Expected: 404; Received: %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
## Description

Read network interfaces from hw.Spec.Interfaces and expose them via EC2-style metadata routes at /meta-data/network/interfaces/macs/<mac>/ with per-interface attributes: mac, local-ipv4, netmask, gateway.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## How are existing users impacted? What migration steps/scripts do we need?

No migration needed.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
