### PR TITLE
Allow additional labels in HookOS service

### DIFF
--- a/helm/tinkerbell/templates/osie/_functions.tpl
+++ b/helm/tinkerbell/templates/osie/_functions.tpl
@@ -150,3 +150,12 @@ if at least one map value is non-nil before using it.
 {{- .Values.optional.osie.service.annotations | toYaml -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "tinkerbell.osie.service.labels" -}}
+{{- $hookLabels := dig "hookos" "service" "labels" nil .Values.optional -}}
+{{- if and (not (kindIs "invalid" $hookLabels)) (gt (len $hookLabels) 0) -}}
+{{- $hookLabels | toYaml -}}
+{{- else if gt (len .Values.optional.osie.service.labels) 0 -}}
+{{- .Values.optional.osie.service.labels | toYaml -}}
+{{- end -}}
+{{- end -}}

--- a/helm/tinkerbell/templates/osie/service.yaml
+++ b/helm/tinkerbell/templates/osie/service.yaml
@@ -12,6 +12,10 @@ kind: Service
 metadata:
   labels:
     app: {{ include "tinkerbell.osie.name" . }}
+    {{- $labels := include "tinkerbell.osie.service.labels" . }}
+    {{- if $labels }}
+    {{- $labels | nindent 4 }}
+    {{- end }}
   name: {{ include "tinkerbell.osie.name" . }}
   namespace: {{ .Release.Namespace | quote }}
   annotations:

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -251,6 +251,7 @@ optional:
       app: hookos # this value is deprecated and will be updated to "osie" in a future release.
     service:
       annotations: {}
+      labels: {}
       lbClass: "kube-vip.io/kube-vip-class"
       loadBalancerIP: ""
       type: LoadBalancer
@@ -306,6 +307,7 @@ optional:
       lbClass:
       loadBalancerIP: 
       type:
+      labels: {}
     affinity: {}
 
   # kubevip objects are used to provide a LoadBalancer IP for the Tinkerbell services.


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Allow additional labels in HookOS service

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Deployed the chart with and without the labels value set
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->
No impact on existing users

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
