### PR TITLE
Ignore NotFound errors when patching Job and Task status:

### DIFF
--- a/rufio/internal/controller/job.go
+++ b/rufio/internal/controller/job.go
@@ -216,6 +216,9 @@ func (r *JobReconciler) createTaskWithOwner(ctx context.Context, job bmc.Job, ta
 // patchStatus patches the specified patch on the Job.
 func (r *JobReconciler) patchStatus(ctx context.Context, job *bmc.Job, patch client.Patch) error {
 	err := r.client.Status().Patch(ctx, job, patch)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to patch Job %s/%s status: %w", job.Namespace, job.Name, err)
 	}

--- a/rufio/internal/controller/task.go
+++ b/rufio/internal/controller/task.go
@@ -286,6 +286,9 @@ func (r *TaskReconciler) checkTaskStatus(ctx context.Context, log logr.Logger, t
 // patchStatus patches the specified patch on the Task.
 func (r *TaskReconciler) patchStatus(ctx context.Context, task *bmc.Task, patch client.Patch) error {
 	err := r.client.Status().Patch(ctx, task, patch)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to patch Task %s/%s status: %w", task.Namespace, task.Name, err)
 	}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
When a BMC Job or Task is deleted (e.g. during Workflow cleanup) while its reconciler is still running, the informer cache can lag behind the API server. This causes patchStatus to fail with a NotFound error, which controller-runtime logs and re-queues, often multiple times until the cache catches up.

This treats NotFound as a no-op in patchStatus for both the Job and Task reconcilers since there is nothing to update on a deleted resource.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
