### PR TITLE
support labels for hookos service

### DIFF
--- a/helm/tinkerbell/templates/osie/service.yaml
+++ b/helm/tinkerbell/templates/osie/service.yaml
@@ -12,6 +12,9 @@ kind: Service
 metadata:
   labels:
     app: {{ include "tinkerbell.osie.name" . }}
+    {{- with .Values.optional.osie.service.labels }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
   name: {{ include "tinkerbell.osie.name" . }}
   namespace: {{ .Release.Namespace | quote }}
   annotations:

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -251,6 +251,7 @@ optional:
       app: hookos # this value is deprecated and will be updated to "osie" in a future release.
     service:
       annotations: {}
+      labels: {}
       lbClass: "kube-vip.io/kube-vip-class"
       loadBalancerIP: ""
       type: LoadBalancer


### PR DESCRIPTION
## Description

This PR allows user to add custom labels to hookos service in helm chart.

Fixes: #426 
The changes include adding labels field in values.yaml and rendering the service in service.yaml

## How Has This Been Tested?

Test command used:
```
helm template test ./helm/tinkerbell \
--set artifactsFileServer=http://192.168.1.10:7173 \
--set optional.hookos.service.labels.mylabel=enabled
```
The rendered output includes:
```
metadata:
  labels:
    app: hookos
    mylabel: enabled
```
This output ensures that custom labels are processed


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
