### PR TITLE
Fix mergify issue:

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -38,6 +38,7 @@ queue_rules:
 
 pull_request_rules:
   - name: refactored queue action rule
-    conditions: []
+    conditions:
+      - -draft
     actions:
       queue:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Mergify has suddenly started enforcing new rules. This is needed so that draft PR's don't block mergify from doing its job.

This is the failure mergify complaining about. "All predecessor PRs in the stack must be open and not drafts to queue."

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
