### PR TITLE
Switch Mergify to autoqueue and exclude draft PRs from queue conditions:

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,8 +2,10 @@ merge_queue:
   max_parallel_checks: 1
 queue_rules:
   - name: default
+    autoqueue: true
     batch_size: 1
     queue_conditions:
+      - -draft
       - base=main
       - or:
           - "#approved-reviews-by>=1"
@@ -36,9 +38,3 @@ queue_rules:
 
       {{ body }}
 
-pull_request_rules:
-  - name: refactored queue action rule
-    conditions:
-      - -draft
-    actions:
-      queue:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Draft PRs were being detected as stack predecessors and blocking unrelated PRs from entering the merge queue. Moving to autoqueue with an explicit -draft queue condition prevents draft PRs from interfering with the queue entirely.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
