### PR TITLE
Fix workflow deadlock after tink-server restart

### DIFF
--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -145,10 +145,30 @@ func (c *Config) Run(ctx context.Context, log logr.Logger) {
 		responseEvent.Message = "action completed"
 		responseEvent.State = state
 
-		if err := c.TransportWriter.Write(ctx, responseEvent); err != nil {
-			log.Info("error writing event", "error", err)
-			doBackoff <- true
-			continue
+		// Retry reporting the action completion with backoff. The agent must persist in
+		// reporting the result because the server will not re-serve the action once the agent
+		// has moved past execution. Giving up here would leave the workflow permanently stuck.
+		reportBackoff := &backoff.ExponentialBackOff{
+			InitialInterval:     c.Backoff.InitialInterval,
+			RandomizationFactor: c.Backoff.RandomizationFactor,
+			Multiplier:          c.Backoff.Multiplier,
+			MaxInterval:         c.Backoff.MaxInterval,
+		}
+		writeOp := func() (any, error) {
+			return nil, c.TransportWriter.Write(ctx, responseEvent)
+		}
+		if _, err := backoff.Retry(ctx, writeOp,
+			backoff.WithBackOff(reportBackoff),
+			backoff.WithMaxElapsedTime(0), // Retry indefinitely; giving up leaves the workflow stuck.
+			backoff.WithNotify(func(err error, next time.Duration) {
+				log.Info("error reporting action, retrying", "error", err, "retryIn", next.String())
+			}),
+		); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Info("permanent error reporting action", "error", err)
+			return
 		}
 		log.Info("reported action status", "action", action, "state", state)
 

--- a/tink/agent/agent_test.go
+++ b/tink/agent/agent_test.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/go-logr/logr"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 )
@@ -29,4 +32,128 @@ func TestRun(_ *testing.T) {
 	go c.Run(ctx, logr.Discard())
 	<-time.After(1 * time.Second)
 	cancel()
+}
+
+// oneActionReader returns one action then blocks until ctx is cancelled.
+type oneActionReader struct {
+	sent atomic.Bool
+}
+
+func (r *oneActionReader) Read(ctx context.Context) (spec.Action, error) {
+	if r.sent.CompareAndSwap(false, true) {
+		return spec.Action{ID: "a1", TimeoutSeconds: 5}, nil
+	}
+	<-ctx.Done()
+	return spec.Action{}, ctx.Err()
+}
+
+// failNWriter fails the first N completion writes then succeeds and cancels the context.
+type failNWriter struct {
+	failCount int
+	calls     atomic.Int32
+	cancel    context.CancelFunc
+}
+
+func (w *failNWriter) Write(_ context.Context, _ spec.Event) error {
+	n := int(w.calls.Add(1))
+	// The first write is the "running" event, always succeed.
+	// Subsequent writes are completion reports; fail the first failCount of those.
+	if n == 1 {
+		return nil
+	}
+	completionCall := n - 1
+	if completionCall <= w.failCount {
+		return fmt.Errorf("transient error %d", completionCall)
+	}
+	// Successful completion write — cancel so Run exits promptly.
+	if w.cancel != nil {
+		w.cancel()
+	}
+	return nil
+}
+
+func TestRunRetriesWriteFailures(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	writer := &failNWriter{failCount: 3, cancel: cancel}
+	c := &Config{
+		TransportReader: &oneActionReader{},
+		RuntimeExecutor: &mock{},
+		TransportWriter: writer,
+		Backoff: &backoff.ExponentialBackOff{
+			InitialInterval:     time.Millisecond,
+			RandomizationFactor: 0,
+			Multiplier:          1,
+			MaxInterval:         time.Millisecond,
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.Run(ctx, logr.Discard())
+		close(done)
+	}()
+
+	select {
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not complete after retried writes")
+	case <-done:
+	}
+
+	// 1 "running" write + (failCount) failed completion writes + 1 successful completion write
+	want := int32(1 + writer.failCount + 1)
+	got := writer.calls.Load()
+	if got != want {
+		t.Errorf("expected %d Write calls, got %d", want, got)
+	}
+}
+
+// permanentWriter always returns a backoff.Permanent error on completion writes.
+type permanentWriter struct {
+	calls atomic.Int32
+}
+
+func (w *permanentWriter) Write(_ context.Context, _ spec.Event) error {
+	n := int(w.calls.Add(1))
+	if n == 1 {
+		return nil // "running" event succeeds
+	}
+	return backoff.Permanent(fmt.Errorf("unrecoverable"))
+}
+
+func TestRunHaltsOnPermanentWriteError(t *testing.T) {
+	writer := &permanentWriter{}
+	c := &Config{
+		TransportReader: &oneActionReader{},
+		RuntimeExecutor: &mock{},
+		TransportWriter: writer,
+		Backoff: &backoff.ExponentialBackOff{
+			InitialInterval:     time.Millisecond,
+			RandomizationFactor: 0,
+			Multiplier:          1,
+			MaxInterval:         time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		c.Run(ctx, logr.Discard())
+		close(done)
+	}()
+
+	select {
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not halt after permanent error")
+	case <-done:
+	}
+
+	// 1 "running" write + 1 permanent-error completion write = 2 total
+	got := writer.calls.Load()
+	if got != 2 {
+		t.Errorf("expected 2 Write calls, got %d", got)
+	}
 }

--- a/tink/agent/internal/transport/grpc/grpc.go
+++ b/tink/agent/internal/transport/grpc/grpc.go
@@ -122,7 +122,10 @@ func (c *Config) doWrite(ctx context.Context, event spec.Event) error {
 		Message:           &proto.ActionMessage{Message: toPtr(event.Message)},
 	}
 	_, err := c.TinkServerClient.ReportActionStatus(ctx, ar)
-	if status.Code(err) == codes.Internal {
+	switch status.Code(err) { //nolint:exhaustive // we want to retry on any error that is not explicitly marked as permanent
+	case codes.OK:
+		return nil
+	case codes.NotFound, codes.InvalidArgument, codes.FailedPrecondition:
 		return backoff.Permanent(err)
 	}
 	if err != nil {

--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -301,27 +301,29 @@ func (h *Handler) doGetAction(ctx context.Context, req *proto.ActionRequest, opt
 func resolveAction(ctx context.Context, task *tinkerbell.Task, currentState *tinkerbell.CurrentState) (*tinkerbell.Action, error) {
 	switch {
 	case isFirstAction(*task):
-		if task.Actions[0].State != tinkerbell.WorkflowStatePending {
-			journal.Log(ctx, "first Action not in pending state")
-			return nil, status.Error(codes.FailedPrecondition, "first Action not in pending state")
-		}
 		journal.Log(ctx, "first Action")
 		return &task.Actions[0], nil
 
-	case currentState != nil && currentState.State == tinkerbell.WorkflowStateRunning:
-		// Re-serve the current running action. This handles agent reconnection after a server
-		// restart where the agent completed an action but couldn't report the result.
+	case currentState != nil && (currentState.State == tinkerbell.WorkflowStateRunning || currentState.State == tinkerbell.WorkflowStatePending):
+		// Re-serve the current action. This handles two restart scenarios:
+		// 1. Server restarts after serving an action but before the agent reports RUNNING
+		//    (currentState persisted as PENDING by GetAction).
+		// 2. Server restarts while the agent is executing (currentState is RUNNING).
 		for idx := range task.Actions {
 			if task.Actions[idx].ID == currentState.ActionID {
-				journal.Log(ctx, "re-serving running Action", "actionID", task.Actions[idx].ID)
+				journal.Log(ctx, "re-serving in-progress Action", "actionID", task.Actions[idx].ID, "state", currentState.State)
 				return &task.Actions[idx], nil
 			}
 		}
-		journal.Log(ctx, "running Action not found in task")
-		return nil, status.Error(codes.NotFound, "running Action not found in task")
+		journal.Log(ctx, "in-progress Action not found in task")
+		return nil, status.Error(codes.NotFound, "in-progress Action not found in task")
 
 	default:
 		// Get the next Action after the one defined in the current state.
+		if currentState == nil {
+			journal.Log(ctx, "no current state available")
+			return nil, status.Error(codes.FailedPrecondition, "no current state available")
+		}
 		if currentState.State != tinkerbell.WorkflowStateSuccess {
 			journal.Log(ctx, "current Action not in success state")
 			return nil, status.Error(codes.FailedPrecondition, "current Action not in success state")

--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -242,39 +242,9 @@ func (h *Handler) doGetAction(ctx context.Context, req *proto.ActionRequest, opt
 		return nil, status.Error(codes.NotFound, "no Actions found")
 	}
 
-	var action *tinkerbell.Action
-	if isFirstAction(*task) {
-		if task.Actions[0].State != tinkerbell.WorkflowStatePending {
-			journal.Log(ctx, "first Action not in pending state")
-			return nil, status.Error(codes.FailedPrecondition, "first Action not in pending state")
-		}
-		journal.Log(ctx, "first Action")
-		action = &task.Actions[0]
-	} else {
-		// This handles Actions after the first one
-		// Get the current Action. If it is not in a success state, return error.
-		if wf.Status.CurrentState.State != tinkerbell.WorkflowStateSuccess {
-			journal.Log(ctx, "current Action not in success state")
-			return nil, status.Error(codes.FailedPrecondition, "current Action not in success state")
-		}
-		// Get the next Action after the one defined in the current state.
-		for idx, act := range task.Actions {
-			if act.ID == wf.Status.CurrentState.ActionID {
-				// if the action is the last one in the task, return error
-				if idx == len(task.Actions)-1 {
-					journal.Log(ctx, "last Action in task")
-					// if the workflow has another task, then return the next action in that task.
-					return nil, status.Error(codes.NotFound, "last Action in task")
-				}
-				action = &task.Actions[idx+1]
-				journal.Log(ctx, "found Action", "actionID", action.ID)
-				break
-			}
-		}
-		if action == nil {
-			journal.Log(ctx, "no Action found")
-			return nil, status.Error(codes.NotFound, "no Action found")
-		}
+	action, err := resolveAction(ctx, task, wf.Status.CurrentState)
+	if err != nil {
+		return nil, err
 	}
 	// This check goes after the action is found, so that multi task Workflows can be handled.
 	if task.AgentID != req.GetAgentId() {
@@ -325,6 +295,50 @@ func (h *Handler) doGetAction(ctx context.Context, req *proto.ActionRequest, opt
 	log.Info("sending action", "action", ar, "actionID", action.ID)
 	journal.Log(ctx, "sending Action", "action", ar)
 	return ar, nil
+}
+
+// resolveAction determines which action to serve for the given task based on the workflow's current state.
+func resolveAction(ctx context.Context, task *tinkerbell.Task, currentState *tinkerbell.CurrentState) (*tinkerbell.Action, error) {
+	switch {
+	case isFirstAction(*task):
+		if task.Actions[0].State != tinkerbell.WorkflowStatePending {
+			journal.Log(ctx, "first Action not in pending state")
+			return nil, status.Error(codes.FailedPrecondition, "first Action not in pending state")
+		}
+		journal.Log(ctx, "first Action")
+		return &task.Actions[0], nil
+
+	case currentState != nil && currentState.State == tinkerbell.WorkflowStateRunning:
+		// Re-serve the current running action. This handles agent reconnection after a server
+		// restart where the agent completed an action but couldn't report the result.
+		for idx := range task.Actions {
+			if task.Actions[idx].ID == currentState.ActionID {
+				journal.Log(ctx, "re-serving running Action", "actionID", task.Actions[idx].ID)
+				return &task.Actions[idx], nil
+			}
+		}
+		journal.Log(ctx, "running Action not found in task")
+		return nil, status.Error(codes.NotFound, "running Action not found in task")
+
+	default:
+		// Get the next Action after the one defined in the current state.
+		if currentState.State != tinkerbell.WorkflowStateSuccess {
+			journal.Log(ctx, "current Action not in success state")
+			return nil, status.Error(codes.FailedPrecondition, "current Action not in success state")
+		}
+		for idx, act := range task.Actions {
+			if act.ID == currentState.ActionID {
+				if idx == len(task.Actions)-1 {
+					journal.Log(ctx, "last Action in task")
+					return nil, status.Error(codes.NotFound, "last Action in task")
+				}
+				journal.Log(ctx, "found Action", "actionID", task.Actions[idx+1].ID)
+				return &task.Actions[idx+1], nil
+			}
+		}
+		journal.Log(ctx, "no Action found")
+		return nil, status.Error(codes.NotFound, "no Action found")
+	}
 }
 
 // isFirstAction checks if the Task is at the first Action.

--- a/tink/server/internal/grpc/grpc_test.go
+++ b/tink/server/internal/grpc/grpc_test.go
@@ -159,6 +159,120 @@ func TestGetAction(t *testing.T) {
 			request: &proto.ActionRequest{},
 			wantErr: status.Errorf(codes.InvalidArgument, "invalid Agent ID"),
 		},
+		"re-serve running first Action after server restart": {
+			request: &proto.ActionRequest{
+				AgentId: toPtr("machine-mac-1"),
+			},
+			workflow: &tinkerbell.Workflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine1",
+					Namespace: "default",
+				},
+				Status: tinkerbell.WorkflowStatus{
+					State: tinkerbell.WorkflowStateRunning,
+					CurrentState: &tinkerbell.CurrentState{
+						AgentID:    "machine-mac-1",
+						TaskID:     "provision",
+						ActionID:   "stream",
+						State:      tinkerbell.WorkflowStateRunning,
+						ActionName: "stream",
+					},
+					GlobalTimeout: 600,
+					Tasks: []tinkerbell.Task{
+						{
+							Name:    "provision",
+							AgentID: "machine-mac-1",
+							ID:      "provision",
+							Actions: []tinkerbell.Action{
+								{
+									Name:    "stream",
+									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
+									Timeout: 300,
+									State:   tinkerbell.WorkflowStateRunning,
+									ID:      "stream",
+								},
+								{
+									Name:    "kexec",
+									Image:   "quay.io/tinkerbell-actions/kexec:v1.0.0",
+									Timeout: 5,
+									State:   tinkerbell.WorkflowStatePending,
+									ID:      "kexec",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &proto.ActionResponse{
+				WorkflowId:  toPtr("default/machine1"),
+				AgentId:     toPtr("machine-mac-1"),
+				TaskId:      toPtr("provision"),
+				ActionId:    toPtr("stream"),
+				Name:        toPtr("stream"),
+				Image:       toPtr("quay.io/tinkerbell-actions/image2disk:v1.0.0"),
+				Timeout:     toPtr(int64(300)),
+				Environment: []string{},
+				Pid:         new(string),
+			},
+			wantErr: nil,
+		},
+		"re-serve running non-first Action after server restart": {
+			request: &proto.ActionRequest{
+				AgentId: toPtr("machine-mac-1"),
+			},
+			workflow: &tinkerbell.Workflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine1",
+					Namespace: "default",
+				},
+				Status: tinkerbell.WorkflowStatus{
+					State: tinkerbell.WorkflowStateRunning,
+					CurrentState: &tinkerbell.CurrentState{
+						AgentID:    "machine-mac-1",
+						TaskID:     "provision",
+						ActionID:   "kexec",
+						State:      tinkerbell.WorkflowStateRunning,
+						ActionName: "kexec",
+					},
+					GlobalTimeout: 600,
+					Tasks: []tinkerbell.Task{
+						{
+							Name:    "provision",
+							AgentID: "machine-mac-1",
+							ID:      "provision",
+							Actions: []tinkerbell.Action{
+								{
+									Name:    "stream",
+									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
+									Timeout: 300,
+									State:   tinkerbell.WorkflowStateSuccess,
+									ID:      "stream",
+								},
+								{
+									Name:    "kexec",
+									Image:   "quay.io/tinkerbell-actions/kexec:v1.0.0",
+									Timeout: 5,
+									State:   tinkerbell.WorkflowStateRunning,
+									ID:      "kexec",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &proto.ActionResponse{
+				WorkflowId:  toPtr("default/machine1"),
+				AgentId:     toPtr("machine-mac-1"),
+				TaskId:      toPtr("provision"),
+				ActionId:    toPtr("kexec"),
+				Name:        toPtr("kexec"),
+				Image:       toPtr("quay.io/tinkerbell-actions/kexec:v1.0.0"),
+				Timeout:     toPtr(int64(5)),
+				Environment: []string{},
+				Pid:         new(string),
+			},
+			wantErr: nil,
+		},
 	}
 
 	for name, tc := range cases {

--- a/tink/server/internal/grpc/grpc_test.go
+++ b/tink/server/internal/grpc/grpc_test.go
@@ -273,6 +273,103 @@ func TestGetAction(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		"nil currentState with non-pending first action": {
+			request: &proto.ActionRequest{
+				AgentId: toPtr("machine-mac-1"),
+			},
+			workflow: &tinkerbell.Workflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine1",
+					Namespace: "default",
+				},
+				Status: tinkerbell.WorkflowStatus{
+					State:         tinkerbell.WorkflowStateRunning,
+					CurrentState:  nil,
+					GlobalTimeout: 600,
+					Tasks: []tinkerbell.Task{
+						{
+							Name:    "provision",
+							AgentID: "machine-mac-1",
+							ID:      "provision",
+							Actions: []tinkerbell.Action{
+								{
+									Name:    "stream",
+									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
+									Timeout: 300,
+									State:   tinkerbell.WorkflowStateSuccess,
+									ID:      "stream",
+								},
+								{
+									Name:    "kexec",
+									Image:   "quay.io/tinkerbell-actions/kexec:v1.0.0",
+									Timeout: 5,
+									State:   tinkerbell.WorkflowStatePending,
+									ID:      "kexec",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: status.Errorf(codes.FailedPrecondition, "no current state available"),
+		},
+		"re-serve pending non-first Action after server restart": {
+			request: &proto.ActionRequest{
+				AgentId: toPtr("machine-mac-1"),
+			},
+			workflow: &tinkerbell.Workflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine1",
+					Namespace: "default",
+				},
+				Status: tinkerbell.WorkflowStatus{
+					State: tinkerbell.WorkflowStateRunning,
+					CurrentState: &tinkerbell.CurrentState{
+						AgentID:    "machine-mac-1",
+						TaskID:     "provision",
+						ActionID:   "kexec",
+						State:      tinkerbell.WorkflowStatePending,
+						ActionName: "kexec",
+					},
+					GlobalTimeout: 600,
+					Tasks: []tinkerbell.Task{
+						{
+							Name:    "provision",
+							AgentID: "machine-mac-1",
+							ID:      "provision",
+							Actions: []tinkerbell.Action{
+								{
+									Name:    "stream",
+									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
+									Timeout: 300,
+									State:   tinkerbell.WorkflowStateSuccess,
+									ID:      "stream",
+								},
+								{
+									Name:    "kexec",
+									Image:   "quay.io/tinkerbell-actions/kexec:v1.0.0",
+									Timeout: 5,
+									State:   tinkerbell.WorkflowStatePending,
+									ID:      "kexec",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &proto.ActionResponse{
+				WorkflowId:  toPtr("default/machine1"),
+				AgentId:     toPtr("machine-mac-1"),
+				TaskId:      toPtr("provision"),
+				ActionId:    toPtr("kexec"),
+				Name:        toPtr("kexec"),
+				Image:       toPtr("quay.io/tinkerbell-actions/kexec:v1.0.0"),
+				Timeout:     toPtr(int64(5)),
+				Environment: []string{},
+				Pid:         new(string),
+			},
+			wantErr: nil,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## Description

If the tink-server restarts while an action is in progress, the workflow gets permanently stuck. Two bugs combine to cause this:

1. **Server side**: `GetAction` rejects requests when `currentState` is not `SUCCESS`, so the reconnecting agent can never retrieve or advance the Action — even though the server itself persists `currentState` as `PENDING` when serving new actions.
2. **Agent side**: When reporting an Action completion fails (server unreachable), the Agent abandons the result and loops back to `GetAction`, which the server then rejects per (1).

### Changes

**Server — `resolveAction` extraction** (`tink/server/internal/grpc/grpc.go`)
- Extract Action resolution into `resolveAction` with a `switch` covering all `currentState` states.
- Re-serve the in-progress Action when `currentState` is `PENDING` or `RUNNING`, covering server restarts at any point between serving and completion.
- Guard against nil `currentState` to prevent panics in edge cases.
- Remove redundant state check in the `isFirstAction` branch (dead code).

**Agent — retry completion reports** (`tink/agent/agent.go`)
- Replace fire-and-forget completion write with `backoff.Retry` using exponential backoff.
- On permanent or context errors, halt the agent (`return`) instead of advancing to the next action.

**Agent transport — error classification** (`tink/agent/internal/transport/grpc/grpc.go`)
- Classify client errors (`InvalidArgument`, `NotFound`, `FailedPrecondition`) as `backoff.Permanent` (non-retryable).
- Keep `Internal` as retryable since `ReportActionStatus` can return it for transient backend failures.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
