### PR TITLE
tootles: pass through storage.raid in HackInstance

### DIFF
--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -57,6 +57,12 @@ type HackInstance struct {
 					} `json:"partitions"`
 					WipeTable bool `json:"wipe_table"`
 				} `json:"disks"`
+				Raid []struct {
+					Name    string   `json:"name"`
+					Level   string   `json:"level"`
+					Devices []string `json:"devices"`
+					Spare   []string `json:"spare,omitempty"`
+				} `json:"raid"`
 				Filesystems []struct {
 					Mount struct {
 						Create struct {

--- a/tootles/internal/backend/backend_test.go
+++ b/tootles/internal/backend/backend_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -370,5 +371,77 @@ func TestIsNotFound(t *testing.T) {
 				t.Fatalf("isNotFound() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestGetHackInstance_PassesThroughRAID verifies that storage.raid entries on
+// a Hardware resource survive the toHackInstance JSON round-trip and appear
+// in the rendered /metadata response. Without the Raid field on
+// HackInstance.Storage, any raid arrays authored on the Hardware CR are
+// silently dropped, breaking rootio workflows that assemble md devices.
+func TestGetHackInstance_PassesThroughRAID(t *testing.T) {
+	hw := &v1alpha1.Hardware{
+		Spec: v1alpha1.HardwareSpec{
+			Metadata: &v1alpha1.HardwareMetadata{
+				Instance: &v1alpha1.MetadataInstance{
+					Storage: &v1alpha1.MetadataInstanceStorage{
+						Disks: []*v1alpha1.MetadataInstanceStorageDisk{
+							{Device: "/dev/sda", WipeTable: true},
+						},
+						Raid: []*v1alpha1.MetadataInstanceStorageRAID{
+							{
+								Name:    "/dev/md0",
+								Level:   "1",
+								Devices: []string{"/dev/sda2", "/dev/sdb2"},
+							},
+						},
+						Filesystems: []*v1alpha1.MetadataInstanceStorageFilesystem{
+							{Mount: &v1alpha1.MetadataInstanceStorageMount{
+								Device: "/dev/md0", Format: "ext4", Point: "/",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b := New(&mockReader{hw: hw})
+	hi, err := b.GetHackInstance(context.Background(), "1.2.3.4")
+	if err != nil {
+		t.Fatalf("GetHackInstance: %v", err)
+	}
+
+	out, err := json.Marshal(hi)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var parsed struct {
+		Metadata struct {
+			Instance struct {
+				Storage struct {
+					Raid []struct {
+						Name    string   `json:"name"`
+						Level   string   `json:"level"`
+						Devices []string `json:"devices"`
+					} `json:"raid"`
+				} `json:"storage"`
+			} `json:"instance"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+
+	got := parsed.Metadata.Instance.Storage.Raid
+	if len(got) != 1 {
+		t.Fatalf("want 1 raid entry in HackInstance JSON, got %d; JSON=%s", len(got), out)
+	}
+	if got[0].Name != "/dev/md0" || got[0].Level != "1" {
+		t.Errorf("raid[0] = %+v, want name=/dev/md0 level=1", got[0])
+	}
+	if diff := cmp.Diff([]string{"/dev/sda2", "/dev/sdb2"}, got[0].Devices); diff != "" {
+		t.Errorf("raid[0].devices mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Description

The `HackInstance` type used by tootles to serve `/metadata` does a typed JSON round-trip (see `tootles/internal/backend/backend.go` `toHackInstance`) but lacked a `Raid` field on its `Storage` struct. Any `raid` entries present in the `Hardware` CR were silently dropped on the way out, leaving the downstream rootio action with no arrays to assemble and breaking any workflow that formats a filesystem on `/dev/mdX`.

The `Hardware` CR type already models `Raid` (`api/v1alpha1/tinkerbell/hardware.go` `MetadataInstanceStorageRAID`), so the fix is a one-struct addition on the metadata side that mirrors the existing `Disks` / `Filesystems` shape.

### Changes

**`pkg/data/instance.go`**
- Add a `Raid` field to `HackInstance.Storage` with the inline-struct style already used by `Disks` and `Filesystems`. Fields: `name`, `level`, `devices`, `spare` (omitempty). This is the mirror that makes the existing `json.Marshal` / `json.Unmarshal` round-trip in `toHackInstance` pick up `raid` entries from the `Hardware` CR.

**`tootles/internal/backend/backend_test.go`**
- Add `TestGetHackInstance_PassesThroughRAID`. Constructs a `Hardware` with `storage.raid` populated, calls `GetHackInstance`, marshals the result, and asserts the raid list survives. Pins the contract so a future edit to either struct that drops `raid` fails the build.

Fixes: #

## How Has This Been Tested?

- New unit test in `tootles/internal/backend/backend_test.go` passes locally (`go test ./tootles/internal/backend/ -run TestGetHackInstance_PassesThroughRAID -v`).
- Full `go test ./tootles/... ./pkg/...` green on this branch against `upstream/main`.
- No behavioural change for Hardware resources without `storage.raid` — the new field is `omitempty` and the existing tests for `toHackInstance` still pass.

## How are existing users impacted? What migration steps/scripts do we need?

Purely additive. No migration. Users who were not setting `storage.raid` on their Hardware resources see no change. Users who were setting `storage.raid` (and wondering why rootio wasn't assembling their arrays) will find the field now serialized into `/metadata` and picked up by the rootio action.

## Checklist

- [x] The title of the PR is clear and informative
- [x] The PR includes tests for new functionality
- [x] Documentation changes are not required (internal struct, behaviour matches existing `Disks` / `Filesystems`)
- [x] All commits are DCO signed off