### PR TITLE
Filter compatible BMC providers before open

### DIFF
--- a/rufio/internal/controller/client.go
+++ b/rufio/internal/controller/client.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -14,6 +15,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/tinkerbell/tinkerbell/api/v1alpha1/bmc"
 )
+
+var errNoCompatibleDrivers = errors.New("no compatible BMC providers found")
 
 // ClientFunc defines a func that returns a bmclib.Client.
 type ClientFunc func(ctx context.Context, log logr.Logger, hostIP, username, password string, opts *BMCOptions) (*bmclib.Client, error)
@@ -36,8 +39,9 @@ func NewClientFunc(timeout time.Duration) ClientFunc {
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
-		if opts != nil && opts.ProviderOptions != nil && len(opts.PreferredOrder) > 0 {
-			client.Registry.Drivers = client.Registry.PreferDriver(toStringSlice(opts.PreferredOrder)...)
+		if err := prepareClientForOpen(ctx, client, opts); err != nil {
+			log.Info("Failed to prepare BMC client", "error", err)
+			return nil, err
 		}
 		if err := client.Open(ctx); err != nil {
 			md := client.GetMetadata()
@@ -50,6 +54,19 @@ func NewClientFunc(timeout time.Duration) ClientFunc {
 
 		return client, nil
 	}
+}
+
+func prepareClientForOpen(ctx context.Context, client *bmclib.Client, opts *BMCOptions) error {
+	if opts != nil && opts.ProviderOptions != nil && len(opts.PreferredOrder) > 0 {
+		client.Registry.Drivers = client.Registry.PreferDriver(toStringSlice(opts.PreferredOrder)...)
+	}
+
+	client.FilterForCompatible(ctx)
+	if len(client.Registry.Drivers) == 0 {
+		return errNoCompatibleDrivers
+	}
+
+	return nil
 }
 
 type BMCOptions struct {

--- a/rufio/internal/controller/client_test.go
+++ b/rufio/internal/controller/client_test.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bmc-toolbox/bmclib/v2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jacobweinstock/registrar"
+	"github.com/tinkerbell/tinkerbell/api/v1alpha1/bmc"
+)
+
+type compatibleTestProvider struct {
+	name       string
+	compatible bool
+	opened     bool
+}
+
+func (p *compatibleTestProvider) Name() string {
+	return p.name
+}
+
+func (p *compatibleTestProvider) Compatible(context.Context) bool {
+	return p.compatible
+}
+
+func (p *compatibleTestProvider) Open(context.Context) error {
+	p.opened = true
+	return nil
+}
+
+func TestPrepareClientForOpenFiltersIncompatibleDrivers(t *testing.T) {
+	incompatible := &compatibleTestProvider{name: "dell", compatible: false}
+	standard := &compatibleTestProvider{name: "ipmitool", compatible: true}
+	preferred := &compatibleTestProvider{name: "gofish", compatible: true}
+	client := newCompatibleTestClient(incompatible, standard, preferred)
+
+	opts := &BMCOptions{
+		ProviderOptions: &bmc.ProviderOptions{
+			PreferredOrder: []bmc.ProviderName{"gofish"},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := prepareClientForOpen(ctx, client, opts); err != nil {
+		t.Fatalf("prepare client for open: %v", err)
+	}
+
+	want := []string{"gofish", "ipmitool"}
+	if diff := cmp.Diff(want, compatibleTestDriverNames(client.Registry.Drivers)); diff != "" {
+		t.Fatalf("unexpected drivers (-want +got):\n%s", diff)
+	}
+
+	if err := client.Open(ctx); err != nil {
+		t.Fatalf("open filtered client: %v", err)
+	}
+	if incompatible.opened {
+		t.Fatal("incompatible driver was opened")
+	}
+	if !standard.opened || !preferred.opened {
+		t.Fatal("compatible drivers were not opened")
+	}
+}
+
+func TestPrepareClientForOpenErrorsWithoutCompatibleDrivers(t *testing.T) {
+	client := newCompatibleTestClient(
+		&compatibleTestProvider{name: "dell", compatible: false},
+		&compatibleTestProvider{name: "ipmitool", compatible: false},
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := prepareClientForOpen(ctx, client, nil)
+	if !errors.Is(err, errNoCompatibleDrivers) {
+		t.Fatalf("expected no compatible drivers error, got %v", err)
+	}
+	if len(client.Registry.Drivers) != 0 {
+		t.Fatalf("expected empty driver registry, got %d drivers", len(client.Registry.Drivers))
+	}
+}
+
+func newCompatibleTestClient(providers ...*compatibleTestProvider) *bmclib.Client {
+	registry := registrar.NewRegistry()
+	for _, provider := range providers {
+		registry.Register(provider.name, provider.name, nil, nil, provider)
+	}
+
+	return bmclib.NewClient("127.0.0.1", "username", "password", bmclib.WithRegistry(registry))
+}
+
+func compatibleTestDriverNames(drivers registrar.Drivers) []string {
+	names := make([]string, 0, len(drivers))
+	for _, driver := range drivers {
+		names = append(names, driver.Name)
+	}
+
+	return names
+}


### PR DESCRIPTION
## Summary
- filter Rufio bmclib clients with `FilterForCompatible` before opening connections
- keep configured preferred provider ordering before filtering
- return a clear error when no compatible providers remain

## Testing
- `go test ./rufio/internal/controller -count=1`
- `go test ./rufio/... -count=1`
- `go vet ./rufio/...`
- `go test ./rufio/internal/controller -run TestPrepareClientForOpen -race -count=1`
- `TMPDIR=/home/akash/.cache make test TEST_PKG=rufio/internal/controller`

Resolves #461