### PR TITLE
Get nerdctl logs working:

### DIFF
--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -137,4 +137,5 @@ func RegisterDockerRuntimeFlags(c *config, fs *flag.FlagSet) {
 func RegisterContainerdRuntimeFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.Options.Runtime.Containerd.Namespace, "containerd-namespace", "tinkerbell", "Containerd namespace")
 	fs.StringVar(&c.Options.Runtime.Containerd.SocketPath, "containerd-socket", "/run/containerd/containerd.sock", "Containerd socket path")
+	fs.StringVar(&c.Options.Runtime.Containerd.DataRoot, "containerd-data-root", "/var/lib/nerdctl", "Root directory for nerdctl-compatible per-container state (json-file logs read by `nerdctl logs`)")
 }

--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -252,6 +252,7 @@ type DockerRuntime struct {
 type ContainerdRuntime struct {
 	Namespace  string
 	SocketPath string
+	DataRoot   string
 }
 
 // BackoffOptions holds the configuration for the backoff strategy.
@@ -325,6 +326,9 @@ func (o *Options) ConfigureAndRun(inctx context.Context, log logr.Logger, id str
 		}
 		if o.Runtime.Containerd.SocketPath != "" {
 			opts = append(opts, containerd.WithSocketPath(o.Runtime.Containerd.SocketPath))
+		}
+		if o.Runtime.Containerd.DataRoot != "" {
+			opts = append(opts, containerd.WithDataRoot(o.Runtime.Containerd.DataRoot))
 		}
 		cd, err := containerd.NewConfig(log, opts...)
 		if err != nil {

--- a/tink/agent/internal/runtime/containerd/containerd.go
+++ b/tink/agent/internal/runtime/containerd/containerd.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"syscall"
 	"time"
@@ -95,6 +96,9 @@ type Config struct {
 	Log        logr.Logger
 	SocketPath string
 	CNI        gocni.CNI
+	// DataRoot is the on-disk root used for nerdctl-compatible per-container
+	// state (the json-file logs that `nerdctl logs` reads).
+	DataRoot string
 }
 
 type Opt func(*Config)
@@ -117,11 +121,18 @@ func WithSocketPath(socketPath string) Opt {
 	}
 }
 
+func WithDataRoot(dataRoot string) Opt {
+	return func(c *Config) {
+		c.DataRoot = dataRoot
+	}
+}
+
 func NewConfig(log logr.Logger, opts ...Opt) (*Config, error) {
 	c := &Config{
 		Log:        log,
 		Namespace:  defaultNamespace,
 		SocketPath: defaultSocketPath,
+		DataRoot:   defaultDataRoot,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -229,12 +240,34 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 		}
 	}()
 
+	// Compute the per-container log directory and json-file path. nerdctl
+	// reads these locations directly (it does NOT consult the
+	// nerdctl/log-uri label), so they must match its conventions exactly
+	// for `nerdctl logs <id>` to work.
+	dataStore, err := dataStoreDir(c.DataRoot, c.SocketPath)
+	if err != nil {
+		return fmt.Errorf("failed to compute data store: %w", err)
+	}
+
 	// create a container
-	tainer, hostname, err := c.createContainer(ctx, image, a, useHostNetwork, df)
+	tainer, hostname, err := c.createContainer(ctx, image, a, useHostNetwork, df, dataStore)
 	if err != nil {
 		return fmt.Errorf("error creating container: %w", err)
 	}
+	// success is flipped to true at the single happy-path return below.
+	// The deferred cleanups below key off it: on failure we retain the
+	// container (and its rootfs snapshot + on-disk log directory) so an
+	// operator can run `nerdctl --namespace tinkerbell ps -a / inspect /
+	// logs <id>` and then `nerdctl rm <id>` to reclaim everything. CNI and
+	// DNS scratch state are always cleaned up because they leak host
+	// resources rather than debug value.
+	success := false
 	defer func() {
+		if !success {
+			c.Log.Info("action failed, retaining container for debugging (clean up with `nerdctl rm`)",
+				"container", tainer.ID(), "namespace", c.Namespace)
+			return
+		}
 		dctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), c.Namespace), 10*time.Second)
 		if err := tainer.Delete(dctx, containerd.WithSnapshotCleanup); err != nil {
 			c.Log.Info("failed to delete container", "container", tainer.ID(), "error", err)
@@ -249,9 +282,45 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 		c.Log.Error(err, "failed to set container hostname in DNS files")
 	}
 
-	// create the task
-	task, err := tainer.NewTask(ctx, cio.NewCreator(cio.WithStdio))
+	containerID := tainer.ID()
+
+	// Write log-config.json so `nerdctl logs` selects the json-file driver.
+	logDir := containerLogDir(dataStore, c.Namespace, containerID)
+	if err := writeLogConfig(logDir, c.SocketPath); err != nil {
+		return fmt.Errorf("failed to write log-config.json: %w", err)
+	}
+
+	// Open the json-file log writer pair and tee container stdout/stderr
+	// into both the json-file (for `nerdctl logs`) and tink-agent's own
+	// stdout/stderr (which are forwarded via syslog to tink-server).
+	logPair, err := newJSONLogPair(containerLogFile(dataStore, c.Namespace, containerID))
 	if err != nil {
+		return fmt.Errorf("failed to open container log file: %w", err)
+	}
+	// Closed below, after task.Delete, so io copy goroutines drain first.
+
+	// On success, remove the per-container log directory so we don't
+	// accumulate state on long-lived hosts. On failure (or context
+	// cancellation) we deliberately keep the directory so operators can run
+	// `nerdctl logs <id>` for post-mortem. Registered BEFORE the task defer
+	// so it runs AFTER it (LIFO): the log file must be closed and flushed
+	// before the directory is removed.
+	defer func() {
+		if success {
+			if err := os.RemoveAll(logDir); err != nil {
+				c.Log.Info("failed to remove container log directory", "dir", logDir, "error", err)
+			}
+		}
+	}()
+
+	// create the task
+	task, err := tainer.NewTask(ctx, cio.NewCreator(cio.WithStreams(
+		nil,
+		io.MultiWriter(os.Stdout, logPair.Stdout),
+		io.MultiWriter(os.Stderr, logPair.Stderr),
+	)))
+	if err != nil {
+		_ = logPair.Close()
 		return fmt.Errorf("error creating task: %w", err)
 	}
 	defer func() {
@@ -263,10 +332,14 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 			c.Log.V(1).Info("task deleted", "task", task.ID(), "status", status)
 		}
 		cancel()
+		// Flush + close the log file AFTER task.Delete so the cio copy
+		// goroutines have finished writing.
+		if err := logPair.Close(); err != nil {
+			c.Log.Info("failed to close container log file", "error", err)
+		}
 	}()
 
 	// Setup CNI networking if not using host network
-	containerID := tainer.ID()
 	c.Log.V(1).Info("network configuration", "useHostNetwork", useHostNetwork, "cniAvailable", c.CNI != nil, "networkNamespace", a.Namespaces.Network)
 	if !useHostNetwork && c.CNI != nil {
 		netns := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
@@ -308,6 +381,7 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 		if exitStatus.ExitCode() != 0 {
 			return fmt.Errorf("task exited with non-zero code: %d, error: %w", exitStatus.ExitCode(), exitStatus.Error())
 		}
+		success = true
 		return nil
 	case <-ctx.Done():
 		// Context was cancelled; kill the task and wait for it to exit.
@@ -322,7 +396,7 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	}
 }
 
-func (c *Config) createContainer(ctx context.Context, image containerd.Image, action spec.Action, useHostNetwork bool, df *dnsFiles) (containerd.Container, string, error) {
+func (c *Config) createContainer(ctx context.Context, image containerd.Image, action spec.Action, useHostNetwork bool, df *dnsFiles, dataStore string) (containerd.Container, string, error) {
 	newOpts := []containerd.NewContainerOpts{}
 	specOpts := []oci.SpecOpts{
 		oci.WithImageConfig(image), // Loads ENTRYPOINT and CMD from image
@@ -382,8 +456,16 @@ func (c *Config) createContainer(ctx context.Context, image containerd.Image, ac
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to generate container ID: %w", err)
 	}
-	snapshotName := conv.ParseName(action.ID, action.Name)
-	newOpts = append(newOpts, containerd.WithNewSnapshot(snapshotName, image))
+	// displayName is the human-readable name surfaced to operators (NAMES
+	// column in `nerdctl ps`, .Name in `nerdctl inspect`). snapshotID is
+	// the on-disk snapshot identifier, suffixed with the first 8 chars of
+	// the container ID so retried actions (which reuse action.ID) don't
+	// collide on the snapshot name when an earlier failed attempt's
+	// container has been retained for debugging. Keeping these distinct
+	// preserves a stable display name across retries.
+	displayName := conv.ParseName(action.ID, action.Name)
+	snapshotID := displayName + "-" + containerID[:8]
+	newOpts = append(newOpts, containerd.WithNewSnapshot(snapshotID, image))
 
 	// Compute the container hostname. For host-network containers, use the
 	// host's real hostname; for isolated-network containers, use the first
@@ -402,16 +484,36 @@ func (c *Config) createContainer(ctx context.Context, image containerd.Image, ac
 	specOpts = append(specOpts, oci.WithHostname(hostname))
 	newOpts = append(newOpts, containerd.WithNewSpec(specOpts...))
 
-	// Set container labels so nerdctl can display container metadata correctly.
-	// - nerdctl/name: human-readable name shown in the NAMES column of nerdctl ps.
-	// - nerdctl/extraHosts: custom host-to-IP mappings (--add-host); empty for
-	//   tink-agent containers but must be set to "[]" so nerdctl inspect shows
-	//   an empty array instead of null.
-	// - nerdctl/hostname: the container hostname, used by nerdctl inspect.
+	// Container labels. Verified against nerdctl main: pkg/cmd/container/
+	// {logs,remove,inspect}.go, pkg/logging/log_viewer.go, pkg/ocihook/
+	// ocihook.go, pkg/containerutil/container_network_manager.go.
+	//
+	// Required for `nerdctl logs`:
+	//   - nerdctl/namespace: read into LogViewOptions.Namespace; an empty
+	//     namespace fails Validate() with "log viewing options require a
+	//     ContainerID and Namespace". The log driver itself is selected
+	//     from log-config.json on disk (see writeLogConfig), NOT a label.
+	//
+	// Required for `nerdctl rm` to clean up our per-container log dir:
+	//   - nerdctl/state-dir: nerdctl rm does os.RemoveAll(labels[state-dir]).
+	//
+	// Required because nerdctl json.Unmarshals it unconditionally:
+	//   - nerdctl/extraHosts: ocihook and container_network_manager parse
+	//     this as JSON; missing/empty would trip the OCI hook with a json
+	//     error. "[]" is the safe minimum.
+	//
+	// Cosmetic (surfaced by `nerdctl ps` / `nerdctl inspect` only):
+	//   - nerdctl/name:     NAMES column in `ps`; Name in `inspect`.
+	//   - nerdctl/hostname: Config.Hostname in `inspect`.
+	//   - nerdctl/log-uri:  HostConfig.LogConfig.LogURI in `inspect`. NOT
+	//     read by `nerdctl logs` (driver comes from log-config.json).
 	labels := map[string]string{
-		"nerdctl/name":       snapshotName,
+		"nerdctl/namespace":  c.Namespace,
+		"nerdctl/name":       displayName,
 		"nerdctl/extraHosts": "[]",
 		"nerdctl/hostname":   hostname,
+		"nerdctl/log-uri":    "json-file://" + containerLogFile(dataStore, c.Namespace, containerID),
+		"nerdctl/state-dir":  containerLogDir(dataStore, c.Namespace, containerID),
 	}
 	newOpts = append(newOpts, containerd.WithContainerLabels(labels))
 

--- a/tink/agent/internal/runtime/containerd/datastore.go
+++ b/tink/agent/internal/runtime/containerd/datastore.go
@@ -1,0 +1,119 @@
+package containerd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultDataRoot mirrors nerdctl's default --data-root. nerdctl stores
+// per-container state (including json-file logs) under
+// <DataRoot>/<sha256(address)[:8]>/containers/<namespace>/<id>/.
+//
+// See: https://github.com/containerd/nerdctl/blob/main/pkg/clientutil/client.go
+const defaultDataRoot = "/var/lib/nerdctl"
+
+// dataStoreDir reproduces nerdctl's pkg/clientutil.DataStore so that files
+// written here are discoverable by the `nerdctl` CLI talking to the same
+// containerd socket. The 8-character suffix is the first 8 hex chars of the
+// SHA-256 of the (symlink-resolved) socket path; e.g. for the default
+// "/run/containerd/containerd.sock" the suffix is "1935db59".
+//
+// Reproduced (rather than imported) to avoid pulling nerdctl's full
+// dependency tree. Mirror of:
+// https://github.com/containerd/nerdctl/blob/main/pkg/clientutil/client.go
+func dataStoreDir(dataRoot, address string) (string, error) {
+	if dataRoot == "" {
+		dataRoot = defaultDataRoot
+	}
+	if err := os.MkdirAll(dataRoot, 0o700); err != nil {
+		return "", fmt.Errorf("create data root %q: %w", dataRoot, err)
+	}
+	suffix, err := addrHash(address)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(dataRoot, suffix)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create data store %q: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// addrHash returns the first 8 hex chars of sha256(realpath(address)).
+// nerdctl strips a leading "unix://" scheme and resolves symlinks before
+// hashing, so we do the same. We deliberately fail fast if the path does
+// not resolve: silently falling back to hashing the unresolved address
+// would diverge from nerdctl's hash whenever the path contains symlinks,
+// causing `nerdctl logs` to look in a different per-socket directory than
+// the one tink-agent wrote logs to. By the time Execute reaches this
+// code, containerd.New(SocketPath) in NewConfig has already dialed the
+// socket, so a missing path here indicates a real configuration problem.
+func addrHash(address string) (string, error) {
+	addr := strings.TrimPrefix(address, "unix://")
+	resolved, err := filepath.EvalSymlinks(addr)
+	if err != nil {
+		return "", fmt.Errorf("eval symlinks for %q: %w", addr, err)
+	}
+	sum := sha256.Sum256([]byte(resolved))
+	return hex.EncodeToString(sum[:])[:8], nil
+}
+
+// containerLogDir returns the per-container directory nerdctl expects for
+// logs and log-config.json: <dataStore>/containers/<namespace>/<id>.
+func containerLogDir(dataStore, namespace, id string) string {
+	return filepath.Join(dataStore, "containers", namespace, id)
+}
+
+// containerLogFile returns the json-file log path nerdctl reads for
+// `nerdctl logs`: <containerLogDir>/<id>-json.log.
+//
+// Mirror of nerdctl's pkg/logging/jsonfile.Path:
+// https://github.com/containerd/nerdctl/blob/main/pkg/logging/jsonfile/jsonfile.go
+func containerLogFile(dataStore, namespace, id string) string {
+	return filepath.Join(containerLogDir(dataStore, namespace, id), id+"-json.log")
+}
+
+// logConfig is the shape nerdctl persists at
+// <containerLogDir>/log-config.json. nerdctl's `nerdctl logs` reads this
+// file (NOT the nerdctl/log-uri label) to choose a log driver, so it must
+// exist for our containers to be readable.
+//
+// Mirror of nerdctl's pkg/logging.LogConfig:
+// https://github.com/containerd/nerdctl/blob/main/pkg/logging/logging.go
+type logConfig struct {
+	Driver  string            `json:"driver"`
+	Opts    map[string]string `json:"opts,omitempty"`
+	Address string            `json:"address"`
+}
+
+// writeLogConfig writes log-config.json for a container so that
+// `nerdctl logs` selects the json-file driver. The address must match
+// the containerd socket nerdctl is invoked against; it is normalized to
+// include the "unix://" scheme.
+func writeLogConfig(dir, address string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create log dir %q: %w", dir, err)
+	}
+	if !strings.Contains(address, "://") {
+		address = "unix://" + address
+	}
+	cfg := logConfig{
+		Driver:  "json-file",
+		Opts:    map[string]string{},
+		Address: address,
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal log-config: %w", err)
+	}
+	path := filepath.Join(dir, "log-config.json")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return nil
+}

--- a/tink/agent/internal/runtime/containerd/datastore_test.go
+++ b/tink/agent/internal/runtime/containerd/datastore_test.go
@@ -1,0 +1,142 @@
+package containerd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAddrHash_NerdctlExample reproduces nerdctl's documented example from
+// pkg/clientutil.DataStore: the suffix for "/run/containerd/containerd.sock"
+// is "1935db59". We can't write to /run in tests, so simulate the address
+// via a tempdir + symlink and compute the expected suffix the same way
+// nerdctl would, then assert that addrHash matches sha256(realpath)[:8].
+func TestAddrHash_StableForResolvedPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "containerd.sock")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.sock")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both paths must resolve to the same hash because EvalSymlinks
+	// collapses the symlink first.
+	h1, err := addrHash(target)
+	if err != nil {
+		t.Fatalf("addrHash(target): %v", err)
+	}
+	h2, err := addrHash(link)
+	if err != nil {
+		t.Fatalf("addrHash(link): %v", err)
+	}
+	if h1 != h2 {
+		t.Errorf("symlink and target should hash equal, got %q vs %q", h1, h2)
+	}
+
+	// And the hash must be sha256(realpath)[:8].
+	want := func() string {
+		s := sha256.Sum256([]byte(target))
+		return hex.EncodeToString(s[:])[:8]
+	}()
+	if h1 != want {
+		t.Errorf("addrHash = %q, want %q", h1, want)
+	}
+}
+
+func TestAddrHash_StripsUnixScheme(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "containerd.sock")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plain, err := addrHash(target)
+	if err != nil {
+		t.Fatalf("addrHash(plain): %v", err)
+	}
+	scheme, err := addrHash("unix://" + target)
+	if err != nil {
+		t.Fatalf("addrHash(unix://): %v", err)
+	}
+	if plain != scheme {
+		t.Errorf("unix:// prefix must be stripped, got %q vs %q", plain, scheme)
+	}
+}
+
+func TestDataStoreDir_CreatesDirectories(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "data-root")
+	sock := filepath.Join(t.TempDir(), "containerd.sock")
+	if err := os.WriteFile(sock, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := dataStoreDir(root, sock)
+	if err != nil {
+		t.Fatalf("dataStoreDir: %v", err)
+	}
+	if fi, err := os.Stat(got); err != nil || !fi.IsDir() {
+		t.Fatalf("expected data store dir to exist, got err=%v", err)
+	}
+	// Must be a 8-hex-char child of root.
+	parent, suffix := filepath.Split(got)
+	if filepath.Clean(parent) != filepath.Clean(root) {
+		t.Errorf("parent = %q, want %q", parent, root)
+	}
+	if len(suffix) != 8 {
+		t.Errorf("suffix %q is not 8 chars", suffix)
+	}
+}
+
+func TestContainerLogPaths(t *testing.T) {
+	dir := containerLogDir("/var/lib/nerdctl/abcd1234", "tinkerbell", "deadbeef")
+	if got, want := dir, "/var/lib/nerdctl/abcd1234/containers/tinkerbell/deadbeef"; got != want {
+		t.Errorf("containerLogDir = %q, want %q", got, want)
+	}
+	file := containerLogFile("/var/lib/nerdctl/abcd1234", "tinkerbell", "deadbeef")
+	if got, want := file, "/var/lib/nerdctl/abcd1234/containers/tinkerbell/deadbeef/deadbeef-json.log"; got != want {
+		t.Errorf("containerLogFile = %q, want %q", got, want)
+	}
+}
+
+func TestWriteLogConfig(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ctr")
+	if err := writeLogConfig(dir, "/run/containerd/containerd.sock"); err != nil {
+		t.Fatalf("writeLogConfig: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "log-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got logConfig
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v (raw=%s)", err, b)
+	}
+	if got.Driver != "json-file" {
+		t.Errorf("Driver = %q, want json-file", got.Driver)
+	}
+	if got.Address != "unix:///run/containerd/containerd.sock" {
+		t.Errorf("Address = %q, want unix:// prefix added", got.Address)
+	}
+}
+
+func TestWriteLogConfig_PreservesExistingScheme(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ctr")
+	if err := writeLogConfig(dir, "tcp://1.2.3.4:5000"); err != nil {
+		t.Fatalf("writeLogConfig: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "log-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got logConfig
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Address != "tcp://1.2.3.4:5000" {
+		t.Errorf("Address = %q, want unchanged", got.Address)
+	}
+}

--- a/tink/agent/internal/runtime/containerd/jsonlog.go
+++ b/tink/agent/internal/runtime/containerd/jsonlog.go
@@ -1,0 +1,155 @@
+package containerd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// jsonLogEntry is the per-line shape consumed by `nerdctl logs` (and
+// Docker's json-file driver). nerdctl preserves the trailing "\n" inside
+// the Log field.
+//
+// Mirror of nerdctl's pkg/logging/jsonfile.Entry:
+// https://github.com/containerd/nerdctl/blob/main/pkg/logging/jsonfile/jsonfile.go
+type jsonLogEntry struct {
+	Log    string    `json:"log,omitempty"`
+	Stream string    `json:"stream,omitempty"`
+	Time   time.Time `json:"time"`
+}
+
+// jsonLogWriter is an io.Writer that splits its input on newlines and emits
+// one JSON-Lines record per complete line. The trailing newline of each
+// line is preserved inside the "log" field, matching Docker's json-file
+// format.
+//
+// Multiple jsonLogWriters can share a single mutex/encoder/file handle so
+// that interleaved stdout+stderr writes still produce well-formed JSONL.
+type jsonLogWriter struct {
+	mu     *sync.Mutex
+	enc    *json.Encoder
+	stream string
+
+	// buf accumulates partial lines (input that did not end in '\n') so
+	// that they are emitted as a single record once the rest arrives.
+	// Guarded by mu (cross-stream serialization is fine; each writer only
+	// touches its own buf, but we share the lock with the encoder anyway).
+	buf bytes.Buffer
+}
+
+// Write implements io.Writer. It always returns len(p) on success so it
+// can be wrapped in io.MultiWriter alongside os.Stdout/os.Stderr.
+func (w *jsonLogWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Accumulate, then flush every complete line.
+	w.buf.Write(p)
+	for {
+		data := w.buf.Bytes()
+		i := bytes.IndexByte(data, '\n')
+		if i < 0 {
+			break
+		}
+		// Emit data[:i+1] (include the newline, matching nerdctl).
+		line := make([]byte, i+1)
+		copy(line, data[:i+1])
+		// Advance past this line BEFORE attempting to encode, so that a
+		// failing encode does not leave the bad bytes in w.buf where the
+		// next Write would re-encode them and repeat the error
+		// indefinitely. The failing record is dropped (logging is
+		// best-effort here; the same content is also tee'd to the agent's
+		// own stdout via io.MultiWriter).
+		w.buf.Next(i + 1)
+		if err := w.encodeLocked(string(line)); err != nil {
+			// All of p has already been absorbed into w.buf (and any
+			// earlier complete lines were encoded successfully). Report
+			// the bytes as consumed so io.MultiWriter does not raise a
+			// spurious "short write" on top of the real encode error.
+			return len(p), err
+		}
+	}
+	return len(p), nil
+}
+
+// flush emits any buffered partial line as a final record. Callers must
+// invoke this once writes are done (e.g. before closing the file) so the
+// last line of output without a trailing newline is not lost.
+func (w *jsonLogWriter) flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buf.Len() == 0 {
+		return nil
+	}
+	line := w.buf.String()
+	w.buf.Reset()
+	return w.encodeLocked(line)
+}
+
+// encodeLocked writes a single JSONL record. Must be called with w.mu held.
+func (w *jsonLogWriter) encodeLocked(line string) error {
+	return w.enc.Encode(jsonLogEntry{
+		Log:    line,
+		Stream: w.stream,
+		Time:   time.Now().UTC(),
+	})
+}
+
+// jsonLogPair is the pair of writers (one per stream) plus a Close that
+// flushes any buffered partial lines and closes the underlying file.
+type jsonLogPair struct {
+	Stdout io.Writer
+	Stderr io.Writer
+
+	flushers []*jsonLogWriter
+	file     *os.File
+}
+
+// Close flushes any buffered partial lines and closes the file. It is safe
+// to call multiple times. The underlying file is always closed even if a
+// flush returns an error, so a partial-line encode failure does not leak
+// the OS file descriptor; all errors are joined via errors.Join.
+func (p *jsonLogPair) Close() error {
+	if p == nil || p.file == nil {
+		return nil
+	}
+	var errs []error
+	for _, w := range p.flushers {
+		if err := w.flush(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := p.file.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	p.file = nil
+	return errors.Join(errs...)
+}
+
+// newJSONLogPair opens (or creates) the json-file at path and returns
+// stdout/stderr writers that share a single file handle, mutex and
+// json.Encoder so JSONL records stay well-formed across both streams.
+func newJSONLogPair(path string) (*jsonLogPair, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open log file %q: %w", path, err)
+	}
+	mu := &sync.Mutex{}
+	enc := json.NewEncoder(f)
+	stdoutW := &jsonLogWriter{mu: mu, enc: enc, stream: "stdout"}
+	stderrW := &jsonLogWriter{mu: mu, enc: enc, stream: "stderr"}
+	return &jsonLogPair{
+		Stdout:   stdoutW,
+		Stderr:   stderrW,
+		flushers: []*jsonLogWriter{stdoutW, stderrW},
+		file:     f,
+	}, nil
+}

--- a/tink/agent/internal/runtime/containerd/jsonlog_test.go
+++ b/tink/agent/internal/runtime/containerd/jsonlog_test.go
@@ -1,0 +1,227 @@
+package containerd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// decodeAll consumes the json-file at path into a slice of entries.
+func decodeAll(t *testing.T, path string) []jsonLogEntry {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var out []jsonLogEntry
+	dec := json.NewDecoder(f)
+	for {
+		var e jsonLogEntry
+		if err := dec.Decode(&e); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func TestJSONLogPair_MultiLineWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log.json")
+	pair, err := newJSONLogPair(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(pair.Stdout, "alpha\nbeta\ngamma\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := pair.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := decodeAll(t, path)
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d (%+v)", len(got), got)
+	}
+	for i, want := range []string{"alpha\n", "beta\n", "gamma\n"} {
+		if got[i].Log != want {
+			t.Errorf("entry[%d].Log = %q, want %q", i, got[i].Log, want)
+		}
+		if got[i].Stream != "stdout" {
+			t.Errorf("entry[%d].Stream = %q, want stdout", i, got[i].Stream)
+		}
+		if got[i].Time.IsZero() {
+			t.Errorf("entry[%d].Time should not be zero", i)
+		}
+	}
+}
+
+func TestJSONLogPair_PartialLineBuffering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log.json")
+	pair, err := newJSONLogPair(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write the line in three pieces; only one entry should appear, after
+	// the newline finally arrives.
+	io.WriteString(pair.Stdout, "hel")
+	io.WriteString(pair.Stdout, "lo wor")
+	io.WriteString(pair.Stdout, "ld\n")
+	if err := pair.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := decodeAll(t, path)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d (%+v)", len(got), got)
+	}
+	if got[0].Log != "hello world\n" {
+		t.Errorf("Log = %q, want %q", got[0].Log, "hello world\n")
+	}
+}
+
+func TestJSONLogPair_FlushUnterminatedTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log.json")
+	pair, err := newJSONLogPair(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No trailing newline — flush on Close must still emit the line.
+	io.WriteString(pair.Stdout, "no-newline-here")
+	if err := pair.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := decodeAll(t, path)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d (%+v)", len(got), got)
+	}
+	if got[0].Log != "no-newline-here" {
+		t.Errorf("Log = %q, want %q", got[0].Log, "no-newline-here")
+	}
+}
+
+func TestJSONLogPair_StreamLabels(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log.json")
+	pair, err := newJSONLogPair(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.WriteString(pair.Stdout, "out\n")
+	io.WriteString(pair.Stderr, "err\n")
+	if err := pair.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := decodeAll(t, path)
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d (%+v)", len(got), got)
+	}
+	streams := []string{got[0].Stream, got[1].Stream}
+	logs := []string{got[0].Log, got[1].Log}
+	if streams[0] != "stdout" || streams[1] != "stderr" {
+		t.Errorf("streams = %v, want [stdout stderr]", streams)
+	}
+	if logs[0] != "out\n" || logs[1] != "err\n" {
+		t.Errorf("logs = %v", logs)
+	}
+}
+
+// TestJSONLogPair_ConcurrentWrites makes sure interleaved writes from the
+// stdout and stderr writers still produce well-formed JSONL (one decodable
+// object per line). Without the shared mutex, partial-line buffering across
+// two Encoders would corrupt the file.
+func TestJSONLogPair_ConcurrentWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log.json")
+	pair, err := newJSONLogPair(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			io.WriteString(pair.Stdout, "stdout line\n")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			io.WriteString(pair.Stderr, "stderr line\n")
+		}
+	}()
+	wg.Wait()
+	if err := pair.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := decodeAll(t, path)
+	if len(got) != 2*n {
+		t.Fatalf("want %d entries, got %d", 2*n, len(got))
+	}
+	var outCount, errCount int
+	for _, e := range got {
+		switch e.Stream {
+		case "stdout":
+			outCount++
+			if e.Log != "stdout line\n" {
+				t.Errorf("stdout entry corrupt: %q", e.Log)
+			}
+		case "stderr":
+			errCount++
+			if e.Log != "stderr line\n" {
+				t.Errorf("stderr entry corrupt: %q", e.Log)
+			}
+		default:
+			t.Errorf("unknown stream %q", e.Stream)
+		}
+	}
+	if outCount != n || errCount != n {
+		t.Errorf("counts: stdout=%d stderr=%d, want %d each", outCount, errCount, n)
+	}
+}
+
+// TestJSONLogPair_TeeShape verifies that combining the writer with another
+// io.Writer via io.MultiWriter (as the runtime does with os.Stdout) gives
+// both sinks the original bytes.
+func TestJSONLogPair_TeeShape(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log.json")
+	pair, err := newJSONLogPair(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sideStdout bytes.Buffer
+	w := io.MultiWriter(&sideStdout, pair.Stdout)
+	io.WriteString(w, "tee one\ntee two\n")
+	if err := pair.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sideStdout.String(); got != "tee one\ntee two\n" {
+		t.Errorf("side stdout = %q, want raw bytes", got)
+	}
+	got := decodeAll(t, path)
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0].Log != "tee one\n" || got[1].Log != "tee two\n" {
+		t.Errorf("entries = %+v", got)
+	}
+	// Sanity: each entry must carry a non-zero timestamp from "now".
+	// Allow a small clock skew window in either direction.
+	now := time.Now()
+	for _, e := range got {
+		if e.Time.IsZero() {
+			t.Errorf("time is zero: %v", e.Time)
+			continue
+		}
+		if d := now.Sub(e.Time); d < -time.Second || d > time.Minute {
+			t.Errorf("time %v not within recent window of %v (delta %v)", e.Time, now, d)
+		}
+	}
+}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Without this `nerdctl logs` for Action containers didn't work at all. This is because the tink-agent uses the containerd SDK which doesn't setup any of the needed scaffolding for nerdctl. So plumbing is needed to get nerdctl to "see" them properly. Having nerdctl logs work properly makes the user experience match the expectation.

Fixes: #751 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
