### PR TITLE
Address FOSSA license and vulnerability findings:

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,19 @@
+# FOSSA CLI v3 configuration.
+# Schema: https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
+#
+# Per-issue license ignores, denied/flagged license categorization, and
+# CVE suppressions are managed in the FOSSA web UI under Project Settings
+# (Ignore Rules) and Policies. This file only narrows which manifests in
+# the repository are analyzed so that out-of-scope or duplicate dependency
+# graphs do not surface as noise in this project's scan.
+
+version: 3
+
+paths:
+  exclude:
+    # Build and tooling scratch directories. Nothing here is shipped, and
+    # the contents (downloaded binaries, generated bundles such as
+    # out/THIRD_PARTY_LICENSES-linux-*) are not manifests we want FOSSA to
+    # interpret as projects.
+    - out
+    - tmp

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinkerbell/tinkerbell/api
 
-go 1.24.1
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0
@@ -19,7 +19,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -58,8 +58,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -9,6 +9,9 @@
       },
     },
   },
+  "overrides": {
+    "picomatch": "^4.0.4",
+  },
   "packages": {
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -122,7 +125,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,5 +2,8 @@
   "dependencies": {
     "@tailwindcss/cli": "4.2.0",
     "tailwindcss": "4.2.0"
+  },
+  "overrides": {
+    "picomatch": "^4.0.4"
   }
 }


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Consolidate api/ onto x/text v0.37.0 to eliminate duplicate CC-BY-SA false positives from Unicode/CLDR test data (requires bumping the module's go directive to 1.25.0; CAPT, the only significant external consumer, is already on 1.25.0). Bump transitive picomatch to 4.0.4 to fix CVE-2026-33671 (ReDoS) and CVE-2026-33672 (prototype pollution). Add a minimal .fossa.yml so the analyzer ignores the out/ and tmp/ scratch directories; per-issue ignores and policy remain in the FOSSA web UI for audit trail.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
