### PR TITLE
Change whether the service is enabled

### DIFF
--- a/helm/tinkerbell/templates/service.yaml
+++ b/helm/tinkerbell/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.deployment.hostNetwork }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -188,6 +188,7 @@ rbac:
   secrets:
     enabled: true
 service:
+  enabled: true
   annotations: {}
   labels:
     app: tinkerbell


### PR DESCRIPTION
## Description

Certain deployments require hostNetwork alongside an enabled service.
This PR updates the behavior so that the service can be enabled or disabled without depending on hostNetwork


## How Has This Been Tested?

This change has been tested with an installation using service.enabled=true and service.enabled=false to verify whether the service is created.


## How are existing users impacted? What migration steps/scripts do we need?

Some users may need to disable the service explicitly.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
