### PR TITLE
Add explicit returns after t.Fatal in nil-guard tests:

### DIFF
--- a/tink/agent/internal/runtime/containerd/conv_test.go
+++ b/tink/agent/internal/runtime/containerd/conv_test.go
@@ -139,6 +139,7 @@ func TestParseVolume(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatalf("parseVolume(%q) = nil, want %+v", tt.volume, tt.want)
+				return
 			}
 			if got.Type != tt.want.Type {
 				t.Errorf("Type = %q, want %q", got.Type, tt.want.Type)

--- a/ui/internal/http/crd_test.go
+++ b/ui/internal/http/crd_test.go
@@ -43,6 +43,7 @@ func TestGetDashboardData_TinkerbellCRDs(t *testing.T) {
 
 	if tinkerbellGroup == nil {
 		t.Fatal("tinkerbell.org group not found")
+		return
 	}
 
 	// Check expected CRD kinds exist
@@ -73,6 +74,7 @@ func TestGetDashboardData_BMCCRDs(t *testing.T) {
 
 	if bmcGroup == nil {
 		t.Fatal("bmc.tinkerbell.org group not found")
+		return
 	}
 
 	// Check expected CRD kinds exist
@@ -484,6 +486,7 @@ func TestGetWorkflowSchemaFields_TasksHaveActions(t *testing.T) {
 
 	if tasksField == nil {
 		t.Fatal("tasks field not found")
+		return
 	}
 
 	// Look for actions field in task children
@@ -497,6 +500,7 @@ func TestGetWorkflowSchemaFields_TasksHaveActions(t *testing.T) {
 
 	if actionsField == nil {
 		t.Fatal("actions field not found in task schema")
+		return
 	}
 
 	if !actionsField.Required {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
staticcheck SA5011 intermittently fires in CI on these nil-then-deref patterns because its analyzer doesn't always recognize t.Fatal/t.Fatalf as terminating when running against a partially-restored lint cache. The result is flaky lint failures that reproduce on some PRs but not locally. An explicit return after the Fatal call makes control flow unambiguous and silences the analyzer regardless of cache state.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
