### PR TITLE
fix(ui): prevent duplicate select-all listeners after HTMX swap

### DIFF
--- a/ui/assets/js/app.js
+++ b/ui/assets/js/app.js
@@ -472,41 +472,46 @@ document.addEventListener('DOMContentLoaded', () => {
 	updatePaginationURLs();
 
 	// Check all functionality
+	function updateSelectAllState() {
+		const selectAllMain = document.getElementById('selectAll');
+		const selectAllContent = document.getElementById('selectAllContent');
+		const checkedBoxes = document.querySelectorAll('.row-checkbox:checked');
+		const allRowCheckboxes = document.querySelectorAll('.row-checkbox');
+
+		if (allRowCheckboxes.length === 0) return;
+
+		const allChecked = checkedBoxes.length === allRowCheckboxes.length;
+		const someChecked = checkedBoxes.length > 0;
+		
+		// Update both select all checkboxes
+		[selectAllMain, selectAllContent].forEach(selectAll => {
+			if (selectAll) {
+				selectAll.checked = allChecked;
+				selectAll.indeterminate = someChecked && !allChecked;
+			}
+		});
+	}
+	
+	function handleSelectAll(e) {
+		const isChecked = e.target.checked;
+		document.querySelectorAll('.row-checkbox').forEach(checkbox => {
+			checkbox.checked = isChecked;
+		});
+		updateSelectAllState();
+	}
+
 	function setupCheckAllFunctionality() {
 		const selectAllMain = document.getElementById('selectAll');
 		const selectAllContent = document.getElementById('selectAllContent');
 		const rowCheckboxes = document.querySelectorAll('.row-checkbox');
 
-		function updateSelectAllState() {
-			const checkedBoxes = document.querySelectorAll('.row-checkbox:checked');
-			const allRowCheckboxes = document.querySelectorAll('.row-checkbox');
-			
-			if (allRowCheckboxes.length === 0) return;
-			
-			const allChecked = checkedBoxes.length === allRowCheckboxes.length;
-			const someChecked = checkedBoxes.length > 0;
-			
-			// Update both select all checkboxes
-			[selectAllMain, selectAllContent].forEach(selectAll => {
-				if (selectAll) {
-					selectAll.checked = allChecked;
-					selectAll.indeterminate = someChecked && !allChecked;
-				}
-			});
-		}
-
-		function handleSelectAll(e) {
-			const isChecked = e.target.checked;
-			document.querySelectorAll('.row-checkbox').forEach(checkbox => {
-				checkbox.checked = isChecked;
-			});
-		}
-
 		// Attach event listeners to select all checkboxes
 		if (selectAllMain) {
+			selectAllMain.removeEventListener('change', handleSelectAll);
 			selectAllMain.addEventListener('change', handleSelectAll);
 		}
 		if (selectAllContent) {
+			selectAllContent.removeEventListener('change', handleSelectAll);
 			selectAllContent.addEventListener('change', handleSelectAll);
 		}
 


### PR DESCRIPTION
## Summary
Every `htmx:afterSwap` calls `setupCheckAllFunctionality()`, which was adding new `change` listeners to `#selectAll` and `#selectAllContent` without removing the previous ones. After a few paginations or content swaps, clicking "select all" would fire the handler multiple times.
This PR hoists `handleSelectAll` and `updateSelectAllState` out of `setupCheckAllFunctionality` so the same function references can be passed to `removeEventListener`, and removes the old listener before re-attaching on each swap.
Also calls `updateSelectAllState()` at the end of `handleSelectAll` so both select-all checkboxes stay in sync when either one is clicked.
## Changes
- Move `handleSelectAll` and `updateSelectAllState` to stable outer scope
- Add `removeEventListener` before `addEventListener` on both select-all checkboxes
- Sync both select-all checkboxes after a select-all click