### PR TITLE
Remove the golangci-lint analyzer cache:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,17 +41,6 @@ jobs:
             ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
             ${{ runner.os }}-go-
 
-      - name: Restore golangci-lint cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/golangci-lint
-          key: ${{ runner.os }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-${{ env.GO_VERSION }}-${{ hashFiles('.golangci.yml', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-${{ env.GO_VERSION }}-${{ hashFiles('.golangci.yml', '**/go.sum') }}
-            ${{ runner.os }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-${{ env.GO_VERSION }}-${{ hashFiles('.golangci.yml') }}
-            ${{ runner.os }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-${{ env.GO_VERSION }}-
-            ${{ runner.os }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-
-
       - name: Fix no space errors and Fetch Deps
         run: |
           # fixes "write /run/user/<uid>/<nonce>: no space left on device" error
@@ -80,14 +69,6 @@ jobs:
         run: |
           find ~/.cache/go-build -type f -mmin +90 -delete
 
-      - name: Trim golangci-lint cache
-        if: ${{ github.ref == 'refs/heads/main' }}
-        shell: bash
-        # Mirror the Go cache trim: drop entries not touched during this run
-        # to keep the saved cache from growing unbounded across merges.
-        run: |
-          find ~/.cache/golangci-lint -type f -mmin +90 -delete || true
-
       - name: Set Go cache date
         shell: bash
         run: echo "GO_CACHE_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
@@ -102,14 +83,6 @@ jobs:
             ~/.cache/go-build
           # Save to eg Linux-go-$hash-YYYY-MM-DD to keep the cache fresh
           key: "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ env.GO_CACHE_DATE }}"
-
-      - name: Save golangci-lint cache
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.cache/golangci-lint
-          # Date suffix mirrors the Go cache strategy so the entry rolls daily.
-          key: ${{ runner.os }}-golangci-${{ env.GOLANGCI_LINT_VERSION }}-${{ env.GO_VERSION }}-${{ hashFiles('.golangci.yml', '**/go.sum') }}-${{ env.GO_CACHE_DATE }}
 
   validate-helm-chart:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Too many caching issues. We'll just stick with the cache for ~/go/pkg/mod and ~/.cache/go-build

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
