### PR TITLE
Render tink-controller reference rules as a Helm list joined by pipes:

### DIFF
--- a/docs/technical/REFERENCES.md
+++ b/docs/technical/REFERENCES.md
@@ -213,9 +213,30 @@ Helm Values:
 - `deployment.envs.tinkController.referenceAllowListRules`
 - `deployment.envs.tinkController.referenceDenyListRules`
 
+Each value is a list of rule objects. The chart renders each rule as a JSON object and joins them with `|` for the controller.
+
 ```yaml
---set-json 'deployment.envs.tinkController.referenceAllowListRules={"reference":{"resource":["secrets"]}}'
---set-json 'deployment.envs.tinkController.referenceDenyListRules={"reference":{"resource":["pods"]}}'
+--set-json 'deployment.envs.tinkController.referenceAllowListRules=[{"reference":{"resource":["hardware"]}},{"reference":{"resource":["workflows"]}}]'
+--set-json 'deployment.envs.tinkController.referenceDenyListRules=[{"reference":{"resource":["pods"]}}]'
+```
+
+Or in a values file:
+
+```yaml
+deployment:
+  envs:
+    tinkController:
+      referenceAllowListRules:
+        - reference:
+            resource:
+              - hardware
+        - reference:
+            resource:
+              - workflows
+      referenceDenyListRules:
+        - reference:
+            resource:
+              - pods
 ```
 
 ## Full Example
@@ -231,7 +252,7 @@ The following is a full example of defining a Reference in a Hardware object to 
 1. Configure access to just this specific Secret by setting the allow list rule below when deploying Tinkerbell with Helm
 
    ```bash
-   --set-json 'deployment.envs.tinkController.referenceAllowListRules={"source":{"name":["example-hardware"],"namespace":["tinkerbell"]},"reference":{"name":["my-secret"],"namespace":["tinkerbell"],"resource":["secrets"]}}' 
+   --set-json 'deployment.envs.tinkController.referenceAllowListRules=[{"source":{"name":["example-hardware"],"namespace":["tinkerbell"]},"reference":{"name":["my-secret"],"namespace":["tinkerbell"],"resource":["secrets"]}}]' 
    ```
 
 1. Create the Hardware object, with the Reference to the Secret

--- a/docs/technical/REFERENCES.md
+++ b/docs/technical/REFERENCES.md
@@ -213,7 +213,7 @@ Helm Values:
 - `deployment.envs.tinkController.referenceAllowListRules`
 - `deployment.envs.tinkController.referenceDenyListRules`
 
-Each value is a list of rule objects. The chart renders each rule as a JSON object and joins them with `|` for the controller.
+Each value is a list of rule objects. The chart renders each rule as a JSON object and joins them with `|` for the controller. A single rule object (map) is also accepted and treated as one rule.
 
 ```bash
 --set-json 'deployment.envs.tinkController.referenceAllowListRules=[{"reference":{"resource":["hardware"]}},{"reference":{"resource":["workflows"]}}]'

--- a/docs/technical/REFERENCES.md
+++ b/docs/technical/REFERENCES.md
@@ -215,7 +215,7 @@ Helm Values:
 
 Each value is a list of rule objects. The chart renders each rule as a JSON object and joins them with `|` for the controller.
 
-```yaml
+```bash
 --set-json 'deployment.envs.tinkController.referenceAllowListRules=[{"reference":{"resource":["hardware"]}},{"reference":{"resource":["workflows"]}}]'
 --set-json 'deployment.envs.tinkController.referenceDenyListRules=[{"reference":{"resource":["pods"]}}]'
 ```

--- a/helm/tinkerbell/templates/deployment.yaml
+++ b/helm/tinkerbell/templates/deployment.yaml
@@ -78,11 +78,19 @@ spec:
               value: {{ .Values.deployment.envs.tinkController.maxConcurrentReconciles | quote }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_ALLOW_LIST_RULES
             {{- if .Values.deployment.envs.tinkController.referenceAllowListRules }}
-              value: {{ .Values.deployment.envs.tinkController.referenceAllowListRules | toJson | quote }}
+              {{- $rules := list }}
+              {{- range .Values.deployment.envs.tinkController.referenceAllowListRules }}
+              {{- $rules = append $rules (toJson .) }}
+              {{- end }}
+              value: {{ join "|" $rules | quote }}
             {{- end }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_DENY_LIST_RULES
             {{- if .Values.deployment.envs.tinkController.referenceDenyListRules }}
-              value: {{ .Values.deployment.envs.tinkController.referenceDenyListRules | toJson | quote }}
+              {{- $rules := list }}
+              {{- range .Values.deployment.envs.tinkController.referenceDenyListRules }}
+              {{- $rules = append $rules (toJson .) }}
+              {{- end }}
+              value: {{ join "|" $rules | quote }}
             {{- end }}
           # TINK SERVER
             - name: TINKERBELL_TINK_SERVER_BIND_ADDR

--- a/helm/tinkerbell/templates/deployment.yaml
+++ b/helm/tinkerbell/templates/deployment.yaml
@@ -78,23 +78,31 @@ spec:
               value: {{ .Values.deployment.envs.tinkController.maxConcurrentReconciles | quote }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_ALLOW_LIST_RULES
             {{- if .Values.deployment.envs.tinkController.referenceAllowListRules }}
-              {{- if not (kindIs "slice" .Values.deployment.envs.tinkController.referenceAllowListRules) }}
-                {{- fail "deployment.envs.tinkController.referenceAllowListRules must be a list of rule objects; the map/object form is no longer supported (see docs/technical/REFERENCES.md)" }}
-              {{- end }}
               {{- $rules := list }}
-              {{- range .Values.deployment.envs.tinkController.referenceAllowListRules }}
-              {{- $rules = append $rules (toJson .) }}
+              {{- $value := .Values.deployment.envs.tinkController.referenceAllowListRules }}
+              {{- if kindIs "slice" $value }}
+                {{- range $value }}
+                {{- $rules = append $rules (toJson .) }}
+                {{- end }}
+              {{- else if kindIs "map" $value }}
+                {{- $rules = append $rules (toJson $value) }}
+              {{- else }}
+                {{- fail "deployment.envs.tinkController.referenceAllowListRules must be a list of rule objects or a single rule object (see docs/technical/REFERENCES.md)" }}
               {{- end }}
               value: {{ join "|" $rules | quote }}
             {{- end }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_DENY_LIST_RULES
             {{- if .Values.deployment.envs.tinkController.referenceDenyListRules }}
-              {{- if not (kindIs "slice" .Values.deployment.envs.tinkController.referenceDenyListRules) }}
-                {{- fail "deployment.envs.tinkController.referenceDenyListRules must be a list of rule objects; the map/object form is no longer supported (see docs/technical/REFERENCES.md)" }}
-              {{- end }}
               {{- $rules := list }}
-              {{- range .Values.deployment.envs.tinkController.referenceDenyListRules }}
-              {{- $rules = append $rules (toJson .) }}
+              {{- $value := .Values.deployment.envs.tinkController.referenceDenyListRules }}
+              {{- if kindIs "slice" $value }}
+                {{- range $value }}
+                {{- $rules = append $rules (toJson .) }}
+                {{- end }}
+              {{- else if kindIs "map" $value }}
+                {{- $rules = append $rules (toJson $value) }}
+              {{- else }}
+                {{- fail "deployment.envs.tinkController.referenceDenyListRules must be a list of rule objects or a single rule object (see docs/technical/REFERENCES.md)" }}
               {{- end }}
               value: {{ join "|" $rules | quote }}
             {{- end }}

--- a/helm/tinkerbell/templates/deployment.yaml
+++ b/helm/tinkerbell/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
               value: {{ .Values.deployment.envs.tinkController.maxConcurrentReconciles | quote }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_ALLOW_LIST_RULES
             {{- if .Values.deployment.envs.tinkController.referenceAllowListRules }}
+              {{- if not (kindIs "slice" .Values.deployment.envs.tinkController.referenceAllowListRules) }}
+                {{- fail "deployment.envs.tinkController.referenceAllowListRules must be a list of rule objects; the map/object form is no longer supported (see docs/technical/REFERENCES.md)" }}
+              {{- end }}
               {{- $rules := list }}
               {{- range .Values.deployment.envs.tinkController.referenceAllowListRules }}
               {{- $rules = append $rules (toJson .) }}
@@ -86,6 +89,9 @@ spec:
             {{- end }}
             - name: TINKERBELL_TINK_CONTROLLER_REFERENCE_DENY_LIST_RULES
             {{- if .Values.deployment.envs.tinkController.referenceDenyListRules }}
+              {{- if not (kindIs "slice" .Values.deployment.envs.tinkController.referenceDenyListRules) }}
+                {{- fail "deployment.envs.tinkController.referenceDenyListRules must be a list of rule objects; the map/object form is no longer supported (see docs/technical/REFERENCES.md)" }}
+              {{- end }}
               {{- $rules := list }}
               {{- range .Values.deployment.envs.tinkController.referenceDenyListRules }}
               {{- $rules = append $rules (toJson .) }}

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -109,8 +109,8 @@ deployment:
       leaderElectionNamespace: ""
       logLevel: 0
       maxConcurrentReconciles: 1
-      referenceAllowListRules: {}
-      referenceDenyListRules: {}
+      referenceAllowListRules: []
+      referenceDenyListRules: []
     tinkServer:
       autoDiscoveryAutoEnrollmentEnabled: false
       autoDiscoveryEnabled: false


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

The tink-controller reads the reference allow/deny list from a single environment variable whose value is a pipe-separated string of JSON rule objects. The chart passed the Helm value straight through `toJson`, so a YAML list of rules became a JSON array that the controller cannot parse, leaving no way to express more than one rule via Helm. Accept a native YAML list and join each rule with `|` so multiple rules can be configured.

This is a breaking change to the helm chart and necessary for more than one rule.

Fixes: #604 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
