### PR TITLE
Plumb Namespaces.Network from workflow template to docker runtime

### DIFF
--- a/api/v1alpha1/tinkerbell/workflow.go
+++ b/api/v1alpha1/tinkerbell/workflow.go
@@ -248,6 +248,7 @@ type Action struct {
 	Command           []string          `json:"command,omitempty"`
 	Volumes           []string          `json:"volumes,omitempty"`
 	Pid               string            `json:"pid,omitempty"`
+	Network           string            `json:"network,omitempty"`
 	Environment       map[string]string `json:"environment,omitempty"`
 	State             WorkflowState     `json:"state,omitempty"`
 	ExecutionStart    *metav1.Time      `json:"executionStart,omitempty"`

--- a/crd/bases/v1alpha1/tinkerbell.org_workflows.yaml
+++ b/crd/bases/v1alpha1/tinkerbell.org_workflows.yaml
@@ -419,6 +419,8 @@ spec:
                             type: string
                           name:
                             type: string
+                          network:
+                            type: string
                           pid:
                             type: string
                           state:

--- a/pkg/proto/get_action_response.pb.go
+++ b/pkg/proto/get_action_response.pb.go
@@ -7,12 +7,11 @@
 package proto
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -94,7 +93,9 @@ type ActionResponse struct {
 	// Set environment variables usable from the action itself.
 	Environment []string `protobuf:"bytes,10,rep,name=environment" json:"environment,omitempty"`
 	// Set the namespace that the process IDs will be in.
-	Pid           *string `protobuf:"bytes,11,opt,name=pid" json:"pid,omitempty"`
+	Pid *string `protobuf:"bytes,11,opt,name=pid" json:"pid,omitempty"`
+	// Set the network namespace (e.g. "host") that the action container will run in.
+	Network       *string `protobuf:"bytes,12,opt,name=network" json:"network,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -206,11 +207,18 @@ func (x *ActionResponse) GetPid() string {
 	return ""
 }
 
+func (x *ActionResponse) GetNetwork() string {
+	if x != nil && x.Network != nil {
+		return *x.Network
+	}
+	return ""
+}
+
 var File_get_action_response_proto protoreflect.FileDescriptor
 
 const file_get_action_response_proto_rawDesc = "" +
 	"\n" +
-	"\x19get_action_response.proto\x12\x05proto\"\xae\x02\n" +
+	"\x19get_action_response.proto\x12\x05proto\"\xc8\x02\n" +
 	"\x0eActionResponse\x12\x1f\n" +
 	"\vworkflow_id\x18\x01 \x01(\tR\n" +
 	"workflowId\x12\x17\n" +
@@ -224,7 +232,8 @@ const file_get_action_response_proto_rawDesc = "" +
 	"\avolumes\x18\t \x03(\tR\avolumes\x12 \n" +
 	"\venvironment\x18\n" +
 	" \x03(\tR\venvironment\x12\x10\n" +
-	"\x03pid\x18\v \x01(\tR\x03pid*\x86\x01\n" +
+	"\x03pid\x18\v \x01(\tR\x03pid\x12\x18\n" +
+	"\anetwork\x18\f \x01(\tR\anetwork*\x86\x01\n" +
 	"\x1cPreconditionFailureViolation\x12.\n" +
 	"*PRECONDITION_FAILURE_VIOLATION_UNSPECIFIED\x10\x00\x126\n" +
 	"2PRECONDITION_FAILURE_VIOLATION_NO_ACTION_AVAILABLE\x10\x01B\x83\x01\n" +

--- a/pkg/proto/get_action_response.proto
+++ b/pkg/proto/get_action_response.proto
@@ -48,6 +48,10 @@ message ActionResponse {
     * Set the namespace that the process IDs will be in.
     */
    string pid = 11;
+   /*
+    * Set the network namespace (e.g. "host") that the action container will run in.
+    */
+   string network = 12;
 }
 
 

--- a/tink/agent/internal/runtime/docker/docker.go
+++ b/tink/agent/internal/runtime/docker/docker.go
@@ -77,6 +77,9 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	if a.Namespaces.PID != "" {
 		hostCfg.PidMode = container.PidMode(a.Namespaces.PID)
 	}
+	if a.Namespaces.Network != "" {
+		hostCfg.NetworkMode = container.NetworkMode(a.Namespaces.Network)
+	}
 	for _, v := range a.Volumes {
 		hostCfg.Binds = append(hostCfg.Binds, string(v))
 	}

--- a/tink/agent/internal/transport/grpc/grpc.go
+++ b/tink/agent/internal/transport/grpc/grpc.go
@@ -100,6 +100,7 @@ func (c *Config) doRead(ctx context.Context) (spec.Action, error) {
 		as.Env = append(as.Env, env)
 	}
 	as.Namespaces.PID = response.GetPid()
+	as.Namespaces.Network = response.GetNetwork()
 
 	return as, nil
 }

--- a/tink/controller/internal/workflow/convert.go
+++ b/tink/controller/internal/workflow/convert.go
@@ -25,6 +25,7 @@ func YAMLToStatus(wf *Workflow) *v1alpha1.WorkflowStatus {
 				State:       v1alpha1.WorkflowState(proto.ActionStatusRequest_PENDING.String()),
 				Environment: action.Environment,
 				Pid:         action.Pid,
+				Network:     action.Network,
 			})
 		}
 		tasks = append(tasks, v1alpha1.Task{

--- a/tink/controller/internal/workflow/types.go
+++ b/tink/controller/internal/workflow/types.go
@@ -29,4 +29,5 @@ type Action struct {
 	Volumes     []string          `yaml:"volumes,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
 	Pid         string            `yaml:"pid,omitempty"`
+	Network     string            `yaml:"network,omitempty"`
 }

--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -289,7 +289,8 @@ func (h *Handler) doGetAction(ctx context.Context, req *proto.ActionRequest, opt
 			sort.Strings(resp)
 			return resp
 		}(),
-		Pid: toPtr(action.Pid),
+		Pid:     toPtr(action.Pid),
+		Network: toPtr(action.Network),
 	}
 
 	log.Info("sending action", "action", ar, "actionID", action.ID)


### PR DESCRIPTION
## Description

Adds a `network` field to workflow Action templates that flows through the controller, gRPC wire protocol, and tink-agent into the docker HostConfig's NetworkMode, mirroring the existing `pid` plumbing.

Docker does not enable IPv6 on the default bridge network without explicit daemon configuration: https://docs.docker.com/engine/network/drivers/bridge/#use-the-default-bridge-network. On IPv6-only provisioning environments, action containers on the default bridge have no IPv6 connectivity and cannot reach artifact servers or other IPv6 endpoints. Consumers can now set `network: host` on individual actions in the workflow template to share the host network namespace.

<!--- Please describe what this PR is going to change -->

Fixes: #

## How Has This Been Tested?
In a IPV6 only provisioning environment, image2disk container exits as soon as is it is initialized before this fix with below error:

```
time="2025-05-19T12:04:12.988735566Z" level=debug msg="Assigning addresses for endpoint tinkerbell_stream_image_to_disk_01KXKG3TK57N85E968SM91W9X5's interface on network bridge"
time="2025-05-19T12:04:13.012485717Z" level=debug msg="Sending unsolicited ARP/NA" eid=54aac54e4435f40de54525c3a8ecaac5e34aa5c5ee1066443caf764b407e7b7a ep=tinkerbell_stream_image_to_disk_01KXKG3TK57N85E968SM91W9X5 iface=eth0 ifi=4 ip4=172.18.0.2/16 ip6="<nil>" mac="1a:35:6c:fa:bc:44" mcastRouteOk=true net=bridge nid=986788061bed86a3727a71f5087693a95e52455a5890509e61843a22ce06c18a
time="2025-05-19T12:04:13.157256682Z" level=debug msg="Releasing addresses for endpoint tinkerbell_stream_image_to_disk_01KXKG3TK57N85E968SM91W9X5's interface on network bridge"
```


Smee logs:

Before fix image pull fails:
```
{"time":"2026-07-15T18:55:35.872610676Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"67c173092745","facility":"daemon","host":"fd00:80:66::22","msg":{"agentID":"88:e9:a4:58:5c:cc","container_name":"tinkerbell_stream_image_to_disk_01KXKG3TK57N85E968SM91W9X5","level":0,"msg":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000;IMAGE2DISK - Cloud image streamer\n------------------------\n","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/internal/runtime/docker/docker.go","line":153},"time":"2025-05-19T12:04:13.040854875Z"},"procid":"1312","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-15T18:55:35.873078043Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"33a05695b67f","facility":"daemon","host":"fd00:80:66::22","msg":"time=\"2025-05-19T12:04:13Z\" level=fatal msg=\"Get \\\"http://[fd00:80:66::1]:8081/images/ubuntu-1-35.gz\\\": dial tcp [fd00:80:66::1]:8081: connect: network is unreachable\"\n","procid":"1312","severity":"ERR"},"logger":"smee"}
{"time":"2026-07-15T18:55:35.873335476Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"67c173092745","facility":"daemon","host":"fd00:80:66::22","msg":{"agentID":"88:e9:a4:58:5c:cc","container_name":"tinkerbell_stream_image_to_disk_01KXKG3TK57N85E968SM91W9X5","level":0,"msg":"\u0002\u0000\u0000\u0000\u0000\u0000\u0000�time=\"2025-05-19T12:04:13Z\" level=fatal msg=\"Get \\\"http://[fd00:80:66::1]:8081/images/ubuntu-1-35.gz\\\": dial tcp [fd00:80:66::1]:8081: connect: network is unreachable\"\n","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/internal/runtime/docker/docker.go","line":153},"time":"2025-05-19T12:04:13.041590136Z"},"procid":"1312","severity":"INFO"},"logger":"smee"}
```

After fix image pull succeeds:

```
{"time":"2026-07-14T23:31:53.48113835Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/tink/server/internal/grpc/grpc.go:296","msg":"sending action","agent":"88:e9:a4:58:5c:cc","logger":"tink-server","action":{"workflow_id":"default/dev22-ubuntu-install","task_id":"01KXHF606BE25QXFBVZDJ5W610","agent_id":"88:e9:a4:58:5c:cc","action_id":"01KXHF606BE25QXFBVYVTCWHD2","name":"stream image to disk","image":"127.0.0.1/embedded/image2disk:latest","timeout":600,"volumes":["/dev:/dev","/dev/console:/dev/console","/lib/firmware:/lib/firmware:ro"],"environment":["COMPRESSED=true","DEST_DISK=/dev/sda","IMG_URL=http://[fd00:80:66::1]:8081/images/ubuntu-1-35.gz"],"pid":"","network":"host"},"actionID":"01KXHF606BE25QXFBVYVTCWHD2"}
{"time":"2026-07-14T23:31:53.48155422Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/tink/controller/internal/workflow/reconciler.go:123","msg":"Reconcile","controller":"workflow","controllerGroup":"tinkerbell.org","controllerKind":"Workflow","Workflow":{"name":"dev22-ubuntu-install","namespace":"default"},"namespace":"default","name":"dev22-ubuntu-install","reconcileID":"4e17c001-a6ef-4b20-b562-adff4ccb53e5","logger":"tink-controller"}
{"time":"2026-07-14T23:31:53.482951592Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"3d83751719f9","facility":"daemon","host":"fd00:80:66::22","msg":{"action":{"agent_id":"88:e9:a4:58:5c:cc","env":[{"key":"COMPRESSED","value":"true"},{"key":"DEST_DISK","value":"/dev/sda"},{"key":"IMG_URL","value":"http://[fd00:80:66::1]:8081/images/ubuntu-1-35.gz"}],"id":"01KXHF606BE25QXFBVYVTCWHD2","image":"127.0.0.1/embedded/image2disk:latest","name":"stream image to disk","namespaces":{"network":"host"},"task_id":"01KXHF606BE25QXFBVZDJ5W610","timeoutSeconds":600,"volumes":["/dev:/dev","/dev/console:/dev/console","/lib/firmware:/lib/firmware:ro"],"workflow_id":"default/dev22-ubuntu-install"},"agentID":"88:e9:a4:58:5c:cc","level":0,"msg":"received action","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/agent.go","line":102},"time":"2025-05-19T12:04:11.689825308Z"},"procid":"1319","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-14T23:31:53.626201531Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/tink/controller/internal/workflow/reconciler.go:123","msg":"Reconcile","controller":"workflow","controllerGroup":"tinkerbell.org","controllerKind":"Workflow","Workflow":{"name":"dev22-ubuntu-install","namespace":"default"},"namespace":"default","name":"dev22-ubuntu-install","reconcileID":"6a0a6029-2418-4ec1-8580-a33d118a2404","logger":"tink-controller"}
{"time":"2026-07-14T23:31:53.62718743Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"3d83751719f9","facility":"daemon","host":"fd00:80:66::22","msg":{"action":{"agent_id":"88:e9:a4:58:5c:cc","env":[{"key":"COMPRESSED","value":"true"},{"key":"DEST_DISK","value":"/dev/sda"},{"key":"IMG_URL","value":"http://[fd00:80:66::1]:8081/images/ubuntu-1-35.gz"}],"id":"01KXHF606BE25QXFBVYVTCWHD2","image":"127.0.0.1/embedded/image2disk:latest","name":"stream image to disk","namespaces":{"network":"host"},"task_id":"01KXHF606BE25QXFBVZDJ5W610","timeoutSeconds":600,"volumes":["/dev:/dev","/dev/console:/dev/console","/lib/firmware:/lib/firmware:ro"],"workflow_id":"default/dev22-ubuntu-install"},"agentID":"88:e9:a4:58:5c:cc","level":0,"msg":"reported action status","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/agent.go","line":111},"state":"running","time":"2025-05-19T12:04:11.834219299Z"},"procid":"1319","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-14T23:31:53.741001617Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"a66c6befbdd1","facility":"daemon","host":"fd00:80:66::22","msg":"IMAGE2DISK - Cloud image streamer\n","procid":"1319","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-14T23:31:53.741079553Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"a66c6befbdd1","facility":"daemon","host":"fd00:80:66::22","msg":"------------------------\n","procid":"1319","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-14T23:31:53.743283729Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"a66c6befbdd1","facility":"daemon","host":"fd00:80:66::22","msg":"time=\"2025-05-19T12:04:11Z\" level=info msg=\"Beginning write of image [ubuntu-1-35.gz] to disk [/dev/sda]\"\n","procid":"1319","severity":"ERR"},"logger":"smee"}
{"time":"2026-07-14T23:31:53.743984884Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"3d83751719f9","facility":"daemon","host":"fd00:80:66::22","msg":{"agentID":"88:e9:a4:58:5c:cc","container_name":"tinkerbell_stream_image_to_disk_01KXHF606BE25QXFBVYVTCWHD2","level":0,"msg":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\"IMAGE2DISK - Cloud image streamer\n\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0019------------------------\n","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/internal/runtime/docker/docker.go","line":153},"time":"2025-05-19T12:04:11.951086291Z"},"procid":"1319","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-14T23:31:53.744060947Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"3d83751719f9","facility":"daemon","host":"fd00:80:66::22","msg":{"agentID":"88:e9:a4:58:5c:cc","container_name":"tinkerbell_stream_image_to_disk_01KXHF606BE25QXFBVYVTCWHD2","level":0,"msg":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000@\r                                   \rDownloading... 0 B complete\u0002\u0000\u0000\u0000\u0000\u0000\u0000jtime=\"2025-05-19T12:04:11Z\" level=info msg=\"Beginning write of image [ubuntu-1-35.gz] to disk [/dev/sda]\"\n","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/internal/runtime/docker/docker.go","line":153},"time":"2025-05-19T12:04:11.951231577Z"},"procid":"1319","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-14T23:31:54.244506149Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"3d83751719f9","facility":"daemon","host":"fd00:80:66::22","msg":{"agentID":"88:e9:a4:58:5c:cc","container_name":"tinkerbell_stream_image_to_disk_01KXHF606BE25QXFBVYVTCWHD2","level":0,"msg":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000C\r                                   \rDownloading... 109 MB complete","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/internal/runtime/docker/docker.go","line":153},"time":"2025-05-19T12:04:12.451530529Z"},"procid":"1319","severity":"INFO"},"logger":"smee"}
{"time":"2026-07-14T23:31:54.744694329Z","level":"0","caller":"home/eksadmin/L3/tinkerbell-pr812/smee/internal/syslog/receiver.go:167","msg":"syslog message received","logEntry":{"app-name":"3d83751719f9","facility":"daemon","host":"fd00:80:66::22","msg":{"agentID":"88:e9:a4:58:5c:cc","container_name":"tinkerbell_stream_image_to_disk_01KXHF606BE25QXFBVYVTCWHD2","level":0,"msg":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000C\r                                   \rDownloading... 508 MB complete","source":{"file":"home/eksadmin/L3/tinkerbell-pr812/tink/agent/internal/runtime/docker/docker.go","line":153},"time":"2025-05-19T12:04:12.951795246Z"},"procid":"1319","severity":"INFO"},"logger":"smee"}
``` 


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
