### PR TITLE
fix: harden syslog receiver with concurrency safety and correctness fixes

### DIFF
--- a/smee/internal/syslog/receiver.go
+++ b/smee/internal/syslog/receiver.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -18,42 +17,44 @@ var syslogMessagePool = sync.Pool{
 }
 
 type Receiver struct {
-	c     *net.UDPConn
-	parse chan *message
-	done  chan struct{}
-	err   error
-
+	conn   *net.UDPConn
+	msgCh  chan *message
+	done   chan struct{}
+	wg     sync.WaitGroup
+	mu     sync.Mutex
+	err    error
 	Logger logr.Logger
 }
 
-func StartReceiver(ctx context.Context, logger logr.Logger, laddr string, parsers int) error {
+func StartReceiver(ctx context.Context, logger logr.Logger, laddr string, parsers int) (*Receiver, error) {
 	if parsers < 1 {
 		parsers = 1
 	}
 
 	addr, err := net.ResolveUDPAddr("udp4", laddr)
 	if err != nil {
-		return fmt.Errorf("resolve syslog udp listen address: %w", err)
+		return nil, fmt.Errorf("resolve syslog udp listen address: %w", err)
 	}
 
 	c, err := net.ListenUDP("udp4", addr)
 	if err != nil {
-		return fmt.Errorf("listen on syslog udp address: %w", err)
+		return nil, fmt.Errorf("listen on syslog udp address: %w", err)
 	}
 
-	s := &Receiver{
-		c:      c,
-		parse:  make(chan *message, parsers),
+	r := &Receiver{
+		conn:   c,
+		msgCh:  make(chan *message, parsers*64),
 		done:   make(chan struct{}),
 		Logger: logger,
 	}
 
+	r.wg.Add(parsers)
 	for i := 0; i < parsers; i++ {
-		go s.runParser()
+		go r.runParser()
 	}
-	go s.run(ctx)
+	go r.run(ctx)
 
-	return nil
+	return r, nil
 }
 
 func (r *Receiver) Done() <-chan struct{} {
@@ -61,13 +62,21 @@ func (r *Receiver) Done() <-chan struct{} {
 }
 
 func (r *Receiver) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.err
 }
 
-func (r *Receiver) cleanup() {
-	r.c.Close()
+func (r *Receiver) setErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
 
-	close(r.parse)
+func (r *Receiver) shutdown() {
+	r.conn.Close()
+	close(r.msgCh)
+	r.wg.Wait()
 	close(r.done)
 }
 
@@ -81,7 +90,7 @@ func (r *Receiver) run(ctx context.Context) {
 
 	go func() {
 		<-ctx.Done()
-		r.cleanup()
+		r.conn.Close()
 	}()
 
 	for {
@@ -94,32 +103,30 @@ func (r *Receiver) run(ctx context.Context) {
 				continue
 			}
 		}
-		n, from, err := r.c.ReadFromUDP(msg.buf[:])
+		n, from, err := r.conn.ReadFromUDP(msg.buf[:])
 		if err != nil {
-			err = fmt.Errorf("error reading udp message: %w", err)
-			if _, ok := err.(net.Error); ok {
+			if ctx.Err() != nil {
+				r.shutdown()
+				return
+			}
+			var netErr net.Error
+			if errors.As(err, &netErr) {
 				r.Logger.Error(err, "error reading udp message")
-
 				continue
 			}
-			r.err = err
-
+			r.setErr(fmt.Errorf("error reading udp message: %w", err))
+			r.shutdown()
 			return
 		}
 		msg.time = time.Now().UTC()
 		msg.host = from.IP
 		msg.size = n
-		select {
-		case <-ctx.Done():
-			r.Logger.Info("context done, exiting syslog receiver")
-			return
-		case r.parse <- msg:
-		}
+		r.msgCh <- msg
 		msg = nil
 	}
 }
 
-func parse(m *message) map[string]interface{} {
+func toStructured(m *message) map[string]interface{} {
 	structured := make(map[string]interface{})
 	if m.Facility().String() != "" {
 		structured["facility"] = m.Facility().String()
@@ -127,20 +134,20 @@ func parse(m *message) map[string]interface{} {
 	if m.Severity().String() != "" {
 		structured["severity"] = m.Severity().String()
 	}
-	if string(m.hostname) != "" {
+	if len(m.hostname) > 0 {
 		structured["hostname"] = string(m.hostname)
 	}
-	if string(m.app) != "" {
+	if len(m.app) > 0 {
 		structured["app-name"] = string(m.app)
 	}
-	if string(m.procid) != "" {
+	if len(m.procid) > 0 {
 		structured["procid"] = string(m.procid)
 	}
-	if string(m.msgid) != "" {
+	if len(m.msgid) > 0 {
 		structured["msgid"] = string(m.msgid)
 	}
-	if string(m.msg) != "" {
-		if strings.HasPrefix(string(m.msg), "{") {
+	if len(m.msg) > 0 {
+		if m.msg[0] == '{' {
 			var j map[string]interface{}
 			if err := json.Unmarshal(m.msg, &j); err == nil {
 				structured["msg"] = j
@@ -157,17 +164,17 @@ func parse(m *message) map[string]interface{} {
 }
 
 func (r *Receiver) runParser() {
-	for m := range r.parse {
+	defer r.wg.Done()
+	for m := range r.msgCh {
 		if m.parse() {
-			structured := parse(m)
-			sl := r.Logger.WithValues("logEntry", structured)
+			structured := toStructured(m)
 			if m.Severity() == DEBUG {
-				sl.V(1).Info("syslog message received")
+				r.Logger.V(1).Info("syslog message received", "syslog", structured)
 			} else {
-				sl.Info("syslog message received")
+				r.Logger.Info("syslog message received", "syslog", structured)
 			}
 		} else {
-			r.Logger.V(1).Info("syslog message received", "logEntry", m)
+			r.Logger.V(1).Info("unparseable syslog message", "raw", m)
 		}
 		m.reset()
 		syslogMessagePool.Put(m)

--- a/smee/internal/syslog/receiver.go
+++ b/smee/internal/syslog/receiver.go
@@ -84,6 +84,9 @@ func (r *Receiver) run(ctx context.Context) {
 	var msg *message
 	defer func() {
 		if msg != nil {
+			// Reset before returning to the pool so a partially-populated
+			// message is never reused with stale state.
+			msg.reset()
 			syslogMessagePool.Put(msg)
 		}
 	}()

--- a/smee/internal/syslog/receiver.go
+++ b/smee/internal/syslog/receiver.go
@@ -121,7 +121,15 @@ func (r *Receiver) run(ctx context.Context) {
 		msg.time = time.Now().UTC()
 		msg.host = from.IP
 		msg.size = n
-		r.msgCh <- msg
+		// Guard the send on ctx so a full msgCh (slow/blocked parsers) can't
+		// wedge the read loop past cancellation: closing the conn only unblocks
+		// a blocked read, not a blocked send.
+		select {
+		case <-ctx.Done():
+			r.shutdown()
+			return
+		case r.msgCh <- msg:
+		}
 		msg = nil
 	}
 }

--- a/smee/internal/syslog/receiver_test.go
+++ b/smee/internal/syslog/receiver_test.go
@@ -43,7 +43,7 @@ func TestStartReceiver(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 
-			err := StartReceiver(ctx, logr.Discard(), tc.laddr, tc.parsers)
+			_, err := StartReceiver(ctx, logr.Discard(), tc.laddr, tc.parsers)
 
 			if tc.wantErr {
 				if err == nil {
@@ -72,7 +72,7 @@ func TestStartReceiver_AddressInUse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	err = StartReceiver(ctx, logr.Discard(), addr, 1)
+	_, err = StartReceiver(ctx, logr.Discard(), addr, 1)
 	if err == nil {
 		t.Error("StartReceiver() expected error for address in use but got none")
 	}
@@ -91,39 +91,35 @@ func TestReceiver_DoneAndErr(t *testing.T) {
 	addr := conn.LocalAddr().String()
 	conn.Close()
 
-	err = StartReceiver(ctx, logr.Discard(), addr, 1)
+	r, err := StartReceiver(ctx, logr.Discard(), addr, 1)
 	if err != nil {
 		t.Fatalf("StartReceiver() unexpected error = %v", err)
 	}
 
-	// Since we can't easily access the receiver instance from StartReceiver,
-	// we'll test the concept by creating our own receiver
-	testReceiver := &Receiver{
-		done: make(chan struct{}),
-		err:  nil,
-	}
-
-	// Test Done() method
+	// Test Done() method on the live receiver
 	select {
-	case <-testReceiver.Done():
+	case <-r.Done():
 		t.Error("Done() channel should not be closed initially")
 	default:
 		// Expected behavior
 	}
 
-	// Test Err() method
-	if testReceiver.Err() != nil {
-		t.Errorf("Err() = %v, want nil", testReceiver.Err())
+	// Test Err() method on the live receiver
+	if r.Err() != nil {
+		t.Errorf("Err() = %v, want nil", r.Err())
 	}
 
-	// Simulate an error
-	testReceiver.err = net.ErrClosed
+	// Simulate an error on a separate instance
+	testReceiver := &Receiver{
+		done: make(chan struct{}),
+	}
+	testReceiver.setErr(net.ErrClosed)
 	if !errors.Is(testReceiver.Err(), net.ErrClosed) {
 		t.Errorf("Err() = %v, want %v", testReceiver.Err(), net.ErrClosed)
 	}
 }
 
-func TestReceiver_cleanup(t *testing.T) {
+func TestReceiver_shutdown(t *testing.T) {
 	// Create a real UDP connection for testing
 	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 	if err != nil {
@@ -131,19 +127,19 @@ func TestReceiver_cleanup(t *testing.T) {
 	}
 
 	r := &Receiver{
-		c:     conn,
-		parse: make(chan *message, 1),
+		conn:  conn,
+		msgCh: make(chan *message, 1),
 		done:  make(chan struct{}),
 	}
 
-	// Test that cleanup closes everything
-	r.cleanup()
+	// Test that shutdown closes everything
+	r.shutdown()
 
 	// Verify connection is closed by trying to read from it
 	buf := make([]byte, 1)
 	_, _, err = conn.ReadFromUDP(buf)
 	if err == nil {
-		t.Error("Expected connection to be closed after cleanup()")
+		t.Error("Expected connection to be closed after shutdown()")
 	}
 
 	// Verify channels are closed
@@ -151,13 +147,13 @@ func TestReceiver_cleanup(t *testing.T) {
 	case <-r.done:
 		// Expected - channel should be closed
 	default:
-		t.Error("done channel should be closed after cleanup()")
+		t.Error("done channel should be closed after shutdown()")
 	}
 
 	select {
-	case _, ok := <-r.parse:
+	case _, ok := <-r.msgCh:
 		if ok {
-			t.Error("parse channel should be closed after cleanup()")
+			t.Error("msgCh channel should be closed after shutdown()")
 		}
 	default:
 		// This is also acceptable as the channel might be empty
@@ -238,7 +234,7 @@ func TestParse(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := parse(tc.message)
+			result := toStructured(tc.message)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
 				t.Errorf("parse() mismatch (-want +got):\n%s", diff)
 			}
@@ -247,12 +243,13 @@ func TestParse(t *testing.T) {
 }
 
 func TestReceiver_runParser(t *testing.T) {
-	// Create a test receiver with a parse channel
-	parseChannel := make(chan *message, 2)
+	// Create a test receiver with a message channel
+	msgCh := make(chan *message, 2)
 	receiver := &Receiver{
-		parse:  parseChannel,
+		msgCh:  msgCh,
 		Logger: logr.Discard(),
 	}
+	receiver.wg.Add(1)
 
 	// Create test messages with valid syslog format
 	msg1 := &message{
@@ -278,9 +275,9 @@ func TestReceiver_runParser(t *testing.T) {
 	copy(msg2.buf[:], "<31>debug message")
 
 	// Send messages to the channel
-	parseChannel <- msg1
-	parseChannel <- msg2
-	close(parseChannel)
+	msgCh <- msg1
+	msgCh <- msg2
+	close(msgCh)
 
 	// Track the completion of message processing
 	var wg sync.WaitGroup
@@ -347,7 +344,7 @@ func TestReceiverIntegration(t *testing.T) {
 	conn.Close()
 
 	// Start the receiver
-	err = StartReceiver(ctx, logr.Discard(), addr, 1)
+	_, err = StartReceiver(ctx, logr.Discard(), addr, 1)
 	if err != nil {
 		t.Fatalf("StartReceiver() error = %v", err)
 	}
@@ -397,8 +394,8 @@ func TestReceiver_run_contextCancel(t *testing.T) {
 	defer conn.Close()
 
 	r := &Receiver{
-		c:      conn,
-		parse:  make(chan *message, 1),
+		conn:   conn,
+		msgCh:  make(chan *message, 1),
 		done:   make(chan struct{}),
 		Logger: logr.Discard(),
 	}
@@ -430,8 +427,8 @@ func TestReceiver_run_networkError(t *testing.T) {
 	conn.Close() // Close immediately to cause errors
 
 	r := &Receiver{
-		c:      conn,
-		parse:  make(chan *message, 1),
+		conn:   conn,
+		msgCh:  make(chan *message, 1),
 		done:   make(chan struct{}),
 		Logger: logr.Discard(),
 	}
@@ -461,10 +458,10 @@ func TestReceiver_run_parseChannelBlocking(t *testing.T) {
 	}
 	defer conn.Close()
 
-	parseChannel := make(chan *message) // No buffer - will block immediately
+	msgCh := make(chan *message) // No buffer - will block immediately
 	r := &Receiver{
-		c:      conn,
-		parse:  parseChannel,
+		conn:   conn,
+		msgCh:  msgCh,
 		done:   make(chan struct{}),
 		Logger: logr.Discard(),
 	}
@@ -553,7 +550,7 @@ func TestParse_emptyAndNilFields(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := parse(tc.message)
+			result := toStructured(tc.message)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
 				t.Errorf("parse() mismatch (-want +got):\n%s", diff)
 			}
@@ -590,7 +587,7 @@ func TestParse_priorityEdgeCases(t *testing.T) {
 				priority: tc.priority,
 				host:     net.IPv4(127, 0, 0, 1),
 			}
-			result := parse(message)
+			result := toStructured(message)
 
 			if result["facility"] != tc.facility {
 				t.Errorf("Expected facility %s, got %s", tc.facility, result["facility"])
@@ -636,7 +633,7 @@ func TestParse_malformedJSON(t *testing.T) {
 				msg:      []byte(tc.jsonMsg),
 				host:     net.IPv4(127, 0, 0, 1),
 			}
-			result := parse(message)
+			result := toStructured(message)
 
 			if diff := cmp.Diff(tc.expected, result["msg"]); diff != "" {
 				t.Errorf("JSON parsing mismatch (-want +got):\n%s", diff)
@@ -646,11 +643,12 @@ func TestParse_malformedJSON(t *testing.T) {
 }
 
 func TestReceiver_runParser_invalidMessages(t *testing.T) {
-	parseChannel := make(chan *message, 3)
+	msgCh := make(chan *message, 3)
 	receiver := &Receiver{
-		parse:  parseChannel,
+		msgCh:  msgCh,
 		Logger: logr.Discard(),
 	}
+	receiver.wg.Add(1)
 
 	// Create messages that will fail parsing
 	invalidMsg1 := &message{
@@ -670,9 +668,9 @@ func TestReceiver_runParser_invalidMessages(t *testing.T) {
 	}
 
 	// Send invalid messages
-	parseChannel <- invalidMsg1
-	parseChannel <- invalidMsg2
-	close(parseChannel)
+	msgCh <- invalidMsg1
+	msgCh <- invalidMsg2
+	close(msgCh)
 
 	// Track completion
 	var wg sync.WaitGroup
@@ -765,7 +763,7 @@ func TestStartReceiver_multipleInstances(t *testing.T) {
 
 	for i, addr := range addresses {
 		t.Run(fmt.Sprintf("instance_%d", i), func(t *testing.T) {
-			err := StartReceiver(ctx, logr.Discard(), addr, 2)
+			_, err := StartReceiver(ctx, logr.Discard(), addr, 2)
 			if err != nil {
 				t.Errorf("Failed to start receiver instance %d: %v", i, err)
 			}
@@ -775,11 +773,12 @@ func TestStartReceiver_multipleInstances(t *testing.T) {
 
 func TestReceiver_runParser_DEBUG_severity(t *testing.T) {
 	// Test specific handling of DEBUG severity messages
-	parseChannel := make(chan *message, 1)
+	msgCh := make(chan *message, 1)
 	receiver := &Receiver{
-		parse:  parseChannel,
+		msgCh:  msgCh,
 		Logger: logr.Discard(),
 	}
+	receiver.wg.Add(1)
 
 	// Create a DEBUG message
 	debugMsg := &message{
@@ -793,8 +792,8 @@ func TestReceiver_runParser_DEBUG_severity(t *testing.T) {
 	}
 	copy(debugMsg.buf[:], "<31>debug-host debug-app: debug message")
 
-	parseChannel <- debugMsg
-	close(parseChannel)
+	msgCh <- debugMsg
+	close(msgCh)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/smee/internal/syslog/receiver_test.go
+++ b/smee/internal/syslog/receiver_test.go
@@ -236,7 +236,7 @@ func TestParse(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			result := toStructured(tc.message)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
-				t.Errorf("parse() mismatch (-want +got):\n%s", diff)
+				t.Errorf("toStructured() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -488,6 +488,48 @@ func TestReceiver_run_parseChannelBlocking(t *testing.T) {
 	}
 }
 
+func TestReceiver_run_blockedSendContextCancel(t *testing.T) {
+	// A datagram is read but the unbuffered, undrained msgCh blocks the send.
+	// Cancelling the context must still stop the receiver instead of wedging
+	// the read loop on the send (closing the conn only unblocks a blocked read).
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := conn.LocalAddr().(*net.UDPAddr)
+
+	r := &Receiver{
+		conn:   conn,
+		msgCh:  make(chan *message), // unbuffered, no consumer -> send blocks
+		done:   make(chan struct{}),
+		Logger: logr.Discard(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go r.run(ctx)
+
+	// Send a datagram so run() reads it and then blocks on the send.
+	client, err := net.DialUDP("udp4", nil, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if _, err := client.Write([]byte("<13>1 hello world")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give run() time to read the datagram and block on the send, then cancel.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-r.Done():
+		// Expected: receiver stopped despite the blocked send.
+	case <-time.After(2 * time.Second):
+		t.Fatal("receiver did not stop after context cancellation while blocked on send")
+	}
+}
+
 func TestParse_emptyAndNilFields(t *testing.T) {
 	tests := map[string]struct {
 		message  *message
@@ -552,7 +594,7 @@ func TestParse_emptyAndNilFields(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			result := toStructured(tc.message)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
-				t.Errorf("parse() mismatch (-want +got):\n%s", diff)
+				t.Errorf("toStructured() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/smee/smee.go
+++ b/smee/smee.go
@@ -375,6 +375,23 @@ func (c *Config) ISOHandler(log logr.Logger) (http.Handler, error) {
 
 // Start will run Smee non-HTTP services (DHCP, TFTP, syslog).
 // HTTP serving is handled externally by the HTTP server.
+// runSyslogServer starts the syslog receiver bound to addr and blocks until it
+// stops, returning any error encountered while starting or running it.
+func runSyslogServer(ctx context.Context, log logr.Logger, addr string) error {
+	r, err := syslog.StartReceiver(ctx, log, addr, 1)
+	if err != nil {
+		log.Error(err, "syslog server failure")
+		return err
+	}
+	<-r.Done()
+	if err := r.Err(); err != nil {
+		log.Error(err, "syslog server failure")
+		return err
+	}
+	log.Info("syslog server stopped")
+	return nil
+}
+
 func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 	if c.Backend == nil {
 		return errors.New("no backend provided")
@@ -392,18 +409,7 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 		}
 		log.Info("starting syslog server", "bindAddr", addr)
 		g.Go(func() error {
-			r, err := syslog.StartReceiver(ctx, log, addr.String(), 1)
-			if err != nil {
-				log.Error(err, "syslog server failure")
-				return err
-			}
-			<-r.Done()
-			if err := r.Err(); err != nil {
-				log.Error(err, "syslog server failure")
-				return err
-			}
-			log.Info("syslog server stopped")
-			return nil
+			return runSyslogServer(ctx, log, addr.String())
 		})
 	}
 

--- a/smee/smee.go
+++ b/smee/smee.go
@@ -392,11 +392,16 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 		}
 		log.Info("starting syslog server", "bindAddr", addr)
 		g.Go(func() error {
-			if err := syslog.StartReceiver(ctx, log, addr.String(), 1); err != nil {
+			r, err := syslog.StartReceiver(ctx, log, addr.String(), 1)
+			if err != nil {
 				log.Error(err, "syslog server failure")
 				return err
 			}
-			<-ctx.Done()
+			<-r.Done()
+			if err := r.Err(); err != nil {
+				log.Error(err, "syslog server failure")
+				return err
+			}
 			log.Info("syslog server stopped")
 			return nil
 		})

--- a/smee/smee_test.go
+++ b/smee/smee_test.go
@@ -1,0 +1,48 @@
+package smee
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func TestRunSyslogServer(t *testing.T) {
+	// Grab a free UDP port, then release it so the receiver can bind to it.
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("reserve udp port: %v", err)
+	}
+	addr := conn.LocalAddr().String()
+	conn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runSyslogServer(ctx, logr.Discard(), addr)
+	}()
+
+	// Give the receiver a moment to bind, then cancel to trigger a clean stop.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("runSyslogServer() returned error on clean shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSyslogServer() did not return after context cancellation")
+	}
+}
+
+func TestRunSyslogServer_startError(t *testing.T) {
+	// An unparseable bind address makes StartReceiver fail, so runSyslogServer
+	// should surface the error rather than block.
+	err := runSyslogServer(context.Background(), logr.Discard(), "not-a-valid-address")
+	if err == nil {
+		t.Error("runSyslogServer() expected error for invalid bind address, got nil")
+	}
+}


### PR DESCRIPTION
## Description

Hardens the smee syslog receiver against data races and shutdown/retry bugs, and improves the structured log output so downstream parsers don't misread entries.

## Changes

### Concurrency & correctness
- Return `*Receiver` from `StartReceiver` so callers can use `Done()`/`Err()` for lifecycle management; `smee.go` now blocks on `Done()` and propagates `Err()` instead of only waiting on `ctx.Done()`.
- Guard the shared `err` field with a `sync.Mutex` (`setErr`/`Err`) to fix a data race between the reader goroutine and callers of `Err()`.
- Use `errors.As` on the wrapped `net.Error` so error matching works through `fmt.Errorf` wrapping.
- Check `ctx.Err()` before retrying after the connection closes, avoiding an infinite retry loop on context cancellation.
- Drain parser goroutines with a `sync.WaitGroup` so `done` only closes after all parsers finish.
- Size the message channel to `parsers*64` to reduce blocking between the fast UDP producer and the slower parser consumers.

### Structured logging
- Emit structured syslog data under the `syslog` key (and raw payloads under `raw`) with descriptive log messages, so downstream log parsers don't misparse the entries.

### Cleanup
- Rename colliding identifiers for clarity (`parse` func → `toStructured`, `c` field → `conn`, `parse` chan → `msgCh`) and replace `string(b) != ""` with `len(b) > 0`.

## How Has This Been Tested?

- `make lint` (golangci-lint v2.11.2) — 0 issues.
- `go build ./...` and `go vet ./smee/...` pass.
- `go test -race ./smee/internal/syslog/...` passes, exercising the concurrency fixes under the race detector.
- Full `go test ./...` passes.

## Pre PR Checklist

- [x] You've reviewed the code of conduct
- [x] All commits are DCO signed off
- [x] Code is formatted and linted
- [x] Code builds successfully
- [x] All tests are passing
- [x] Code coverage within 1% of main


## AI Assistance

This contribution was developed with the assistance of Claude (Anthropic). All changes were reviewed and verified by the author.
