### PR TITLE
Add docs, only do prefix path normalization once:

### DIFF
--- a/docs/technical/PORTS_AND_ENDPOINTS.md
+++ b/docs/technical/PORTS_AND_ENDPOINTS.md
@@ -15,12 +15,19 @@ variables.
 | **7443** | TCP (HTTPS) | Consolidated HTTPS server | Same routes as HTTP; enabled when TLS cert/key are provided | `--tls-cert-file` / `--tls-key-file` |
 | **42113** | TCP (gRPC) | Tink Server | Workflow service for tink-agent | `--enable-tink-server=false` |
 | **67** | UDP | Smee DHCP | PXE boot: offers next-server, iPXE script URL, and IP configuration | `--enable-smee=false` |
-| **69** | UDP | Smee TFTP | Serves iPXE firmware binaries to PXE-booting machines | `--enable-smee=false` |
+| **69** | UDP | Smee TFTP | Serves iPXE firmware binaries, and (optionally) PXELinux configs, Raspberry Pi netboot firmware, and arbitrary disk assets to PXE-booting machines | `--enable-smee=false` |
 | **514** | UDP | Smee Syslog | Collects boot-time syslog messages from provisioning machines | `--enable-smee=false` |
 | **2222** | TCP (SSH) | SecondStar | SSH-to-serial bridge for out-of-band hardware management via BMC | `--enable-secondstar=false` |
 
 > **Note:** The HTTP and HTTPS ports are configurable via `--http-port` and
 > `--https-port`. The gRPC port is configurable via `--tink-server-bind-port`.
+> The TFTP server can serve extra on-disk assets from a directory configured
+> via `--tftp-asset-dir` (env `TINKERBELL_TFTP_ASSET_DIR`); it is disabled when
+> empty (the default). The same PXELinux configs and asset directory can also
+> be served over the consolidated HTTP server ("PXE over HTTP", for u-boot's
+> pxe-over-http/wget clients) by enabling `--pxe-http-enabled`; the URL path
+> prefix it mounts under is set with `--pxe-http-path-prefix` (default
+> `/tftp/`).
 
 ---
 
@@ -59,9 +66,30 @@ per-service scraping. A combined endpoint gathers from all registries.
 
 | Route | Method | HTTPS | Redirect | Description |
 |-------|--------|-------|----------|-------------|
-| `/ipxe/binary/` | GET | | | Serves architecture-specific iPXE firmware binaries (e.g. `snp.efi`, `undionly.kpxe`). DHCP option 67 points machines here. |
+| `/ipxe/binary/` | GET, HEAD | | | Serves architecture-specific iPXE firmware binaries (e.g. `snp.efi`, `undionly.kpxe`) from the embedded file set. DHCP option 67 points machines here. |
 | `/ipxe/script/` | GET | | | Serves auto-generated iPXE boot scripts. Supports MAC-address injection in the URL path (e.g. `/ipxe/script/aa:bb:cc:dd:ee:ff/auto.ipxe`). |
 | `/iso/` | GET | ✅ | | Serves dynamically-patched ISO images with per-machine kernel parameters baked in. Enabled via `--smee-iso-enabled`. |
+
+### PXE over HTTP (Smee)
+
+When `--pxe-http-enabled` is set, Smee mounts a handler on the consolidated
+HTTP server that serves the **same routes as the TFTP server** over HTTP, for
+clients that netboot via HTTP (e.g. u-boot's pxe-over-http, which uses `wget`)
+using the same request-path shapes as TFTP. It is disabled by default.
+
+The handler reuses the TFTP route abstraction, but with a reduced route set:
+only the PXELinux and disk-asset routes are enabled (the embedded-iPXE route is
+omitted because iPXE binaries are already served at `/ipxe/binary/`, and the
+Raspberry Pi EEPROM route is out of scope for u-boot). All paths below are
+relative to the configured prefix (`--pxe-http-path-prefix`, default `/tftp/`).
+
+| Route | Method | HTTPS | Redirect | Description |
+|-------|--------|-------|----------|-------------|
+| `{prefix}/pxelinux.cfg/01-<MAC>` | GET, HEAD | | | Serves the on-the-fly `pxelinux.cfg` (extlinux format) from Hardware `spec.netboot.pxelinux.config`, looked up by the dashed MAC in the path (either case accepted). |
+| `{prefix}/<path>` | GET, HEAD | | | Serves an arbitrary file from the TFTP asset directory (`--tftp-asset-dir`). Path traversal outside the directory is rejected. Returns 404 when the file does not exist or no asset directory is configured. |
+
+`HEAD` requests return the `Content-Length` header (set for seekable payloads)
+without a body. Non-`GET`/`HEAD` methods return `405 Method Not Allowed`.
 
 ### EC2-Compatible Metadata (Tootles)
 
@@ -113,6 +141,97 @@ support HTTPS and redirect HTTP → HTTPS when TLS is enabled.
 
 ---
 
+## TFTP Endpoints
+
+Smee's TFTP server (UDP `:69`) serves boot files to machines that PXE-boot over
+TFTP. Each incoming request is offered to a list of routes **in order**. A route
+inspects the requested path and either **claims** the request (serves it, and
+the search stops) or **declines** it (the next route is tried). The routes are
+not alternative filenames that get retried — the client always asks for one
+name, and each route just decides whether that name is "its" kind of request. If
+no route claims it, the server returns a "file unknown" (not-found) error.
+
+Most routes are mutually exclusive by path shape, so ordering only decides
+precedence in the rare case where more than one route could claim the same path
+(first match wins). For example, a request for `snp.efi` is claimed by the
+embedded-iPXE route (it is a compiled-in name); a request for
+`pxelinux.cfg/01-AA-BB-CC-DD-EE-FF` is claimed by the PXELinux route; anything
+else falls through to the disk-asset route if a file of that name exists.
+
+| Requested Path (matched by route) | Served From | Hardware Lookup | Description |
+|-----------------------------------|-------------|-----------------|-------------|
+| `<name>` matches the basename of an embedded iPXE file (e.g. `snp.efi`, `undionly.kpxe`) | Embedded (compiled-in) iPXE binaries | None | Serves the iPXE bootloader, optionally patched with the embedded-script patch. This is the default TFTP boot path. |
+| `pxelinux.cfg/01-<MAC>` | Hardware `spec.netboot.pxelinux.config`, else a static asset-dir file | By MAC (parsed from path; either case) | Serves an on-the-fly `pxelinux.cfg` (extlinux format) for u-boot PXELinux booting. |
+| `<SerialNum>/config.txt` | Hardware `spec.netboot.rpi.configTxt`, else a static asset-dir file | By client IP | Raspberry Pi EEPROM netboot `config.txt`. |
+| `<SerialNum>/cmdline.txt` | Hardware `spec.netboot.osie.kernelParams` (space-joined), else a static asset-dir file | By client IP | Raspberry Pi EEPROM netboot `cmdline.txt`. |
+| `<SerialNum>/<file>` (any other file under the serial prefix) | Asset directory, at `<firmwarePath>/<file>` (see below) | By client IP | Raspberry Pi firmware/binaries (e.g. `start4.elf`, `.dtb`). |
+| `<path>` (any remaining path) | Asset directory (`--tftp-asset-dir`) | None | Fallback: serves an arbitrary file from the asset directory. Path traversal outside the directory is rejected. Returns not-found when the file is absent or no asset directory is configured. |
+
+**Notes:**
+
+- The Raspberry Pi and disk-asset routes require an asset directory
+  (`--tftp-asset-dir`, env `TINKERBELL_TFTP_ASSET_DIR`); both are disabled when
+  it is empty (the default). The Raspberry Pi routes additionally require the
+  matched Hardware to set `spec.netboot.rpi.serialNum` and
+  `spec.netboot.rpi.firmwarePath`.
+- The Raspberry Pi serial number is not derived from the MAC: the Hardware is
+  found by client IP, and its serial number is matched against the request
+  path's prefix.
+- For Raspberry Pi firmware files, the serial-number prefix in the requested
+  path is mapped to a location **inside the asset directory** before the file is
+  read from local disk: a request for `<SerialNum>/start4.elf` is served from
+  the file `<assetDir>/<firmwarePath>/start4.elf`. This is a purely internal
+  disk-path mapping performed by Smee; the TFTP client is **not** redirected and
+  never sees `<firmwarePath>` — it requested `<SerialNum>/start4.elf` and
+  receives those bytes in response.
+- Clients may append a traceparent to the requested filename; it is stripped
+  before route matching.
+- The PXELinux and disk-asset routes can additionally be exposed over the HTTP
+  server; see [PXE over HTTP (Smee)](#pxe-over-http-smee).
+
+These routes rely on the following Hardware fields:
+
+A normal iPXE boot needs **none** of these fields — it uses the compiled-in iPXE
+binaries with no Hardware configuration. They apply only when you opt into
+PXELinux or Raspberry Pi netboot:
+
+| Hardware field | Required? | Effect when unset |
+|---|---|---|
+| `spec.netboot.rpi.serialNum` | Required to enable the RPi route (gates it together with `firmwarePath`) | RPi route is skipped for this machine |
+| `spec.netboot.rpi.firmwarePath` | Required to enable the RPi route | RPi route is skipped for this machine |
+| `spec.netboot.pxelinux.config` | Optional | `pxelinux.cfg/01-<MAC>` is not generated; the request falls through (see precedence) |
+| `spec.netboot.rpi.configTxt` | Optional | `<SerialNum>/config.txt` is not served inline; the request falls through |
+| `spec.netboot.osie.kernelParams` | Optional | `<SerialNum>/cmdline.txt` is not served inline; the request falls through |
+
+`serialNum` is the full serial number or its last 8 characters. `firmwarePath`
+is the asset-directory subpath that the serial prefix maps to on disk (see the
+Raspberry Pi firmware note above); it is internal to Smee, not a client-visible
+redirect.
+
+**Precedence.** There are **no built-in default templates** — when a Hardware
+field is empty its route does not synthesize a default; it declines, and the
+request is offered to the next route. So for the PXELinux / `config.txt` /
+`cmdline.txt` paths the effective order is:
+
+1. The Hardware field, served inline, if set.
+2. Otherwise, a static file of the same requested name under `--tftp-asset-dir`
+   (served by the disk-asset route, only if an asset directory is configured).
+3. Otherwise, not-found.
+
+All other Raspberry Pi firmware/binaries, and any other requested file, come
+solely from the disk-asset route (`--tftp-asset-dir`); they have no
+Hardware-field source.
+
+**`kernelParams` has a second, separate use.** Besides the Raspberry Pi
+`cmdline.txt` above, `spec.netboot.osie.kernelParams` is also injected into the
+generated **iPXE boot script** (a different code path from TFTP serving). There
+the precedence is additive rather than fall-through: the global
+`--ipxe-http-script-extra-kernel-args` values are applied first, then the
+per-Hardware `osie.kernelParams` are appended, so machine-specific values win on
+duplicate keys (the Linux kernel command line is last-wins).
+
+---
+
 ## gRPC Service
 
 | Service | Port | Methods | Description |
@@ -147,8 +266,10 @@ Key DHCP options set:
 
 ### TFTP (UDP :69)
 
-Serves iPXE firmware binaries for initial PXE boot. Machines chain-load from
-TFTP → iPXE binary → HTTP iPXE script → OS kernel/initrd over HTTP.
+Serves boot files for initial PXE boot; see the [TFTP Endpoints](#tftp-endpoints)
+section for the full list of served paths and their sources. In the common iPXE
+case, machines chain-load from TFTP → iPXE binary → HTTP iPXE script → OS
+kernel/initrd over HTTP.
 
 - Block size: 512 bytes (configurable)
 - Single-port mode: enabled by default

--- a/smee/internal/ipxe/binary/http.go
+++ b/smee/internal/ipxe/binary/http.go
@@ -22,20 +22,33 @@ import (
 // HTTP (eg. u-boot's pxe-over-http, which uses wget) instead of TFTP, using the
 // exact same request path shapes.
 //
-// The requested URL path has PathPrefix stripped and is then handed to the
-// Router as a binary.Request, so the underlying Route implementations
+// The requested URL path has the mount prefix stripped and is then handed to
+// the Router as a binary.Request, so the underlying Route implementations
 // (PXELinuxMACRoute, DiskAssetRoute, ...) are reused unchanged.
+//
+// Construct it with NewHTTPHandler so the mount prefix is normalized once.
 type HTTPHandler struct {
 	Log logr.Logger
 	// Router dispatches each request through its configured Routes in order.
 	// The caller is responsible for constructing the Router with the routes it
 	// wants to enable.
 	Router Router
-	// PathPrefix is the URL path prefix the handler is mounted under (eg.
-	// "/tftp/"). It is stripped before the remaining path is dispatched. A
-	// missing leading slash is normalized so it always matches the mount
-	// prefix regardless of how it was configured (eg. "tftp" == "/tftp/").
-	PathPrefix string
+	// prefix is the normalized URL path prefix the handler is mounted under
+	// (eg. "/tftp/"). It is precomputed once by NewHTTPHandler and stripped
+	// from each request path before dispatch, so stripping always agrees with
+	// the mount point regardless of how the prefix was configured (eg. "tftp",
+	// "/tftp", and "/tftp//" all normalize to "/tftp/").
+	prefix string
+}
+
+// NewHTTPHandler builds an HTTPHandler, normalizing pathPrefix once (via
+// normalizePathPrefix) so it does not have to be recomputed on every request.
+func NewHTTPHandler(log logr.Logger, router Router, pathPrefix string) HTTPHandler {
+	return HTTPHandler{
+		Log:    log,
+		Router: router,
+		prefix: normalizePathPrefix(pathPrefix),
+	}
 }
 
 // normalizePathPrefix canonicalizes a mount prefix to a leading- and
@@ -65,10 +78,10 @@ func (h HTTPHandler) Handle(w http.ResponseWriter, req *http.Request) {
 
 	// Strip the mount prefix and any leading slash so the remaining path
 	// matches the shapes the Routes expect (eg. "pxelinux.cfg/01-<MAC>").
-	// PathPrefix is normalized the same way the HTTP server normalizes the
-	// mount point, so stripping always agrees with where the handler is
-	// actually mounted, even for inputs like "tftp" or "/tftp//".
-	rel := strings.TrimPrefix(req.URL.Path, normalizePathPrefix(h.PathPrefix))
+	// h.prefix was normalized at construction the same way the HTTP server
+	// normalizes the mount point, so stripping always agrees with where the
+	// handler is actually mounted, even for inputs like "tftp" or "/tftp//".
+	rel := strings.TrimPrefix(req.URL.Path, h.prefix)
 	rel = strings.TrimPrefix(rel, "/")
 
 	host, port, _ := net.SplitHostPort(req.RemoteAddr)

--- a/smee/internal/ipxe/binary/http_test.go
+++ b/smee/internal/ipxe/binary/http_test.go
@@ -113,11 +113,7 @@ func TestHTTPHandler(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			h := HTTPHandler{
-				Log:        logr.Discard(),
-				Router:     pxeHTTPRouter(resolver, dir),
-				PathPrefix: tt.prefix,
-			}
+			h := NewHTTPHandler(logr.Discard(), pxeHTTPRouter(resolver, dir), tt.prefix)
 			req := httptest.NewRequest(tt.method, tt.target, nil)
 			rr := httptest.NewRecorder()
 			h.Handle(rr, req)

--- a/smee/smee.go
+++ b/smee/smee.go
@@ -353,17 +353,14 @@ func (c *Config) PXEHTTPHandler(log logr.Logger) http.Handler {
 		return nil
 	}
 	resolver := hardware.BackendResolver{Backend: c.Backend}
-	return http.HandlerFunc(binary.HTTPHandler{
-		Log:        log,
-		PathPrefix: c.PXEHTTP.PathPrefix,
-		Router: binary.Router{
-			Log: log,
-			Routes: []binary.Route{
-				binary.PXELinuxMACRoute{Log: log, Resolver: resolver},
-				binary.DiskAssetRoute{Log: log, Dir: c.TFTP.AssetDir},
-			},
+	router := binary.Router{
+		Log: log,
+		Routes: []binary.Route{ // order matters here, first match wins
+			binary.PXELinuxMACRoute{Log: log, Resolver: resolver},
+			binary.DiskAssetRoute{Log: log, Dir: c.TFTP.AssetDir},
 		},
-	}.Handle)
+	}
+	return http.HandlerFunc(binary.NewHTTPHandler(log, router, c.PXEHTTP.PathPrefix).Handle)
 }
 
 // ScriptHandler returns an http.Handler that serves iPXE scripts.
@@ -467,7 +464,7 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 			BlockSize:            c.TFTP.BlockSize,
 			Router: binary.Router{
 				Log: log,
-				Routes: []binary.Route{
+				Routes: []binary.Route{ // order matters here, first match wins
 					binary.EmbeddedIPXERoute{Log: log, Patch: []byte(c.IPXE.EmbeddedScriptPatch)},
 					binary.PXELinuxMACRoute{Log: log, Resolver: resolver},
 					binary.RPiNetbootRoute{Log: log, Resolver: resolver, AssetDir: c.TFTP.AssetDir},


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
normalizing the prefix patch that is set once
on every request is unneccessary. Also, updated
the docs on ports and endpoints.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
