### PR TITLE
fix misattributed Kubernetes library log output:

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -56,7 +56,14 @@ func ConfigAndFlags(disableLogging *bool) (*pflag.FlagSet, func(context.Context,
 		if disableLogging != nil && *disableLogging {
 			log = logr.Discard()
 		}
-		klog.SetLogger(log)
+		// logsapi.ValidateAndApply above is required apiserver setup: it
+		// validates and applies the Kubernetes logging options (s.Logs). A side
+		// effect is that it installs klog's own JSON logger as the process-global
+		// logger, overriding the logger cmd.go set. We don't want that format, so
+		// re-point the global klog logger back at the dedicated "klog" logger here,
+		// matching the name cmd.go uses. This also covers the embedded
+		// kube-controller-manager, which shares the same global klog.
+		klog.SetLogger(log.WithName("klog"))
 		return apiapp.Run(ctx, completedOptions)
 	}
 

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -26,6 +26,9 @@ import (
 	"github.com/tinkerbell/tinkerbell/ui"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/credentials"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
 var (
@@ -152,6 +155,28 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 	}
 
 	log := getLogger(globals.LogLevel)
+
+	// klog (client-go and other Kubernetes libraries) and controller-runtime
+	// both log through process-global loggers for code paths that aren't handed
+	// an explicit, per-instance logger. Set each once here, named after the
+	// library that emits through it, so their output is attributed to the
+	// correct logger instead of to whichever component called SetLogger last.
+	// Per-component logs are unaffected: each manager still logs under its own
+	// name via controllerruntime.Options.Logger.
+	klog.SetLogger(log.WithName("klog"))
+	controllerruntime.SetLogger(log.WithName("controller-runtime"))
+
+	// Kubernetes API servers return HTTP "Warning" headers (e.g. API
+	// deprecations such as v1 Endpoints) that client-go surfaces through a
+	// process-global default warning handler. By default that handler logs via
+	// klog, so warnings inherit whichever component's global klog logger is
+	// active (misattributing them). Own the handler here so warnings are
+	// attributed to a dedicated logger, independent of klog. The embedded
+	// kube-apiserver/kube-controller-manager install their own NoWarnings
+	// handler only from their cobra pre-run, which this binary bypasses, so this
+	// handler is not overridden.
+	rest.SetDefaultWarningHandler(k8sAPIWarningLogger{log: log.WithName("kube-api-warning")})
+
 	cliLog := log.WithName("cli")
 	cliLog.Info("starting tinkerbell",
 		"version", build.GitRevision(),
@@ -264,7 +289,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 		}
 		if embeddedApiserverExecute != nil {
 			if err := retry.Do(func() error {
-				if err := embeddedApiserverExecute(ctx, log.WithName("kube-apiserver")); err != nil {
+				if err := embeddedApiserverExecute(ctx, log); err != nil {
 					return fmt.Errorf("API server error: %w", err)
 				}
 				return nil

--- a/cmd/tinkerbell/logger.go
+++ b/cmd/tinkerbell/logger.go
@@ -20,6 +20,22 @@ func getLogger(level int) logr.Logger {
 	return defaultLogger(level)
 }
 
+// k8sAPIWarningLogger routes client-go API server warning headers (HTTP code
+// 299, e.g. API deprecations) to a logr.Logger. It replaces client-go's default
+// klog-based warning handler so warnings are attributed to a dedicated,
+// identifiable logger instead of whichever component's global klog logger is
+// active.
+type k8sAPIWarningLogger struct {
+	log logr.Logger
+}
+
+func (w k8sAPIWarningLogger) HandleWarningHeader(code int, agent string, message string) {
+	if message == "" {
+		return
+	}
+	w.log.Info(message, "code", code, "agent", agent)
+}
+
 // defaultLogger uses the slog logr implementation.
 func defaultLogger(level int) logr.Logger {
 	// source file and function can be long. This makes the logs less readable.

--- a/rufio/rufio.go
+++ b/rufio/rufio.go
@@ -23,10 +23,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/tinkerbell/tinkerbell/rufio/internal/controller"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	clog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
@@ -105,10 +103,6 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 	if c.Namespace != "" {
 		options.Cache = cache.Options{DefaultNamespaces: map[string]cache.Config{c.Namespace: {}}}
 	}
-
-	controllerruntime.SetLogger(log)
-	clog.SetLogger(log)
-	klog.SetLogger(log)
 
 	mgr, err := controller.NewManager(c.Client, options, c.PowerCheckInterval, c.MaxConcurrentReconciles)
 	if err != nil {

--- a/tink/controller/controller.go
+++ b/tink/controller/controller.go
@@ -12,11 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
-	clog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
@@ -112,10 +110,6 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 	if c.Namespace != "" {
 		options.Cache = cache.Options{DefaultNamespaces: map[string]cache.Config{c.Namespace: {}}}
 	}
-
-	controllerruntime.SetLogger(log)
-	clog.SetLogger(log)
-	klog.SetLogger(log)
 
 	wfOpts := []workflow.Option{}
 	if len(c.ReferenceAllowListRules) > 0 {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Kubernetes client libraries (client-go/klog and controller-runtime) emit some output through process-global loggers rather than a per-instance logger. Multiple components set those globals during startup, so such lines, most visibly the client-go API deprecation warnings for v1 Endpoints, were attributed to whichever component set the global logger last, e.g. "rufio", instead of to their actual source. In the embedded control-plane build this was compounded by the kube-apiserver reconfiguring the global klog logger to its own format after startup, so those warnings stopped using the Tinkerbell logger entirely.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
