### PR TITLE
Add a Kubernetes RuntimeExecutor for tink-agent

### DIFF
--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -76,9 +76,13 @@ func RegisterAllFlags(c *config) *ff.FlagSet {
 	RegisterDockerRuntimeFlags(c, fsd)
 	fsDocker := ff.NewFlagSetFrom("docker runtime", fsd).SetParent(fsContainerd)
 
+	fsk := flag.NewFlagSet("kubernetes runtime", flag.ContinueOnError)
+	RegisterKubernetesRuntimeFlags(c, fsk)
+	fsKubernetes := ff.NewFlagSetFrom("kubernetes runtime", fsk).SetParent(fsDocker)
+
 	fsg := flag.NewFlagSet("grpc transport", flag.ContinueOnError)
 	RegisterGRPCTransportFlags(c, fsg)
-	fsGrpc := ff.NewFlagSetFrom("grpc transport", fsg).SetParent(fsDocker)
+	fsGrpc := ff.NewFlagSetFrom("grpc transport", fsg).SetParent(fsKubernetes)
 
 	fsf := flag.NewFlagSet("file transport", flag.ContinueOnError)
 	RegisterFileTransportFlags(c, fsf)
@@ -98,7 +102,7 @@ func RegisterAllFlags(c *config) *ff.FlagSet {
 func RegisterRootFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.AgentID, "id", "", "ID of the agent")
 	fs.IntVar(&c.LogLevel, "log-level", 0, "Log level")
-	fs.Var(&c.Options.RuntimeSelected, "runtime", fmt.Sprintf("Container runtime used to run Actions, must be one of [%s, %s]", agent.DockerRuntimeType, agent.ContainerdRuntimeType))
+	fs.Var(&c.Options.RuntimeSelected, "runtime", fmt.Sprintf("Container runtime used to run Actions, must be one of [%s, %s, %s]", agent.DockerRuntimeType, agent.ContainerdRuntimeType, agent.KubernetesRuntimeType))
 	fs.Var(&c.Options.TransportSelected, "transport", fmt.Sprintf("Transport used to receive Workflows/Actions and to send results, must be one of [%s, %s, %s]", agent.GRPCTransportType, agent.NATSTransportType, agent.FileTransportType))
 	fs.BoolVar(&c.Options.AttributeDetectionEnabled, "attribute-detection", true, "Enable attribute detection")
 	// This is an implementation detail of github.com/cenkalti/backoff/v5, MaxInterval caps the RetryInterval and not the randomized interval.
@@ -138,4 +142,9 @@ func RegisterContainerdRuntimeFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.Options.Runtime.Containerd.Namespace, "containerd-namespace", "tinkerbell", "Containerd namespace")
 	fs.StringVar(&c.Options.Runtime.Containerd.SocketPath, "containerd-socket", "/run/containerd/containerd.sock", "Containerd socket path")
 	fs.StringVar(&c.Options.Runtime.Containerd.DataRoot, "containerd-data-root", "/var/lib/nerdctl", "Root directory for nerdctl-compatible per-container state (json-file logs read by `nerdctl logs`)")
+}
+
+func RegisterKubernetesRuntimeFlags(c *config, fs *flag.FlagSet) {
+	fs.StringVar(&c.Options.Runtime.Kubernetes.Namespace, "kubernetes-namespace", "tinkerbell", "Namespace Action Jobs are created in")
+	fs.StringVar(&c.Options.Runtime.Kubernetes.Kubeconfig, "kubernetes-kubeconfig", "", "Path to a kubeconfig file; defaults to the in-cluster config")
 }

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -147,4 +147,5 @@ func RegisterContainerdRuntimeFlags(c *config, fs *flag.FlagSet) {
 func RegisterKubernetesRuntimeFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.Options.Runtime.Kubernetes.Namespace, "kubernetes-namespace", "tinkerbell", "Namespace Action Jobs are created in")
 	fs.StringVar(&c.Options.Runtime.Kubernetes.Kubeconfig, "kubernetes-kubeconfig", "", "Path to a kubeconfig file; defaults to the in-cluster config")
+	fs.StringVar(&c.Options.Runtime.Kubernetes.ServiceAccountName, "kubernetes-service-account", "", "ServiceAccount Action Job pods run as; defaults to the namespace's default ServiceAccount. Set this to the Agent's own ServiceAccount to reuse its imagePullSecrets for private images")
 }

--- a/docs/technical/AGENT_KUBERNETES_RUNTIME.md
+++ b/docs/technical/AGENT_KUBERNETES_RUNTIME.md
@@ -27,13 +27,15 @@ RBAC to create/watch `Job`s and `Pod`s and read `Pod` logs in one namespace.
 ```bash
 tink-agent -id=abcd -transport=grpc -grpc-server=tink-server.tinkerbell.svc.cluster.local:42113 \
   -runtime=kubernetes \
-  -kubernetes-namespace=tinkerbell
+  -kubernetes-namespace=tinkerbell \
+  -kubernetes-service-account=tink-agent
 ```
 
 | Flag | Default | Description |
 |---|---|---|
 | `-kubernetes-namespace` | `tinkerbell` | Namespace Action `Job`s are created in. |
 | `-kubernetes-kubeconfig` | *(empty)* | Path to a kubeconfig file. Leave empty to use the in-cluster config — the expected setup when the Agent itself runs as a pod in the cluster it's creating `Job`s in. |
+| `-kubernetes-service-account` | *(empty)* | ServiceAccount the Action `Job`'s pod runs as. Kubernetes does **not** propagate the Agent's own ServiceAccount to objects it creates, so leaving this empty means the `Job` pod runs as the namespace's `default` ServiceAccount, not the Agent's. Set this to the Agent's own ServiceAccount name (e.g. `tink-agent`) to reuse the imagePullSecrets configured on it. |
 
 ## Unsupported Action fields
 
@@ -83,7 +85,10 @@ roleRef:
 ```
 
 Private images are pulled using whatever `imagePullSecrets` are already configured on the
-`tink-agent` ServiceAccount — a one-time, cluster-operator-managed setup:
+`tink-agent` ServiceAccount — but only if `-kubernetes-service-account=tink-agent` is set (see
+[Enabling it](#enabling-it)); otherwise the Job pod runs as the namespace's `default`
+ServiceAccount instead and won't see these secrets. This is a one-time, cluster-operator-managed
+setup:
 
 ```bash
 kubectl create secret docker-registry my-registry-cred \
@@ -128,6 +133,7 @@ spec:
             - -grpc-server=tink-server.tinkerbell.svc.cluster.local:42113
             - -runtime=kubernetes
             - -kubernetes-namespace=tinkerbell
+            - -kubernetes-service-account=tink-agent
 ```
 
 No `privileged`, no `hostNetwork`, no sidecar, no host socket mount — the whole pod is a single,

--- a/docs/technical/AGENT_KUBERNETES_RUNTIME.md
+++ b/docs/technical/AGENT_KUBERNETES_RUNTIME.md
@@ -37,6 +37,14 @@ tink-agent -id=abcd -transport=grpc -grpc-server=tink-server.tinkerbell.svc.clus
 | `-kubernetes-kubeconfig` | *(empty)* | Path to a kubeconfig file. Leave empty to use the in-cluster config — the expected setup when the Agent itself runs as a pod in the cluster it's creating `Job`s in. |
 | `-kubernetes-service-account` | *(empty)* | ServiceAccount the Action `Job`'s pod runs as. Kubernetes does **not** propagate the Agent's own ServiceAccount to objects it creates, so leaving this empty means the `Job` pod runs as the namespace's `default` ServiceAccount, not the Agent's. Set this to the Agent's own ServiceAccount name (e.g. `tink-agent`) to reuse the imagePullSecrets configured on it. |
 
+## Timeouts
+
+An Action's `timeoutSeconds` bounds both the Agent's own wait (as with every other runtime) and,
+independently, the Job's `activeDeadlineSeconds`. The latter is a backstop enforced by the cluster
+itself (kubelet/kube-controller-manager): if the Agent pod is OOM-killed, crashes, or restarts
+mid-Action, the Job would otherwise be orphaned with nothing left to enforce the timeout or clean
+it up.
+
 ## Unsupported Action fields
 
 Because a `Job`'s Pod can land on any node, some Action fields have no safe Kubernetes equivalent

--- a/docs/technical/AGENT_KUBERNETES_RUNTIME.md
+++ b/docs/technical/AGENT_KUBERNETES_RUNTIME.md
@@ -107,7 +107,9 @@ kubectl patch serviceaccount tink-agent -n tinkerbell \
 ```
 
 The `kubernetes` runtime itself never creates or reads Secrets, so no `secrets` RBAC verb is
-needed.
+needed. Action `Job` pods also never get a Kubernetes API token mounted
+(`automountServiceAccountToken: false`), regardless of which ServiceAccount they run as — only the
+Agent itself needs API access.
 
 ## Example Deployment
 

--- a/docs/technical/AGENT_KUBERNETES_RUNTIME.md
+++ b/docs/technical/AGENT_KUBERNETES_RUNTIME.md
@@ -1,0 +1,134 @@
+# Kubernetes `RuntimeExecutor` for `tink-agent`
+
+This document describes the `kubernetes` `RuntimeExecutor`, a way to run `tink-agent` as a
+standing pod inside a Kubernetes cluster that executes Actions as Kubernetes `Job`s instead of
+using a Docker or containerd socket.
+
+## When to use this
+
+`tink-agent` normally runs on the machine being provisioned, using the `docker` or `containerd`
+runtime to execute Actions directly on that hardware (for example `image2disk`, which must run on
+the specific machine it's imaging). The `kubernetes` runtime is **not** a replacement for that: a
+`Job`'s Pod is scheduled by Kubernetes wherever it decides, with no relationship to any particular
+piece of bare metal.
+
+Instead, this runtime is for a different kind of Agent: one that runs as a long-lived pod inside a
+Kubernetes cluster (typically the cluster running the Tink Controller) to execute Actions that
+don't need to touch specific target hardware — for example a Workflow Task, on a standing
+`agentID`, that calls a webhook to notify an external system before or after the actual
+provisioning Tasks run. That standing Agent still needs some way to run Action containers. Giving
+it a Docker or containerd socket means either mounting the host node's socket (root-equivalent
+node access from a pod inside your own cluster) or running Docker-in-Docker as a sidecar
+(`privileged: true` either way). The `kubernetes` runtime avoids both: the Agent's pod only needs
+RBAC to create/watch `Job`s and `Pod`s and read `Pod` logs in one namespace.
+
+## Enabling it
+
+```bash
+tink-agent -id=abcd -transport=grpc -grpc-server=tink-server.tinkerbell.svc.cluster.local:42113 \
+  -runtime=kubernetes \
+  -kubernetes-namespace=tinkerbell
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `-kubernetes-namespace` | `tinkerbell` | Namespace Action `Job`s are created in. |
+| `-kubernetes-kubeconfig` | *(empty)* | Path to a kubeconfig file. Leave empty to use the in-cluster config — the expected setup when the Agent itself runs as a pod in the cluster it's creating `Job`s in. |
+
+## Unsupported Action fields
+
+Because a `Job`'s Pod can land on any node, some Action fields have no safe Kubernetes equivalent
+and are rejected outright (the Action fails fast with a clear error) rather than being silently
+ignored:
+
+- `namespaces.pid` / `namespaces.network` (`hostPID`/`hostNetwork`) — cluster-wide elevated
+  privileges that would defeat the purpose of using this runtime instead of a Docker socket.
+- `volumes` — Docker bind-mount syntax (`/etc/data:/data:ro`) has no faithful Kubernetes
+  equivalent short of `hostPath`.
+
+## RBAC
+
+The Agent only needs namespaced permissions — no `secrets`, no cluster-scoped resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tink-agent-kubernetes-runtime
+  namespace: tinkerbell
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tink-agent-kubernetes-runtime
+  namespace: tinkerbell
+subjects:
+  - kind: ServiceAccount
+    name: tink-agent
+    namespace: tinkerbell
+roleRef:
+  kind: Role
+  name: tink-agent-kubernetes-runtime
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Private images are pulled using whatever `imagePullSecrets` are already configured on the
+`tink-agent` ServiceAccount — a one-time, cluster-operator-managed setup:
+
+```bash
+kubectl create secret docker-registry my-registry-cred \
+  --docker-server=... --docker-username=... --docker-password=... \
+  --namespace tinkerbell
+kubectl patch serviceaccount tink-agent -n tinkerbell \
+  -p '{"imagePullSecrets": [{"name": "my-registry-cred"}]}'
+```
+
+The `kubernetes` runtime itself never creates or reads Secrets, so no `secrets` RBAC verb is
+needed.
+
+## Example Deployment
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tink-agent
+  namespace: tinkerbell
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tink-agent-standalone
+  namespace: tinkerbell
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: tink-agent-standalone}
+  template:
+    metadata:
+      labels: {app: tink-agent-standalone}
+    spec:
+      serviceAccountName: tink-agent
+      containers:
+        - name: tink-agent
+          image: ghcr.io/tinkerbell/tink-agent:latest
+          args:
+            - -id=abcd
+            - -transport=grpc
+            - -grpc-server=tink-server.tinkerbell.svc.cluster.local:42113
+            - -runtime=kubernetes
+            - -kubernetes-namespace=tinkerbell
+```
+
+No `privileged`, no `hostNetwork`, no sidecar, no host socket mount — the whole pod is a single,
+unprivileged container.

--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/attribute"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/runtime/containerd"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/runtime/docker"
+	"github.com/tinkerbell/tinkerbell/tink/agent/internal/runtime/kubernetes"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/transport/file"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/transport/grpc"
@@ -190,6 +191,7 @@ const (
 
 	DockerRuntimeType     RuntimeType = "docker"
 	ContainerdRuntimeType RuntimeType = "containerd"
+	KubernetesRuntimeType RuntimeType = "kubernetes"
 )
 
 type TransportType string
@@ -216,6 +218,7 @@ type Transport struct {
 type Runtime struct {
 	Docker     DockerRuntime
 	Containerd ContainerdRuntime
+	Kubernetes KubernetesRuntime
 }
 
 type Registry struct {
@@ -253,6 +256,10 @@ type ContainerdRuntime struct {
 	Namespace  string
 	SocketPath string
 	DataRoot   string
+}
+type KubernetesRuntime struct {
+	Namespace  string
+	Kubeconfig string
 }
 
 // BackoffOptions holds the configuration for the backoff strategy.
@@ -319,6 +326,13 @@ func (o *Options) ConfigureAndRun(inctx context.Context, log logr.Logger, id str
 
 	var re RuntimeExecutor
 	switch o.RuntimeSelected {
+	case KubernetesRuntimeType:
+		kn, err := kubernetes.NewConfig(log, o.Runtime.Kubernetes.Namespace, o.Runtime.Kubernetes.Kubeconfig)
+		if err != nil {
+			return fmt.Errorf("unable to create Kubernetes config: %w", err)
+		}
+		re = kn
+		log.Info("using Kubernetes runtime")
 	case ContainerdRuntimeType:
 		opts := []containerd.Opt{}
 		if o.Runtime.Containerd.Namespace != "" {
@@ -406,11 +420,11 @@ func (t *TransportType) Type() string {
 
 func (r *RuntimeType) Set(s string) error {
 	switch strings.ToLower(s) {
-	case DockerRuntimeType.String(), ContainerdRuntimeType.String():
+	case DockerRuntimeType.String(), ContainerdRuntimeType.String(), KubernetesRuntimeType.String():
 		*r = RuntimeType(s)
 		return nil
 	default:
-		return fmt.Errorf("invalid Runtime type: %q, must be one of [%s, %s, %s]", s, GRPCTransportType, NATSTransportType, FileTransportType)
+		return fmt.Errorf("invalid Runtime type: %q, must be one of [%s, %s, %s]", s, DockerRuntimeType, ContainerdRuntimeType, KubernetesRuntimeType)
 	}
 }
 

--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -421,7 +421,7 @@ func (t *TransportType) Type() string {
 func (r *RuntimeType) Set(s string) error {
 	switch strings.ToLower(s) {
 	case DockerRuntimeType.String(), ContainerdRuntimeType.String(), KubernetesRuntimeType.String():
-		*r = RuntimeType(s)
+		*r = RuntimeType(strings.ToLower(s))
 		return nil
 	default:
 		return fmt.Errorf("invalid Runtime type: %q, must be one of [%s, %s, %s]", s, DockerRuntimeType, ContainerdRuntimeType, KubernetesRuntimeType)

--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -258,8 +258,9 @@ type ContainerdRuntime struct {
 	DataRoot   string
 }
 type KubernetesRuntime struct {
-	Namespace  string
-	Kubeconfig string
+	Namespace          string
+	Kubeconfig         string
+	ServiceAccountName string
 }
 
 // BackoffOptions holds the configuration for the backoff strategy.
@@ -327,7 +328,8 @@ func (o *Options) ConfigureAndRun(inctx context.Context, log logr.Logger, id str
 	var re RuntimeExecutor
 	switch o.RuntimeSelected {
 	case KubernetesRuntimeType:
-		kn, err := kubernetes.NewConfig(log, o.Runtime.Kubernetes.Namespace, o.Runtime.Kubernetes.Kubeconfig)
+		kn, err := kubernetes.NewConfig(log, o.Runtime.Kubernetes.Namespace, o.Runtime.Kubernetes.Kubeconfig,
+			kubernetes.WithServiceAccountName(o.Runtime.Kubernetes.ServiceAccountName))
 		if err != nil {
 			return fmt.Errorf("unable to create Kubernetes config: %w", err)
 		}

--- a/tink/agent/agent_test.go
+++ b/tink/agent/agent_test.go
@@ -157,3 +157,36 @@ func TestRunHaltsOnPermanentWriteError(t *testing.T) {
 		t.Errorf("expected 2 Write calls, got %d", got)
 	}
 }
+
+func TestRuntimeTypeSet(t *testing.T) {
+	tests := map[string]struct {
+		in      string
+		want    RuntimeType
+		wantErr bool
+	}{
+		"lowercase docker":         {in: "docker", want: DockerRuntimeType},
+		"lowercase containerd":     {in: "containerd", want: ContainerdRuntimeType},
+		"lowercase kubernetes":     {in: "kubernetes", want: KubernetesRuntimeType},
+		"mixed case is normalized": {in: "Kubernetes", want: KubernetesRuntimeType},
+		"unknown value rejected":   {in: "bogus", wantErr: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var r RuntimeType
+			err := r.Set(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r != tt.want {
+				t.Errorf("Set(%q): got %q, want %q", tt.in, r, tt.want)
+			}
+		})
+	}
+}

--- a/tink/agent/internal/runtime/kubernetes/kubernetes.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -193,6 +194,11 @@ func (c *Config) jobFor(a spec.Action) (*batchv1.Job, error) {
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &backoffLimit,
+			// A backstop independent of the Agent's own liveness: if the Agent pod is OOM-killed,
+			// crashes, or restarts mid-Execute, this Job would otherwise be orphaned with nothing
+			// enforcing the Action's timeout or cleaning it up. nil (unset) if the Action has no
+			// timeout, matching the Agent's own ctx-based behavior.
+			ActiveDeadlineSeconds: activeDeadlineSeconds(a),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{actionIDLabel: a.ID},
@@ -214,45 +220,82 @@ func (c *Config) jobFor(a spec.Action) (*batchv1.Job, error) {
 	}, nil
 }
 
+// activeDeadlineSeconds returns nil if the Action has no timeout, so the Job never gets an
+// ActiveDeadlineSeconds it wasn't asked for.
+func activeDeadlineSeconds(a spec.Action) *int64 {
+	if a.TimeoutSeconds <= 0 {
+		return nil
+	}
+	return int64Ptr(int64(a.TimeoutSeconds))
+}
+
+// watchReconnectBackoff bounds how long waitForPod waits before re-listing and re-establishing a
+// watch after one closes for a benign reason, so a persistent connectivity problem can't turn into
+// a tight List/Watch loop hammering the API server.
+const watchReconnectBackoff = time.Second
+
 // waitForPod blocks until the Action's Job Pod reaches a terminal state (a container has
 // terminated, or the Pod itself failed/succeeded without ever reporting a container status, e.g.
-// ImagePullBackOff) and returns it.
+// ImagePullBackOff) and returns it. A watch closing on its own — API server watch timeouts,
+// resourceVersion expiry, and transient network interruptions all do this routinely — is not
+// treated as fatal: waitForPod re-lists and re-establishes the watch instead, so a long-running
+// Action can't fail spuriously just because its watch aged out.
 func (c *Config) waitForPod(ctx context.Context, actionID string) (*corev1.Pod, error) {
 	pods := c.Client.CoreV1().Pods(c.Namespace)
 	selector := fmt.Sprintf("%s=%s", actionIDLabel, actionID)
 
-	// Check first in case the Pod already reached a terminal state before the watch below is
-	// established (e.g. a very fast-exiting container).
-	list, err := pods.List(ctx, metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		return nil, fmt.Errorf("kubernetes: listing pods: %w", err)
-	}
-	for i := range list.Items {
-		if podTerminated(&list.Items[i]) {
-			return &list.Items[i], nil
+	for {
+		// Check first in case the Pod already reached a terminal state before the watch below is
+		// (re-)established (e.g. a very fast-exiting container).
+		list, err := pods.List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return nil, fmt.Errorf("kubernetes: listing pods: %w", err)
+		}
+		for i := range list.Items {
+			if podTerminated(&list.Items[i]) {
+				return &list.Items[i], nil
+			}
+		}
+
+		pod, closed, err := c.watchForTerminatedPod(ctx, pods, selector, list.ResourceVersion)
+		if err != nil {
+			return nil, err
+		}
+		if !closed {
+			return pod, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(watchReconnectBackoff):
 		}
 	}
+}
 
-	w, err := pods.Watch(ctx, metav1.ListOptions{LabelSelector: selector, ResourceVersion: list.ResourceVersion})
+// watchForTerminatedPod watches until the Action's Pod terminates or the watch itself closes.
+// closed is true only in the latter case, in which case pod and err are both nil.
+func (c *Config) watchForTerminatedPod(ctx context.Context, pods corev1client.PodInterface, selector, resourceVersion string) (pod *corev1.Pod, closed bool, err error) {
+	w, err := pods.Watch(ctx, metav1.ListOptions{LabelSelector: selector, ResourceVersion: resourceVersion})
 	if err != nil {
-		return nil, fmt.Errorf("kubernetes: watching pods: %w", err)
+		return nil, false, fmt.Errorf("kubernetes: watching pods: %w", err)
 	}
 	defer w.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, false, ctx.Err()
 		case event, ok := <-w.ResultChan():
 			if !ok {
-				return nil, fmt.Errorf("kubernetes: watch closed before pod for action %s terminated", actionID)
+				return nil, true, nil
 			}
 			pod, ok := event.Object.(*corev1.Pod)
 			if !ok {
 				continue
 			}
 			if podTerminated(pod) {
-				return pod, nil
+				return pod, false, nil
 			}
 		}
 	}
@@ -330,6 +373,8 @@ func convEnv(envs []spec.Env) []corev1.EnvVar {
 }
 
 func boolPtr(v bool) *bool { return &v }
+
+func int64Ptr(v int64) *int64 { return &v }
 
 var invalidJobNameChars = regexp.MustCompile(`[^a-z0-9-]`)
 

--- a/tink/agent/internal/runtime/kubernetes/kubernetes.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes.go
@@ -50,6 +50,13 @@ type Config struct {
 	Log       logr.Logger
 	Client    kubernetes.Interface // interface, not *kubernetes.Clientset, so it can be faked in tests
 	Namespace string               // fixed namespace Jobs/Pods are created in
+	// ServiceAccountName is the ServiceAccount Job Pods run as. Kubernetes does not propagate the
+	// identity of the caller that creates an object to that object, so leaving this empty does NOT
+	// mean the Job inherits the Agent's own ServiceAccount: it means the Job Pod runs as the
+	// namespace's "default" ServiceAccount instead, which may not carry the imagePullSecrets a
+	// private image needs. Set this to the Agent's own ServiceAccount name to reuse its
+	// imagePullSecrets.
+	ServiceAccountName string
 }
 
 // Opt configures a Config returned by NewConfig.
@@ -58,6 +65,11 @@ type Opt func(*Config)
 // WithClient overrides the Kubernetes client used, for example with a fake clientset in tests.
 func WithClient(c kubernetes.Interface) Opt {
 	return func(cfg *Config) { cfg.Client = c }
+}
+
+// WithServiceAccountName sets the ServiceAccount Job Pods run as. See Config.ServiceAccountName.
+func WithServiceAccountName(name string) Opt {
+	return func(cfg *Config) { cfg.ServiceAccountName = name }
 }
 
 // NewConfig builds a Config. If kubeconfig is empty, it uses the in-cluster config, which is the
@@ -186,10 +198,13 @@ func (c *Config) jobFor(a spec.Action) (*batchv1.Job, error) {
 					Labels: map[string]string{actionIDLabel: a.ID},
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
-					Containers:    []corev1.Container{container},
-					// No ServiceAccountName override: inherits the executing Agent pod's own
-					// ServiceAccount, including whatever imagePullSecrets it already carries.
+					RestartPolicy:      corev1.RestartPolicyNever,
+					Containers:         []corev1.Container{container},
+					ServiceAccountName: c.ServiceAccountName,
+					// Action containers never need Kubernetes API access themselves (only the
+					// Agent does), so don't hand them an API token regardless of which
+					// ServiceAccount they run as.
+					AutomountServiceAccountToken: boolPtr(false),
 					// No SecurityContext/Privileged: deliberately the Kubernetes default
 					// (unprivileged), unlike docker.go/containerd.go which both set Privileged
 					// unconditionally for the bare-metal case this runtime isn't used for.
@@ -313,6 +328,8 @@ func convEnv(envs []spec.Env) []corev1.EnvVar {
 	}
 	return out
 }
+
+func boolPtr(v bool) *bool { return &v }
 
 var invalidJobNameChars = regexp.MustCompile(`[^a-z0-9-]`)
 

--- a/tink/agent/internal/runtime/kubernetes/kubernetes.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes.go
@@ -1,0 +1,304 @@
+// Package kubernetes implements a tink-agent RuntimeExecutor that runs Actions as Kubernetes
+// Jobs via the Kubernetes API instead of a local Docker/containerd socket. It is intended for a
+// standing Agent running as a pod inside a Kubernetes cluster, not for the bare-metal
+// CaptainOS/HookOS provisioning path.
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	actionIDLabel = "tinkerbell.org/action-id"
+	// actionContainerName is the name given to the Action's container in jobFor. podTerminated
+	// and exitError match on this name specifically so an unrelated sidecar container injected
+	// by a mutating admission webhook (Istio, Linkerd, Vault Agent Injector, etc.) can never be
+	// mistaken for the Action's own outcome.
+	actionContainerName = "action"
+	// logStreamTimeout bounds how long streamLogs may block fetching a terminated Pod's logs.
+	// It intentionally does not reuse Execute's ctx: logs are worth fetching even if the Action's
+	// own timeout already fired, but the fetch itself must still be bounded, or a stalled kubelet
+	// log endpoint would hang Execute (and therefore the single-threaded agent.Config.Run loop)
+	// forever.
+	logStreamTimeout = 30 * time.Second
+)
+
+// Config is a RuntimeExecutor that runs Actions as Kubernetes Jobs.
+type Config struct {
+	Log       logr.Logger
+	Client    kubernetes.Interface // interface, not *kubernetes.Clientset, so it can be faked in tests
+	Namespace string               // fixed namespace Jobs/Pods are created in
+}
+
+// Opt configures a Config returned by NewConfig.
+type Opt func(*Config)
+
+// WithClient overrides the Kubernetes client used, for example with a fake clientset in tests.
+func WithClient(c kubernetes.Interface) Opt {
+	return func(cfg *Config) { cfg.Client = c }
+}
+
+// NewConfig builds a Config. If kubeconfig is empty, it uses the in-cluster config, which is the
+// expected deployment (the Agent running as a pod in the cluster it's creating Jobs in).
+func NewConfig(log logr.Logger, namespace, kubeconfig string, opts ...Opt) (*Config, error) {
+	cfg := &Config{Log: log, Namespace: namespace}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.Client != nil {
+		return cfg, nil
+	}
+
+	restCfg, err := restConfig(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes: %w", err)
+	}
+	cfg.Client = client
+
+	return cfg, nil
+}
+
+func restConfig(kubeconfig string) (*rest.Config, error) {
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	return rest.InClusterConfig()
+}
+
+// Execute creates a Job for the Action, waits for its Pod to terminate, streams the Pod's logs,
+// and returns nil on a zero exit code or a descriptive error otherwise. The Job (and its Pod) are
+// always deleted before Execute returns.
+func (c *Config) Execute(ctx context.Context, a spec.Action) error {
+	job, err := c.jobFor(a)
+	if err != nil {
+		return err
+	}
+
+	jobs := c.Client.BatchV1().Jobs(c.Namespace)
+	created, err := jobs.Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("kubernetes: creating job: %w", err)
+	}
+
+	defer func() {
+		// Always clean up, regardless of outcome. Use a background context since ctx may
+		// already be cancelled/expired, and foreground propagation so the Pod is gone too.
+		policy := metav1.DeletePropagationForeground
+		if err := jobs.Delete(context.Background(), created.Name, metav1.DeleteOptions{PropagationPolicy: &policy}); err != nil {
+			c.Log.Info("failed to delete job", "job", created.Name, "error", err)
+		}
+	}()
+
+	pod, err := c.waitForPod(ctx, a.ID)
+	if err != nil {
+		return err
+	}
+
+	c.streamLogs(pod.Name)
+
+	return exitError(pod)
+}
+
+// jobFor builds the Kubernetes Job for an Action. It fails fast on Action fields that have no
+// safe Kubernetes equivalent rather than silently ignoring them.
+func (c *Config) jobFor(a spec.Action) (*batchv1.Job, error) {
+	if a.Namespaces.PID != "" || a.Namespaces.Network != "" {
+		return nil, fmt.Errorf("kubernetes runtime: host PID/network namespaces are not supported")
+	}
+	if len(a.Volumes) > 0 {
+		return nil, fmt.Errorf("kubernetes runtime: volumes are not supported")
+	}
+
+	backoffLimit := int32(0) // retries are handled by (*agent.Config).Run, not the Job
+
+	container := corev1.Container{
+		Name:  actionContainerName,
+		Image: a.Image,
+		Env:   convEnv(a.Env),
+	}
+	if a.Cmd != "" {
+		container.Command = []string{a.Cmd}
+	}
+	if len(a.Args) > 0 {
+		container.Args = a.Args
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName(a.ID, a.Name),
+			Namespace: c.Namespace,
+			Labels:    map[string]string{actionIDLabel: a.ID},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{actionIDLabel: a.ID},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers:    []corev1.Container{container},
+					// No ServiceAccountName override: inherits the executing Agent pod's own
+					// ServiceAccount, including whatever imagePullSecrets it already carries.
+					// No SecurityContext/Privileged: deliberately the Kubernetes default
+					// (unprivileged), unlike docker.go/containerd.go which both set Privileged
+					// unconditionally for the bare-metal case this runtime isn't used for.
+				},
+			},
+		},
+	}, nil
+}
+
+// waitForPod blocks until the Action's Job Pod reaches a terminal state (a container has
+// terminated, or the Pod itself failed/succeeded without ever reporting a container status, e.g.
+// ImagePullBackOff) and returns it.
+func (c *Config) waitForPod(ctx context.Context, actionID string) (*corev1.Pod, error) {
+	pods := c.Client.CoreV1().Pods(c.Namespace)
+	selector := fmt.Sprintf("%s=%s", actionIDLabel, actionID)
+
+	// Check first in case the Pod already reached a terminal state before the watch below is
+	// established (e.g. a very fast-exiting container).
+	list, err := pods.List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes: listing pods: %w", err)
+	}
+	for i := range list.Items {
+		if podTerminated(&list.Items[i]) {
+			return &list.Items[i], nil
+		}
+	}
+
+	w, err := pods.Watch(ctx, metav1.ListOptions{LabelSelector: selector, ResourceVersion: list.ResourceVersion})
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes: watching pods: %w", err)
+	}
+	defer w.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return nil, fmt.Errorf("kubernetes: watch closed before pod for action %s terminated", actionID)
+			}
+			pod, ok := event.Object.(*corev1.Pod)
+			if !ok {
+				continue
+			}
+			if podTerminated(pod) {
+				return pod, nil
+			}
+		}
+	}
+}
+
+func podTerminated(pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+		return true
+	}
+	return actionContainerStatus(pod).Terminated != nil
+}
+
+// exitError returns nil if the Action container exited 0, and a descriptive error otherwise. This
+// is the fix over tinklet's kube.go, whose wait condition returns success as soon as a container
+// has any terminated state without ever inspecting the exit code.
+func exitError(pod *corev1.Pod) error {
+	if t := actionContainerStatus(pod).Terminated; t != nil {
+		if t.ExitCode == 0 {
+			return nil
+		}
+		return fmt.Errorf("kubernetes: container exited %d: %s", t.ExitCode, t.Reason)
+	}
+	return fmt.Errorf("kubernetes: pod %s ended in phase %s with no terminated container status", pod.Name, pod.Status.Phase)
+}
+
+// actionContainerStatus returns the status of the Action's own container, identified by name, so
+// an unrelated sidecar container (e.g. injected by a mesh/vault mutating webhook) is never
+// mistaken for the Action's outcome. It returns the zero value if the container isn't found yet.
+func actionContainerStatus(pod *corev1.Pod) corev1.ContainerState {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == actionContainerName {
+			return cs.State
+		}
+	}
+	return corev1.ContainerState{}
+}
+
+// streamLogs is best-effort: it's read after the Pod has already terminated and the Job/Pod are
+// about to be deleted, so failures here shouldn't affect the Action's outcome. It deliberately
+// uses its own bounded timeout rather than Execute's ctx (which may already be done) or an
+// unbounded context.Background() (which could hang Execute, and therefore the single-threaded
+// agent.Config.Run loop, forever if the log endpoint stalls).
+func (c *Config) streamLogs(podName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), logStreamTimeout)
+	defer cancel()
+
+	rc, err := c.Client.CoreV1().Pods(c.Namespace).GetLogs(podName, &corev1.PodLogOptions{}).Stream(ctx)
+	if err != nil {
+		c.Log.Info("failed to fetch pod logs", "pod", podName, "error", err)
+		return
+	}
+	defer rc.Close()
+
+	buf := make([]byte, 4096)
+	for {
+		n, err := rc.Read(buf)
+		if n > 0 {
+			c.Log.Info(string(buf[:n]), "pod", podName)
+		}
+		if err != nil {
+			if err != io.EOF {
+				c.Log.Error(err, "error reading pod logs", "pod", podName)
+			}
+			return
+		}
+	}
+}
+
+func convEnv(envs []spec.Env) []corev1.EnvVar {
+	var out []corev1.EnvVar
+	for _, e := range envs {
+		out = append(out, corev1.EnvVar{Name: e.Key, Value: e.Value})
+	}
+	return out
+}
+
+var invalidJobNameChars = regexp.MustCompile(`[^a-z0-9-]`)
+
+// jobName builds a DNS-1123 compliant Job name from an Action's ID and name. Truncation can
+// produce name collisions across Actions, but that's cosmetic, not a correctness issue: Execute
+// finds a Job's Pod back via the action-id label, not the name.
+func jobName(actionID, name string) string {
+	const maxLen = 63
+
+	base := strings.ToLower(fmt.Sprintf("tinkerbell-%s-%s", name, actionID))
+	base = invalidJobNameChars.ReplaceAllString(base, "-")
+	base = strings.Trim(base, "-")
+	if len(base) > maxLen {
+		base = strings.Trim(base[:maxLen], "-")
+	}
+	if base == "" {
+		base = "tinkerbell-action"
+	}
+
+	return base
+}

--- a/tink/agent/internal/runtime/kubernetes/kubernetes.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes.go
@@ -16,8 +16,11 @@ import (
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -35,6 +38,11 @@ const (
 	// log endpoint would hang Execute (and therefore the single-threaded agent.Config.Run loop)
 	// forever.
 	logStreamTimeout = 30 * time.Second
+	// jobDeleteTimeout bounds how long the deferred cleanup in Execute waits for a deleted Job to
+	// actually disappear (foreground-propagation Delete only marks it for deletion; the garbage
+	// collector removes it asynchronously). Like logStreamTimeout, it uses its own bounded context
+	// rather than Execute's ctx, which may already be cancelled/expired by this point.
+	jobDeleteTimeout = 30 * time.Second
 )
 
 // Config is a RuntimeExecutor that runs Actions as Kubernetes Jobs.
@@ -85,7 +93,8 @@ func restConfig(kubeconfig string) (*rest.Config, error) {
 
 // Execute creates a Job for the Action, waits for its Pod to terminate, streams the Pod's logs,
 // and returns nil on a zero exit code or a descriptive error otherwise. The Job (and its Pod) are
-// always deleted before Execute returns.
+// always deleted, and confirmed gone, before Execute returns, so a retried Action (same ID, same
+// deterministic Job name) never races its own predecessor's still-terminating Job.
 func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	job, err := c.jobFor(a)
 	if err != nil {
@@ -100,11 +109,10 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 
 	defer func() {
 		// Always clean up, regardless of outcome. Use a background context since ctx may
-		// already be cancelled/expired, and foreground propagation so the Pod is gone too.
-		policy := metav1.DeletePropagationForeground
-		if err := jobs.Delete(context.Background(), created.Name, metav1.DeleteOptions{PropagationPolicy: &policy}); err != nil {
-			c.Log.Info("failed to delete job", "job", created.Name, "error", err)
-		}
+		// already be cancelled/expired.
+		delCtx, cancel := context.WithTimeout(context.Background(), jobDeleteTimeout)
+		defer cancel()
+		c.deleteJob(delCtx, jobs, created.Name)
 	}()
 
 	pod, err := c.waitForPod(ctx, a.ID)
@@ -115,6 +123,30 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	c.streamLogs(pod.Name)
 
 	return exitError(pod)
+}
+
+// deleteJob issues a foreground-propagation delete and then waits for the Job to actually
+// disappear (foreground propagation only marks it for deletion; the garbage collector removes it
+// asynchronously), so the caller can rely on the Job name being free again once this returns.
+// Errors are logged, not returned: cleanup is best-effort and must never fail an Action that
+// otherwise already succeeded or failed on its own terms.
+func (c *Config) deleteJob(ctx context.Context, jobs batchv1client.JobInterface, name string) {
+	policy := metav1.DeletePropagationForeground
+	if err := jobs.Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &policy}); err != nil && !apierrors.IsNotFound(err) {
+		c.Log.Info("failed to delete job", "job", name, "error", err)
+		return
+	}
+
+	err := wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		_, err := jobs.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		c.Log.Info("timed out waiting for job deletion to complete", "job", name, "error", err)
+	}
 }
 
 // jobFor builds the Kubernetes Job for an Action. It fails fast on Action fields that have no
@@ -252,7 +284,7 @@ func (c *Config) streamLogs(podName string) {
 	ctx, cancel := context.WithTimeout(context.Background(), logStreamTimeout)
 	defer cancel()
 
-	rc, err := c.Client.CoreV1().Pods(c.Namespace).GetLogs(podName, &corev1.PodLogOptions{}).Stream(ctx)
+	rc, err := c.Client.CoreV1().Pods(c.Namespace).GetLogs(podName, &corev1.PodLogOptions{Container: actionContainerName}).Stream(ctx)
 	if err != nil {
 		c.Log.Info("failed to fetch pod logs", "pod", podName, "error", err)
 		return

--- a/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
@@ -101,6 +102,28 @@ func TestJobFor(t *testing.T) {
 						Spec: corev1.PodSpec{
 							RestartPolicy:                corev1.RestartPolicyNever,
 							ServiceAccountName:           "tink-agent",
+							AutomountServiceAccountToken: boolPtr(false),
+							Containers:                   []corev1.Container{{Name: "action", Image: "img"}},
+						},
+					},
+				},
+			},
+		},
+		"timeout sets ActiveDeadlineSeconds on the job": {
+			action: spec.Action{ID: "id7", Name: "n7", Image: "img", TimeoutSeconds: 90},
+			want: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tinkerbell-n7-id7",
+					Namespace: "tinkerbell",
+					Labels:    map[string]string{actionIDLabel: "id7"},
+				},
+				Spec: batchv1.JobSpec{
+					BackoffLimit:          int32Ptr(0),
+					ActiveDeadlineSeconds: int64Ptr(90),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{actionIDLabel: "id7"}},
+						Spec: corev1.PodSpec{
+							RestartPolicy:                corev1.RestartPolicyNever,
 							AutomountServiceAccountToken: boolPtr(false),
 							Containers:                   []corev1.Container{{Name: "action", Image: "img"}},
 						},
@@ -235,6 +258,42 @@ func TestExecute_ContextCancelled(t *testing.T) {
 	}
 	if len(jobs.Items) != 0 {
 		t.Fatalf("expected job to be deleted, found %d", len(jobs.Items))
+	}
+}
+
+// TestWaitForPod_ReconnectsAfterWatchCloses verifies that a watch closing for a benign reason
+// (API server watch timeout, resourceVersion expiry, transient network blip) is not treated as a
+// fatal error: waitForPod must re-list and re-establish the watch instead of failing a
+// long-running Action just because its watch aged out.
+func TestWaitForPod_ReconnectsAfterWatchCloses(t *testing.T) {
+	runningPod := podWithContainerState("action-7", "tinkerbell", corev1.PodRunning, nil)
+	terminatedPod := podWithContainerState("action-7", "tinkerbell", corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0})
+
+	client := fake.NewSimpleClientset(runningPod)
+
+	var watches atomic.Int32
+	client.PrependWatchReactor("pods", func(_ clienttesting.Action) (bool, watch.Interface, error) {
+		fw := watch.NewFake()
+		if watches.Add(1) == 1 {
+			// First watch: close immediately, simulating a benign disconnect.
+			fw.Stop()
+			return true, fw, nil
+		}
+		// Second watch: deliver the terminated pod.
+		go fw.Modify(terminatedPod)
+		return true, fw, nil
+	})
+
+	c := &Config{Log: logr.Discard(), Client: client, Namespace: "tinkerbell"}
+	got, err := c.waitForPod(context.Background(), "action-7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !podTerminated(got) {
+		t.Fatalf("expected a terminated pod, got %+v", got)
+	}
+	if n := watches.Load(); n < 2 {
+		t.Fatalf("expected waitForPod to reconnect after the first watch closed, got %d watch call(s)", n)
 	}
 }
 

--- a/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
@@ -179,10 +179,10 @@ func TestExecute(t *testing.T) {
 		wantErr bool
 	}{
 		"success": {
-			pod: podWithContainerState("action-1", "tinkerbell", corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0}),
+			pod: podWithContainerState("action-1", corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0}),
 		},
 		"non-zero exit code": {
-			pod:     podWithContainerState("action-2", "tinkerbell", corev1.PodFailed, &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}),
+			pod:     podWithContainerState("action-2", corev1.PodFailed, &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}),
 			wantErr: true,
 		},
 		"failed with no container status": {
@@ -197,13 +197,13 @@ func TestExecute(t *testing.T) {
 			wantErr: true,
 		},
 		"success despite a terminated sidecar container listed first": {
-			pod: podWithContainers("action-5", "tinkerbell", corev1.PodSucceeded,
+			pod: podWithContainers("action-5", corev1.PodSucceeded,
 				corev1.ContainerStatus{Name: "istio-proxy", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
 				corev1.ContainerStatus{Name: actionContainerName, State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
 			),
 		},
 		"failure from the action container despite a healthy sidecar listed first": {
-			pod: podWithContainers("action-6", "tinkerbell", corev1.PodFailed,
+			pod: podWithContainers("action-6", corev1.PodFailed,
 				corev1.ContainerStatus{Name: "istio-proxy", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
 				corev1.ContainerStatus{Name: actionContainerName, State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
 			),
@@ -266,8 +266,8 @@ func TestExecute_ContextCancelled(t *testing.T) {
 // fatal error: waitForPod must re-list and re-establish the watch instead of failing a
 // long-running Action just because its watch aged out.
 func TestWaitForPod_ReconnectsAfterWatchCloses(t *testing.T) {
-	runningPod := podWithContainerState("action-7", "tinkerbell", corev1.PodRunning, nil)
-	terminatedPod := podWithContainerState("action-7", "tinkerbell", corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0})
+	runningPod := podWithContainerState("action-7", corev1.PodRunning, nil)
+	terminatedPod := podWithContainerState("action-7", corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0})
 
 	client := fake.NewSimpleClientset(runningPod)
 
@@ -331,17 +331,17 @@ func TestDeleteJob(t *testing.T) {
 	}
 }
 
-func podWithContainerState(actionID, namespace string, phase corev1.PodPhase, terminated *corev1.ContainerStateTerminated) *corev1.Pod {
-	return podWithContainers(actionID, namespace, phase,
+func podWithContainerState(actionID string, phase corev1.PodPhase, terminated *corev1.ContainerStateTerminated) *corev1.Pod {
+	return podWithContainers(actionID, phase,
 		corev1.ContainerStatus{Name: actionContainerName, State: corev1.ContainerState{Terminated: terminated}},
 	)
 }
 
-func podWithContainers(actionID, namespace string, phase corev1.PodPhase, statuses ...corev1.ContainerStatus) *corev1.Pod {
+func podWithContainers(actionID string, phase corev1.PodPhase, statuses ...corev1.ContainerStatus) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod-" + actionID,
-			Namespace: namespace,
+			Namespace: "tinkerbell",
 			Labels:    map[string]string{actionIDLabel: actionID},
 		},
 		Status: corev1.PodStatus{

--- a/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
@@ -3,15 +3,20 @@ package kubernetes
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 )
 
 func TestJobFor(t *testing.T) {
@@ -204,6 +209,40 @@ func TestExecute_ContextCancelled(t *testing.T) {
 	}
 	if len(jobs.Items) != 0 {
 		t.Fatalf("expected job to be deleted, found %d", len(jobs.Items))
+	}
+}
+
+// TestDeleteJob verifies that deleteJob blocks until the Job actually disappears rather than
+// returning as soon as the Delete call is acknowledged (foreground-propagation Delete only marks
+// the Job for deletion; the garbage collector removes it asynchronously). Without this, a retried
+// Action reusing the same deterministic Job name could race its own predecessor's still-terminating
+// Job with an AlreadyExists error.
+func TestDeleteJob(t *testing.T) {
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: "tinkerbell"}}
+	client := fake.NewSimpleClientset(job)
+
+	var gets atomic.Int32
+	client.PrependReactor("get", "jobs", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		if gets.Add(1) == 1 {
+			// First poll: still exists, so deleteJob must keep waiting.
+			return true, job, nil
+		}
+		return true, nil, apierrors.NewNotFound(batchv1.Resource("jobs"), "j1")
+	})
+
+	c := &Config{Log: logr.Discard()}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	c.deleteJob(ctx, client.BatchV1().Jobs("tinkerbell"), "j1")
+	elapsed := time.Since(start)
+
+	if gets.Load() < 2 {
+		t.Fatalf("expected deleteJob to poll Get at least twice, got %d", gets.Load())
+	}
+	if elapsed < 400*time.Millisecond {
+		t.Fatalf("deleteJob returned after %v, expected it to wait for the poll interval before the job disappeared", elapsed)
 	}
 }
 

--- a/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
@@ -1,0 +1,230 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestJobFor(t *testing.T) {
+	tests := map[string]struct {
+		action  spec.Action
+		want    *batchv1.Job
+		wantErr bool
+	}{
+		"basic": {
+			action: spec.Action{
+				ID:    "abc-123",
+				Name:  "my-action",
+				Image: "example.com/image:v1",
+				Cmd:   "/bin/sh",
+				Args:  []string{"-c", "echo hi"},
+				Env:   []spec.Env{{Key: "FOO", Value: "bar"}},
+			},
+			want: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tinkerbell-my-action-abc-123",
+					Namespace: "tinkerbell",
+					Labels:    map[string]string{actionIDLabel: "abc-123"},
+				},
+				Spec: batchv1.JobSpec{
+					BackoffLimit: int32Ptr(0),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{actionIDLabel: "abc-123"},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers: []corev1.Container{
+								{
+									Name:    "action",
+									Image:   "example.com/image:v1",
+									Command: []string{"/bin/sh"},
+									Args:    []string{"-c", "echo hi"},
+									Env:     []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"no cmd or args": {
+			action: spec.Action{ID: "id2", Name: "n2", Image: "img"},
+			want: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tinkerbell-n2-id2",
+					Namespace: "tinkerbell",
+					Labels:    map[string]string{actionIDLabel: "id2"},
+				},
+				Spec: batchv1.JobSpec{
+					BackoffLimit: int32Ptr(0),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{actionIDLabel: "id2"}},
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers:    []corev1.Container{{Name: "action", Image: "img"}},
+						},
+					},
+				},
+			},
+		},
+		"host pid namespace rejected": {
+			action:  spec.Action{ID: "id3", Namespaces: spec.Namespaces{PID: "host"}},
+			wantErr: true,
+		},
+		"host network namespace rejected": {
+			action:  spec.Action{ID: "id4", Namespaces: spec.Namespaces{Network: "host"}},
+			wantErr: true,
+		},
+		"volumes rejected": {
+			action:  spec.Action{ID: "id5", Volumes: []spec.Volume{"/etc/data:/data:ro"}},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Config{Namespace: "tinkerbell"}
+			got, err := c.jobFor(tt.action)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("unexpected job (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestJobNameTruncation(t *testing.T) {
+	longName := "this-is-a-very-long-action-name-that-well-exceeds-the-limit-imposed-by-kubernetes"
+	name := jobName("some-id", longName)
+	if len(name) > 63 {
+		t.Fatalf("job name %q exceeds 63 chars: %d", name, len(name))
+	}
+}
+
+func TestExecute(t *testing.T) {
+	tests := map[string]struct {
+		pod     *corev1.Pod
+		wantErr bool
+	}{
+		"success": {
+			pod: podWithContainerState("action-1", "tinkerbell", corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0}),
+		},
+		"non-zero exit code": {
+			pod:     podWithContainerState("action-2", "tinkerbell", corev1.PodFailed, &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}),
+			wantErr: true,
+		},
+		"failed with no container status": {
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-action-3",
+					Namespace: "tinkerbell",
+					Labels:    map[string]string{actionIDLabel: "action-3"},
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodFailed},
+			},
+			wantErr: true,
+		},
+		"success despite a terminated sidecar container listed first": {
+			pod: podWithContainers("action-5", "tinkerbell", corev1.PodSucceeded,
+				corev1.ContainerStatus{Name: "istio-proxy", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
+				corev1.ContainerStatus{Name: actionContainerName, State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
+			),
+		},
+		"failure from the action container despite a healthy sidecar listed first": {
+			pod: podWithContainers("action-6", "tinkerbell", corev1.PodFailed,
+				corev1.ContainerStatus{Name: "istio-proxy", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
+				corev1.ContainerStatus{Name: actionContainerName, State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
+			),
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			actionID := tt.pod.Labels[actionIDLabel]
+			client := fake.NewSimpleClientset(tt.pod)
+			c := &Config{Log: logr.Discard(), Client: client, Namespace: "tinkerbell"}
+
+			err := c.Execute(context.Background(), spec.Action{ID: actionID, Name: "n", Image: "img"})
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// The Job must be cleaned up regardless of outcome.
+			jobs, jerr := client.BatchV1().Jobs("tinkerbell").List(context.Background(), metav1.ListOptions{})
+			if jerr != nil {
+				t.Fatalf("listing jobs: %v", jerr)
+			}
+			if len(jobs.Items) != 0 {
+				t.Fatalf("expected job to be deleted, found %d", len(jobs.Items))
+			}
+		})
+	}
+}
+
+func TestExecute_ContextCancelled(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	c := &Config{Log: logr.Discard(), Client: client, Namespace: "tinkerbell"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.Execute(ctx, spec.Action{ID: "action-4", Name: "n", Image: "img"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	jobs, jerr := client.BatchV1().Jobs("tinkerbell").List(context.Background(), metav1.ListOptions{})
+	if jerr != nil {
+		t.Fatalf("listing jobs: %v", jerr)
+	}
+	if len(jobs.Items) != 0 {
+		t.Fatalf("expected job to be deleted, found %d", len(jobs.Items))
+	}
+}
+
+func podWithContainerState(actionID, namespace string, phase corev1.PodPhase, terminated *corev1.ContainerStateTerminated) *corev1.Pod {
+	return podWithContainers(actionID, namespace, phase,
+		corev1.ContainerStatus{Name: actionContainerName, State: corev1.ContainerState{Terminated: terminated}},
+	)
+}
+
+func podWithContainers(actionID, namespace string, phase corev1.PodPhase, statuses ...corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-" + actionID,
+			Namespace: namespace,
+			Labels:    map[string]string{actionIDLabel: actionID},
+		},
+		Status: corev1.PodStatus{
+			Phase:             phase,
+			ContainerStatuses: statuses,
+		},
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }

--- a/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
@@ -21,9 +21,10 @@ import (
 
 func TestJobFor(t *testing.T) {
 	tests := map[string]struct {
-		action  spec.Action
-		want    *batchv1.Job
-		wantErr bool
+		action             spec.Action
+		serviceAccountName string
+		want               *batchv1.Job
+		wantErr            bool
 	}{
 		"basic": {
 			action: spec.Action{
@@ -47,7 +48,8 @@ func TestJobFor(t *testing.T) {
 							Labels: map[string]string{actionIDLabel: "abc-123"},
 						},
 						Spec: corev1.PodSpec{
-							RestartPolicy: corev1.RestartPolicyNever,
+							RestartPolicy:                corev1.RestartPolicyNever,
+							AutomountServiceAccountToken: boolPtr(false),
 							Containers: []corev1.Container{
 								{
 									Name:    "action",
@@ -75,8 +77,32 @@ func TestJobFor(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{actionIDLabel: "id2"}},
 						Spec: corev1.PodSpec{
-							RestartPolicy: corev1.RestartPolicyNever,
-							Containers:    []corev1.Container{{Name: "action", Image: "img"}},
+							RestartPolicy:                corev1.RestartPolicyNever,
+							AutomountServiceAccountToken: boolPtr(false),
+							Containers:                   []corev1.Container{{Name: "action", Image: "img"}},
+						},
+					},
+				},
+			},
+		},
+		"explicit service account name is set on the pod": {
+			action:             spec.Action{ID: "id6", Name: "n6", Image: "img"},
+			serviceAccountName: "tink-agent",
+			want: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tinkerbell-n6-id6",
+					Namespace: "tinkerbell",
+					Labels:    map[string]string{actionIDLabel: "id6"},
+				},
+				Spec: batchv1.JobSpec{
+					BackoffLimit: int32Ptr(0),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{actionIDLabel: "id6"}},
+						Spec: corev1.PodSpec{
+							RestartPolicy:                corev1.RestartPolicyNever,
+							ServiceAccountName:           "tink-agent",
+							AutomountServiceAccountToken: boolPtr(false),
+							Containers:                   []corev1.Container{{Name: "action", Image: "img"}},
 						},
 					},
 				},
@@ -98,7 +124,7 @@ func TestJobFor(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := &Config{Namespace: "tinkerbell"}
+			c := &Config{Namespace: "tinkerbell", ServiceAccountName: tt.serviceAccountName}
 			got, err := c.jobFor(tt.action)
 			if tt.wantErr {
 				if err == nil {


### PR DESCRIPTION
Follow-up to the discussion on #847: a Kubernetes-native `RuntimeExecutor` for the standing
`agentID: "abcd"`-style Agent so it doesn't need a privileged Docker socket mount or a
Docker-in-Docker sidecar just to run Action containers.

## Summary
- Adds a third `RuntimeExecutor` to `tink-agent`, `kubernetes`, alongside the existing `docker` and
  `containerd` backends: executes Actions as Kubernetes `Job`s via the API server instead of a
  local container-runtime socket.
- Intended for a standing Agent running as a long-lived pod inside a Kubernetes cluster to execute
  Actions that don't need to touch specific bare-metal hardware — not a replacement for
  `docker`/`containerd` on the actual provisioning path (a `Job`'s Pod can land on any node).
- Enabled via `-runtime=kubernetes`, `-kubernetes-namespace` (default `tinkerbell`), and optional
  `-kubernetes-kubeconfig` for out-of-cluster use; defaults to the in-cluster config.
- Fails fast, rather than silently ignoring, on Action fields with no safe Kubernetes equivalent:
  `namespaces.pid`/`namespaces.network` (hostPID/hostNetwork) and `volumes` (Docker bind-mount
  syntax).
- Needs only namespaced RBAC on `jobs`/`pods`/`pods/log` — no `secrets`, no cluster-scoped
  permissions. Private images use whatever `imagePullSecrets` are already on the Agent's own
  ServiceAccount.
- Exit-code checking and container-log streaming are scoped specifically to the Action's own
  container by name, so an unrelated sidecar (Istio, Linkerd, Vault Agent Injector, etc. injected
  into the Agent's namespace) can never be mistaken for the Action's outcome.

See `docs/technical/AGENT_KUBERNETES_RUNTIME.md` for usage, RBAC, and an example Deployment.

## Compatibility
- Purely additive: a new opt-in `-runtime` value. No behavior change for existing
  `docker`/`containerd` deployments or the default runtime.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` passing (1459 tests)
- [x] `golangci-lint run` clean (only pre-existing, unrelated `goconst` findings in `containerd`)
- [x] Verified against a real cluster (kind): Job create/watch/exit-code/log-stream/cleanup for
      success, non-zero exit, and pod-failed-with-no-container-status cases
- [x] RBAC verified empirically, not just by inspection: minted a ServiceAccount token scoped to
      exactly the documented Role and ran `Execute` through it — `jobs`/`pods` succeeded,
      `secrets`/`namespaces`/deleting the Role itself were all denied
- [x] Exercised the real `agent.Config.Run` retry/timeout loop (not just the runtime package)
      against a real cluster: fast success, an in-flight timeout (a genuinely still-running
      container hitting its deadline), and retries-exhausted
- [x] Code coverage: 54.1% (main) → 54.2% (branch)