### PR TITLE
Recover from leftover Jobs and reconnect on watch errors in kubernetes RuntimeExecutor

### DIFF
--- a/tink/agent/internal/runtime/kubernetes/kubernetes.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes.go
@@ -19,6 +19,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -107,7 +108,9 @@ func restConfig(kubeconfig string) (*rest.Config, error) {
 // Execute creates a Job for the Action, waits for its Pod to terminate, streams the Pod's logs,
 // and returns nil on a zero exit code or a descriptive error otherwise. The Job (and its Pod) are
 // always deleted, and confirmed gone, before Execute returns, so a retried Action (same ID, same
-// deterministic Job name) never races its own predecessor's still-terminating Job.
+// deterministic Job name) never races its own predecessor's still-terminating Job. If a Job with
+// that name already exists — a leftover from a previous Agent process that crashed or restarted
+// before its own cleanup ran — Execute adopts it via adoptExistingJob instead of failing outright.
 func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	job, err := c.jobFor(a)
 	if err != nil {
@@ -116,6 +119,9 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 
 	jobs := c.Client.BatchV1().Jobs(c.Namespace)
 	created, err := jobs.Create(ctx, job, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		created, err = c.adoptExistingJob(ctx, jobs, job.Name, a.ID, err)
+	}
 	if err != nil {
 		return fmt.Errorf("kubernetes: creating job: %w", err)
 	}
@@ -136,6 +142,22 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	c.streamLogs(pod.Name)
 
 	return exitError(pod)
+}
+
+// adoptExistingJob recovers from a Jobs.Create AlreadyExists conflict by checking whether the
+// existing Job belongs to this same Action (its action-id label matches). If so, it's a leftover
+// from a previous Agent process that crashed or restarted before its deferred cleanup could run:
+// Execute can safely observe it instead of failing the Action permanently just because its
+// deterministic name (see jobName) is already taken. If the existing Job belongs to a different
+// Action — a rare name-truncation collision — or can't be fetched, createErr is returned unchanged
+// so the caller never touches a Job it doesn't own.
+func (c *Config) adoptExistingJob(ctx context.Context, jobs batchv1client.JobInterface, name, actionID string, createErr error) (*batchv1.Job, error) {
+	existing, err := jobs.Get(ctx, name, metav1.GetOptions{})
+	if err != nil || existing.Labels[actionIDLabel] != actionID {
+		return nil, createErr
+	}
+	c.Log.Info("adopting existing job left over from a previous attempt", "job", existing.Name)
+	return existing, nil
 }
 
 // deleteJob issues a foreground-propagation delete and then waits for the Job to actually
@@ -274,7 +296,10 @@ func (c *Config) waitForPod(ctx context.Context, actionID string) (*corev1.Pod, 
 }
 
 // watchForTerminatedPod watches until the Action's Pod terminates or the watch itself closes.
-// closed is true only in the latter case, in which case pod and err are both nil.
+// closed is true only in the latter case, in which case pod and err are both nil. A watch.Error
+// event (e.g. a 410 Gone from a resourceVersion that aged out) is treated the same as a closed
+// channel rather than silently ignored: waitForPod re-lists and re-establishes the watch after a
+// short backoff, instead of waiting out the rest of ctx for no reason.
 func (c *Config) watchForTerminatedPod(ctx context.Context, pods corev1client.PodInterface, selector, resourceVersion string) (pod *corev1.Pod, closed bool, err error) {
 	w, err := pods.Watch(ctx, metav1.ListOptions{LabelSelector: selector, ResourceVersion: resourceVersion})
 	if err != nil {
@@ -288,6 +313,10 @@ func (c *Config) watchForTerminatedPod(ctx context.Context, pods corev1client.Po
 			return nil, false, ctx.Err()
 		case event, ok := <-w.ResultChan():
 			if !ok {
+				return nil, true, nil
+			}
+			if event.Type == watch.Error {
+				c.Log.Info("pod watch reported an error, reconnecting", "error", apierrors.FromObject(event.Object))
 				return nil, true, nil
 			}
 			pod, ok := event.Object.(*corev1.Pod)

--- a/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
+++ b/tink/agent/internal/runtime/kubernetes/kubernetes_test.go
@@ -261,6 +261,66 @@ func TestExecute_ContextCancelled(t *testing.T) {
 	}
 }
 
+// TestExecute_AdoptsLeftoverJobFromSameAction verifies that Execute recovers from a Jobs.Create
+// AlreadyExists conflict when the existing Job belongs to this same Action: a leftover from a
+// previous Agent process that crashed or restarted before its own deferred cleanup could run.
+func TestExecute_AdoptsLeftoverJobFromSameAction(t *testing.T) {
+	actionID, name := "action-8", "n8"
+	leftoverJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName(actionID, name),
+			Namespace: "tinkerbell",
+			Labels:    map[string]string{actionIDLabel: actionID},
+		},
+	}
+	terminatedPod := podWithContainerState(actionID, corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0})
+
+	client := fake.NewSimpleClientset(leftoverJob, terminatedPod)
+	c := &Config{Log: logr.Discard(), Client: client, Namespace: "tinkerbell"}
+
+	if err := c.Execute(context.Background(), spec.Action{ID: actionID, Name: name, Image: "img"}); err != nil {
+		t.Fatalf("expected Execute to adopt the leftover job and succeed, got: %v", err)
+	}
+
+	jobs, jerr := client.BatchV1().Jobs("tinkerbell").List(context.Background(), metav1.ListOptions{})
+	if jerr != nil {
+		t.Fatalf("listing jobs: %v", jerr)
+	}
+	if len(jobs.Items) != 0 {
+		t.Fatalf("expected the adopted job to be cleaned up, found %d", len(jobs.Items))
+	}
+}
+
+// TestExecute_DoesNotAdoptDifferentActionsJob verifies that Execute does not touch an existing Job
+// whose deterministic name collides but whose action-id label belongs to a different Action (see
+// jobName's truncation-collision note): adopting it could mean observing, or worse deleting, a
+// Job for an unrelated, possibly still-running Action.
+func TestExecute_DoesNotAdoptDifferentActionsJob(t *testing.T) {
+	actionID, name := "action-9", "n9"
+	othersJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName(actionID, name),
+			Namespace: "tinkerbell",
+			Labels:    map[string]string{actionIDLabel: "some-other-action"},
+		},
+	}
+
+	client := fake.NewSimpleClientset(othersJob)
+	c := &Config{Log: logr.Discard(), Client: client, Namespace: "tinkerbell"}
+
+	if err := c.Execute(context.Background(), spec.Action{ID: actionID, Name: name, Image: "img"}); err == nil {
+		t.Fatalf("expected Execute to fail rather than adopt a job belonging to a different action")
+	}
+
+	jobs, jerr := client.BatchV1().Jobs("tinkerbell").List(context.Background(), metav1.ListOptions{})
+	if jerr != nil {
+		t.Fatalf("listing jobs: %v", jerr)
+	}
+	if len(jobs.Items) != 1 || jobs.Items[0].Labels[actionIDLabel] != "some-other-action" {
+		t.Fatalf("expected the other action's job to be left untouched, got %+v", jobs.Items)
+	}
+}
+
 // TestWaitForPod_ReconnectsAfterWatchCloses verifies that a watch closing for a benign reason
 // (API server watch timeout, resourceVersion expiry, transient network blip) is not treated as a
 // fatal error: waitForPod must re-list and re-establish the watch instead of failing a
@@ -294,6 +354,43 @@ func TestWaitForPod_ReconnectsAfterWatchCloses(t *testing.T) {
 	}
 	if n := watches.Load(); n < 2 {
 		t.Fatalf("expected waitForPod to reconnect after the first watch closed, got %d watch call(s)", n)
+	}
+}
+
+// TestWaitForPod_ReconnectsAfterWatchError verifies that a watch.Error event (e.g. a 410 Gone from
+// a resourceVersion that aged out) is treated the same as a closed watch: waitForPod must re-list
+// and re-establish the watch immediately instead of silently ignoring the event and waiting out
+// the rest of ctx for no reason.
+func TestWaitForPod_ReconnectsAfterWatchError(t *testing.T) {
+	runningPod := podWithContainerState("action-11", corev1.PodRunning, nil)
+	terminatedPod := podWithContainerState("action-11", corev1.PodSucceeded, &corev1.ContainerStateTerminated{ExitCode: 0})
+
+	client := fake.NewSimpleClientset(runningPod)
+
+	var watches atomic.Int32
+	client.PrependWatchReactor("pods", func(_ clienttesting.Action) (bool, watch.Interface, error) {
+		fw := watch.NewFake()
+		if watches.Add(1) == 1 {
+			// First watch: deliver a watch.Error event, simulating a resourceVersion that aged
+			// out mid-watch (a 410 Gone).
+			go fw.Error(&metav1.Status{Status: metav1.StatusFailure, Reason: metav1.StatusReasonGone})
+			return true, fw, nil
+		}
+		// Second watch: deliver the terminated pod.
+		go fw.Modify(terminatedPod)
+		return true, fw, nil
+	})
+
+	c := &Config{Log: logr.Discard(), Client: client, Namespace: "tinkerbell"}
+	got, err := c.waitForPod(context.Background(), "action-11")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !podTerminated(got) {
+		t.Fatalf("expected a terminated pod, got %+v", got)
+	}
+	if n := watches.Load(); n < 2 {
+		t.Fatalf("expected waitForPod to reconnect after the watch error, got %d watch call(s)", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #893 (Kubernetes `RuntimeExecutor` for `tink-agent`), addressing two gaps @copilot-pull-request-reviewer flagged after that PR merged:

- **Recover from a leftover Job on Agent crash/restart.** `Execute` previously failed permanently if `Jobs.Create` returned `AlreadyExists`. Since Job names are deterministic (by design, for observability), a leftover Job from a previous Agent process that crashed or restarted mid-`Execute` (before its own deferred cleanup could run) would otherwise make that Action fail forever instead of recovering. `Execute` now adopts the existing Job when its `action-id` label matches the current Action. A name collision with a *different* Action's Job (a rare truncation collision — see `jobName`'s doc comment) is still treated as a hard error, since adopting it could mean observing, or worse deleting, a Job this Agent doesn't own.
- **Reconnect on watch errors, not just closed channels.** `waitForPod`'s watch loop silently ignored `watch.Error` events (e.g. a `410 Gone` from a resourceVersion that aged out) via the `event.Object.(*corev1.Pod)` type assertion failing and falling through to `continue`. It's now treated the same as a closed watch: re-list and re-establish immediately, rather than waiting out the rest of the Action's timeout for no reason.

## Test plan

- [x] `go build ./tink/... ./cmd/agent/...`
- [x] `go vet ./tink/agent/... ./cmd/agent/...`
- [x] `gofmt -l` clean
- [x] `go test ./tink/agent/... ./cmd/agent/...` — all passing, including 4 new tests (`TestExecute_AdoptsLeftoverJobFromSameAction`, `TestExecute_DoesNotAdoptDifferentActionsJob`, `TestWaitForPod_ReconnectsAfterWatchError`, plus the pre-existing `TestWaitForPod_ReconnectsAfterWatchCloses`)
- [x] `golangci-lint run -c .golangci.yml ./tink/... ./cmd/...` — 0 new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)