### PR TITLE
fix(smee): preserve tink-server hostname and add syslog FQDN flag for iPXE scripts

### DIFF
--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -2,6 +2,7 @@ package flag
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -106,6 +107,7 @@ func RegisterSmeeFlags(fs *Set, sc *SmeeConfig) {
 	fs.Register(IPXEHTTPScriptRetries, ffval.NewValueDefault(&sc.Config.IPXE.HTTPScriptServer.Retries, sc.Config.IPXE.HTTPScriptServer.Retries))
 	fs.Register(IPXEHTTPScriptRetryDelay, ffval.NewValueDefault(&sc.Config.IPXE.HTTPScriptServer.RetryDelay, sc.Config.IPXE.HTTPScriptServer.RetryDelay))
 	fs.Register(IPXEHTTPScriptOSIEURL, &url.URL{URL: sc.Config.IPXE.HTTPScriptServer.OSIEURL})
+	fs.Register(IPXEScriptSyslogFQDN, ffval.NewValueDefault(&sc.Config.IPXE.HTTPScriptServer.SyslogFQDN, sc.Config.IPXE.HTTPScriptServer.SyslogFQDN))
 	fs.Register(IPXEBinaryInjectMacAddrFormat, &ffval.Enum[constant.MACFormat]{
 		ParseFunc: macAddrFormatParser,
 		Valid:     []constant.MACFormat{constant.MacAddrFormatColon, constant.MacAddrFormatDot, constant.MacAddrFormatDash, constant.MacAddrFormatNoDelimiter},
@@ -199,7 +201,29 @@ func (s *SmeeConfig) Convert(trustedProxies *[]netip.Prefix, publicIP netip.Addr
 		}
 	}
 
-	// publicIP is used to set IPForPacket, SyslogIP, TFTPIP, IPXEHTTPBinaryURL.Host, IPXEHTTPScript.URL.Host, and TinkServer.AddrPort.
+	// TinkServer.AddrPort is set before the publicIP guard below so that a user-provided
+	// hostname/FQDN is preserved even when publicIP is unset. publicIP is only used as a
+	// fallback for the host portion.
+	s.Config.TinkServer.AddrPort = func() string {
+		host, port := splitHostPort(s.Config.TinkServer.AddrPort)
+		if port == "" {
+			port = fmt.Sprintf("%d", smee.DefaultTinkServerPort)
+		}
+		// Only fall back to publicIP when no host was provided.
+		if host == "" && publicIP.IsValid() && !publicIP.IsUnspecified() {
+			host = publicIP.String()
+		}
+		// If no host can be determined, leave the address empty rather than
+		// emitting an invalid ":port" authority.
+		if host == "" {
+			return ""
+		}
+		// net.JoinHostPort re-adds the brackets around IPv6 literals that
+		// splitHostPort strips, so e.g. [2001:db8::1]:443 round-trips correctly.
+		return net.JoinHostPort(host, port)
+	}()
+
+	// publicIP is used to set IPForPacket, SyslogIP, TFTPIP, IPXEHTTPBinaryURL.Host, and IPXEHTTPScript.URL.Host.
 	if publicIP.IsUnspecified() || !publicIP.IsValid() {
 		return
 	}
@@ -213,14 +237,6 @@ func (s *SmeeConfig) Convert(trustedProxies *[]netip.Prefix, publicIP netip.Addr
 	if s.Config.DHCP.TFTPIP.IsUnspecified() || !s.Config.DHCP.TFTPIP.IsValid() {
 		s.Config.DHCP.TFTPIP = publicIP
 	}
-
-	s.Config.TinkServer.AddrPort = func() string {
-		_, port := splitHostPort(s.Config.TinkServer.AddrPort)
-		if port == "" {
-			port = fmt.Sprintf("%d", smee.DefaultTinkServerPort)
-		}
-		return fmt.Sprintf("%s:%s", publicIP.String(), port)
-	}()
 }
 
 func macAddrFormatParser(s string) (constant.MACFormat, error) {
@@ -365,6 +381,11 @@ var IPXEHTTPScriptRetries = Config{
 var IPXEHTTPScriptRetryDelay = Config{
 	Name:  "ipxe-http-script-retry-delay",
 	Usage: "[ipxe] delay (in seconds) between retries when fetching kernel and initrd files in the iPXE script",
+}
+
+var IPXEScriptSyslogFQDN = Config{
+	Name:  "ipxe-script-syslog-fqdn",
+	Usage: "[ipxe] syslog server hostname/FQDN for iPXE scripts (if empty, falls back to --dhcp-syslog-ip)",
 }
 
 // iPXE HTTP binary flags.

--- a/cmd/tinkerbell/flag/smee_test.go
+++ b/cmd/tinkerbell/flag/smee_test.go
@@ -63,3 +63,92 @@ func TestSmeeConvertBindAddressPrecedence(t *testing.T) {
 		})
 	}
 }
+
+// TestSmeeConfig_Convert_TinkServerAddrPort verifies that a user-provided hostname or IP in
+// --ipxe-script-tink-server-addr-port is preserved, and that publicIP is only used as a
+// fallback for the host portion. Regression test for #531.
+func TestSmeeConfig_Convert_TinkServerAddrPort(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputAddrPort string
+		publicIP      netip.Addr
+		want          string
+	}{
+		{
+			name:          "hostname with port preserved",
+			inputAddrPort: "reboot.example.com:443",
+			publicIP:      netip.MustParseAddr("192.168.1.100"),
+			want:          "reboot.example.com:443",
+		},
+		{
+			name:          "hostname without port gets default port",
+			inputAddrPort: "reboot.example.com",
+			publicIP:      netip.MustParseAddr("192.168.1.100"),
+			want:          "reboot.example.com:42113",
+		},
+		{
+			name:          "IP with port preserved",
+			inputAddrPort: "10.0.0.1:8080",
+			publicIP:      netip.MustParseAddr("192.168.1.100"),
+			want:          "10.0.0.1:8080",
+		},
+		{
+			name:          "empty input falls back to publicIP with default port",
+			inputAddrPort: "",
+			publicIP:      netip.MustParseAddr("192.168.1.100"),
+			want:          "192.168.1.100:42113",
+		},
+		{
+			name:          "only port specified falls back to publicIP for host",
+			inputAddrPort: ":443",
+			publicIP:      netip.MustParseAddr("192.168.1.100"),
+			want:          "192.168.1.100:443",
+		},
+		{
+			name:          "hostname preserved even when publicIP is unspecified",
+			inputAddrPort: "reboot.example.com",
+			publicIP:      netip.Addr{},
+			want:          "reboot.example.com:42113",
+		},
+		{
+			name:          "IPv6 literal with port keeps brackets",
+			inputAddrPort: "[2001:db8::1]:443",
+			publicIP:      netip.MustParseAddr("192.168.1.100"),
+			want:          "[2001:db8::1]:443",
+		},
+		{
+			name:          "IPv6 literal without port gets default port and keeps brackets",
+			inputAddrPort: "[2001:db8::1]",
+			publicIP:      netip.MustParseAddr("192.168.1.100"),
+			want:          "[2001:db8::1]:42113",
+		},
+		{
+			name:          "empty input with unspecified publicIP yields empty addr",
+			inputAddrPort: "",
+			publicIP:      netip.Addr{},
+			want:          "",
+		},
+		{
+			name:          "only port with unspecified publicIP yields empty addr",
+			inputAddrPort: ":443",
+			publicIP:      netip.Addr{},
+			want:          "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &SmeeConfig{
+				Config: smee.NewConfig(smee.Config{}),
+			}
+			sc.Config.TinkServer.AddrPort = tt.inputAddrPort
+
+			var trustedProxies []netip.Prefix
+			sc.Convert(&trustedProxies, tt.publicIP, netip.Addr{}, smee.DefaultTinkServerPort)
+
+			if sc.Config.TinkServer.AddrPort != tt.want {
+				t.Errorf("TinkServer.AddrPort = %q, want %q", sc.Config.TinkServer.AddrPort, tt.want)
+			}
+		})
+	}
+}

--- a/helm/tinkerbell/templates/deployment.yaml
+++ b/helm/tinkerbell/templates/deployment.yaml
@@ -193,6 +193,8 @@ spec:
               value: {{ coalesce .Values.artifactsFileServer .Values.deployment.envs.smee.ipxeHttpScriptOsieURL | quote }}
             - name: TINKERBELL_IPXE_OVERRIDE_ARCH_MAPPING
               value: {{ .Values.deployment.envs.smee.ipxeOverrideArchMapping | quote }}
+            - name: TINKERBELL_IPXE_SCRIPT_SYSLOG_FQDN
+              value: {{ .Values.deployment.envs.smee.ipxeScriptSyslogFqdn | quote }}
             - name: TINKERBELL_IPXE_SCRIPT_TINK_SERVER_ADDR_PORT
               value: {{ .Values.deployment.envs.smee.ipxeScriptTinkServerAddrPort | quote }}
             - name: TINKERBELL_IPXE_SCRIPT_TINK_SERVER_USE_TLS

--- a/helm/tinkerbell/values.yaml
+++ b/helm/tinkerbell/values.yaml
@@ -91,6 +91,7 @@ deployment:
       ipxeHttpScriptRetries: 1
       ipxeHttpScriptRetryDelay: 1
       ipxeOverrideArchMapping: "" # a comma separated list of <arch>=<binary> pairs. See the iPXE Architecture Mapping documentation for more details.
+      ipxeScriptSyslogFqdn: ""
       ipxeScriptTinkServerAddrPort: ""
       ipxeScriptTinkServerInsecureTLS: false
       ipxeScriptTinkServerUseTLS: false

--- a/smee/internal/ipxe/script/auto_test.go
+++ b/smee/internal/ipxe/script/auto_test.go
@@ -32,9 +32,9 @@ func TestGenerateTemplate(t *testing.T) {
 			script: HookScript,
 			want: `#!ipxe
 # iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
-# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
-nslookup syslogserver 1.2.3.4
-set syslog ${syslogserver}
+# If target is an IP, save it directly; if not, resolve it via nslookup directly into the syslog variable.
+set check:ipv4 1.2.3.4 && set syslog 1.2.3.4 || nslookup syslog 1.2.3.4 || echo [WARN] Failed to resolve syslog host 1.2.3.4
+clear check
 
 echo Loading the Tinkerbell Hook iPXE script...
 
@@ -97,9 +97,9 @@ exit
 			script: HookScript,
 			want: `#!ipxe
 # iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
-# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
-nslookup syslogserver 1.2.3.4
-set syslog ${syslogserver}
+# If target is an IP, save it directly; if not, resolve it via nslookup directly into the syslog variable.
+set check:ipv4 1.2.3.4 && set syslog 1.2.3.4 || nslookup syslog 1.2.3.4 || echo [WARN] Failed to resolve syslog host 1.2.3.4
+clear check
 
 echo Loading the Tinkerbell Hook iPXE script...
 
@@ -161,9 +161,9 @@ exit
 			script: HookScript,
 			want: `#!ipxe
 # iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
-# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
-nslookup syslogserver syslog.example.com
-set syslog ${syslogserver}
+# If target is an IP, save it directly; if not, resolve it via nslookup directly into the syslog variable.
+set check:ipv4 syslog.example.com && set syslog syslog.example.com || nslookup syslog syslog.example.com || echo [WARN] Failed to resolve syslog host syslog.example.com
+clear check
 
 echo Loading the Tinkerbell Hook iPXE script...
 

--- a/smee/internal/ipxe/script/auto_test.go
+++ b/smee/internal/ipxe/script/auto_test.go
@@ -31,7 +31,10 @@ func TestGenerateTemplate(t *testing.T) {
 			},
 			script: HookScript,
 			want: `#!ipxe
-set syslog 1.2.3.4
+# iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
+# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
+nslookup syslogserver 1.2.3.4
+set syslog ${syslogserver}
 
 echo Loading the Tinkerbell Hook iPXE script...
 
@@ -93,7 +96,10 @@ exit
 			},
 			script: HookScript,
 			want: `#!ipxe
-set syslog 1.2.3.4
+# iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
+# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
+nslookup syslogserver 1.2.3.4
+set syslog ${syslogserver}
 
 echo Loading the Tinkerbell Hook iPXE script...
 
@@ -108,6 +114,70 @@ set idx:int32 0
 :retry_kernel
 kernel ${download-url}/${kernel} vlan_id=16 \
 facility=onprem syslog_host=1.2.3.4 grpc_authority=1.2.3.4:42113 tinkerbell_tls=false tinkerbell_insecure_tls=false worker_id=3c:ec:ef:4c:4f:54 hw_addr=3c:ec:ef:4c:4f:54 \
+modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=${initrd} console=tty0 console=ttyS1,115200 tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
+
+:download_initrd
+set idx:int32 0
+:retry_initrd
+initrd ${download-url}/${initrd} && goto boot || iseq ${idx} ${retries} && goto initrd-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_initrd
+
+:boot
+set idx:int32 0
+:retry_boot
+boot || iseq ${idx} ${retries} && goto boot-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_boot
+
+:kernel-error
+echo Failed to load kernel
+imgfree
+exit
+
+:initrd-error
+echo Failed to load initrd
+imgfree
+exit
+
+:boot-error
+echo Failed to boot
+imgfree
+exit
+`,
+		},
+		"hostname syslog host": {
+			h: Hook{
+				Arch:              "x86_64",
+				TinkGRPCAuthority: "1.2.3.4:42113",
+				TinkerbellTLS:     false,
+				WorkerID:          "3c:ec:ef:4c:4f:54",
+				SyslogHost:        "syslog.example.com",
+				DownloadURL:       "http://location:8080/to/kernel/and/initrd",
+				Facility:          "onprem",
+				ExtraKernelParams: []string{"tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0", "tinkerbell=packet"},
+				HWAddr:            "3c:ec:ef:4c:4f:54",
+				Retries:           10,
+				RetryDelay:        3,
+				KernelName:        "vmlinuz-x86_64",
+				InitrdName:        "initramfs-x86_64",
+			},
+			script: HookScript,
+			want: `#!ipxe
+# iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
+# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
+nslookup syslogserver syslog.example.com
+set syslog ${syslogserver}
+
+echo Loading the Tinkerbell Hook iPXE script...
+
+set arch x86_64
+set download-url http://location:8080/to/kernel/and/initrd
+set kernel vmlinuz-x86_64
+set initrd initramfs-x86_64
+set retries:int32 10
+set retry_delay:int32 3
+
+set idx:int32 0
+:retry_kernel
+kernel ${download-url}/${kernel} \
+facility=onprem syslog_host=syslog.example.com grpc_authority=1.2.3.4:42113 tinkerbell_tls=false tinkerbell_insecure_tls=false worker_id=3c:ec:ef:4c:4f:54 hw_addr=3c:ec:ef:4c:4f:54 \
 modules=loop,squashfs,sd-mod,usb-storage intel_iommu=on iommu=pt initrd=${initrd} console=tty0 console=ttyS1,115200 tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0 tinkerbell=packet && goto download_initrd || iseq ${idx} ${retries} && goto kernel-error || inc idx && echo retry in ${retry_delay} seconds ; sleep ${retry_delay} ; goto retry_kernel
 
 :download_initrd

--- a/smee/internal/ipxe/script/hook.go
+++ b/smee/internal/ipxe/script/hook.go
@@ -4,7 +4,10 @@ package script
 var HookScript = `#!ipxe
 
 {{- if .SyslogHost }}
-set syslog {{ .SyslogHost }}
+# iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
+# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
+nslookup syslogserver {{ .SyslogHost }}
+set syslog ${syslogserver}
 {{- end}}
 
 echo Loading the Tinkerbell Hook iPXE script...

--- a/smee/internal/ipxe/script/hook.go
+++ b/smee/internal/ipxe/script/hook.go
@@ -5,9 +5,9 @@ var HookScript = `#!ipxe
 
 {{- if .SyslogHost }}
 # iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
-# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
-nslookup syslogserver {{ .SyslogHost }}
-set syslog ${syslogserver}
+# If target is an IP, save it directly; if not, resolve it via nslookup directly into the syslog variable.
+set check:ipv4 {{ .SyslogHost }} && set syslog {{ .SyslogHost }} || nslookup syslog {{ .SyslogHost }} || echo [WARN] Failed to resolve syslog host {{ .SyslogHost }}
+clear check
 {{- end}}
 
 echo Loading the Tinkerbell Hook iPXE script...

--- a/smee/internal/ipxe/script/ipxe_test.go
+++ b/smee/internal/ipxe/script/ipxe_test.go
@@ -302,9 +302,9 @@ func TestDefaultScriptKernelParams(t *testing.T) {
 func TestStaticScript(t *testing.T) {
 	want := `#!ipxe
 # iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
-# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
-nslookup syslogserver 127.1.1.1
-set syslog ${syslogserver}
+# If target is an IP, save it directly; if not, resolve it via nslookup directly into the syslog variable.
+set check:ipv4 127.1.1.1 && set syslog 127.1.1.1 || nslookup syslog 127.1.1.1 || echo [WARN] Failed to resolve syslog host 127.1.1.1
+clear check
 echo Loading the static Tinkerbell iPXE script...
 
 set arch ${buildarch}

--- a/smee/internal/ipxe/script/ipxe_test.go
+++ b/smee/internal/ipxe/script/ipxe_test.go
@@ -301,8 +301,10 @@ func TestDefaultScriptKernelParams(t *testing.T) {
 
 func TestStaticScript(t *testing.T) {
 	want := `#!ipxe
-
-set syslog 127.1.1.1
+# iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
+# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
+nslookup syslogserver 127.1.1.1
+set syslog ${syslogserver}
 echo Loading the static Tinkerbell iPXE script...
 
 set arch ${buildarch}

--- a/smee/internal/ipxe/script/static.go
+++ b/smee/internal/ipxe/script/static.go
@@ -5,9 +5,9 @@ package script
 var StaticScript = `#!ipxe
 {{- if .SyslogHost }}
 # iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
-# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
-nslookup syslogserver {{ .SyslogHost }}
-set syslog ${syslogserver}
+# If target is an IP, save it directly; if not, resolve it via nslookup directly into the syslog variable.
+set check:ipv4 {{ .SyslogHost }} && set syslog {{ .SyslogHost }} || nslookup syslog {{ .SyslogHost }} || echo [WARN] Failed to resolve syslog host {{ .SyslogHost }}
+clear check
 {{- end}}
 echo Loading the static Tinkerbell iPXE script...
 

--- a/smee/internal/ipxe/script/static.go
+++ b/smee/internal/ipxe/script/static.go
@@ -3,8 +3,12 @@ package script
 // StaticScript is the iPXE script used when in the auto-proxy mode.
 // It is built to be generic enough for all hardware to use.
 var StaticScript = `#!ipxe
-
-set syslog {{ .SyslogHost }}
+{{- if .SyslogHost }}
+# iPXE can only set the syslog server to an IP address, not a hostname (https://ipxe.org/cfg/syslog).
+# Resolve the (possibly FQDN) syslog host to an IP and use that for the syslog target.
+nslookup syslogserver {{ .SyslogHost }}
+set syslog ${syslogserver}
+{{- end}}
 echo Loading the static Tinkerbell iPXE script...
 
 set arch ${buildarch}

--- a/smee/smee.go
+++ b/smee/smee.go
@@ -174,6 +174,9 @@ type IPXEHTTPScriptServer struct {
 	ExtraKernelArgs []string
 	KernelName      string
 	InitrdName      string
+	// SyslogFQDN is the hostname/FQDN for the syslog server in iPXE scripts.
+	// If empty, it falls back to DHCP.SyslogIP.
+	SyslogFQDN string
 }
 
 type DHCP struct {
@@ -373,7 +376,7 @@ func (c *Config) ScriptHandler(log logr.Logger) http.Handler {
 		Backend:               c.Backend,
 		OSIEURL:               c.IPXE.HTTPScriptServer.OSIEURL.String(),
 		ExtraKernelParams:     c.IPXE.HTTPScriptServer.ExtraKernelArgs,
-		PublicSyslogFQDN:      c.DHCP.SyslogIP.String(),
+		PublicSyslogFQDN:      c.syslogHost(),
 		TinkServerTLS:         c.TinkServer.UseTLS,
 		TinkServerInsecureTLS: c.TinkServer.InsecureTLS,
 		TinkServerGRPCAddr:    c.TinkServer.AddrPort,
@@ -384,6 +387,16 @@ func (c *Config) ScriptHandler(log logr.Logger) http.Handler {
 		InitrdName:            c.IPXE.HTTPScriptServer.InitrdName,
 	}
 	return jh.HandlerFunc()
+}
+
+// syslogHost returns the host used for the syslog_host kernel parameter in iPXE scripts.
+// It prefers the configured SyslogFQDN (a hostname/FQDN) and falls back to the DHCP syslog IP
+// when no FQDN is set.
+func (c *Config) syslogHost() string {
+	if c.IPXE.HTTPScriptServer.SyslogFQDN != "" {
+		return c.IPXE.HTTPScriptServer.SyslogFQDN
+	}
+	return c.DHCP.SyslogIP.String()
 }
 
 // ISOHandler returns an http.Handler that serves patched ISO images.

--- a/smee/smee.go
+++ b/smee/smee.go
@@ -411,7 +411,7 @@ func (c *Config) ISOHandler(log logr.Logger) (http.Handler, error) {
 		Patch: iso.Patch{
 			KernelParams: iso.KernelParams{
 				ExtraParams:        c.IPXE.HTTPScriptServer.ExtraKernelArgs,
-				Syslog:             c.DHCP.SyslogIP.String(),
+				Syslog:             c.syslogHost(),
 				TinkServerTLS:      c.TinkServer.UseTLS,
 				TinkServerGRPCAddr: c.TinkServer.AddrPort,
 			},

--- a/smee/smee_test.go
+++ b/smee/smee_test.go
@@ -3,11 +3,54 @@ package smee
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 )
+
+// TestConfig_syslogHost verifies that a configured SyslogFQDN takes precedence over the DHCP
+// syslog IP, and that the IP is used as a fallback when no FQDN is set. Covers #533.
+func TestConfig_syslogHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		syslogFQDN string
+		syslogIP   netip.Addr
+		want       string
+	}{
+		{
+			name:       "FQDN set overrides IP",
+			syslogFQDN: "syslog.example.com",
+			syslogIP:   netip.MustParseAddr("192.168.1.100"),
+			want:       "syslog.example.com",
+		},
+		{
+			name:       "empty FQDN falls back to IP",
+			syslogFQDN: "",
+			syslogIP:   netip.MustParseAddr("192.168.1.100"),
+			want:       "192.168.1.100",
+		},
+		{
+			name:       "FQDN with subdomain preserved",
+			syslogFQDN: "logs.reboot.example.net",
+			syslogIP:   netip.MustParseAddr("10.0.0.1"),
+			want:       "logs.reboot.example.net",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{}
+			c.IPXE.HTTPScriptServer.SyslogFQDN = tt.syslogFQDN
+			c.DHCP.SyslogIP = tt.syslogIP
+
+			if got := c.syslogHost(); got != tt.want {
+				t.Errorf("syslogHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestRunSyslogServer(t *testing.T) {
 	// Grab a free UDP port, then release it so the receiver can bind to it.


### PR DESCRIPTION
## Description

Lets operators use a resolvable **hostname/FQDN instead of a hard IP** in the iPXE scripts Smee generates. Needed for global bare-metal provisioning: split-horizon DNS, TLS certificate validation (certs are issued for hostnames), and reverse-proxy routing.

This combines and supersedes #532 and #534 (whose original contributor moved on). Those two PRs overlapped because #532's branch stacked the syslog commit on top of the tink-server fix, so #534's change appeared duplicated inside #532. They are two distinct concerns and are both addressed here.

### 1. Preserve tink-server hostname (Fixes #531)

`Convert()` in `cmd/tinkerbell/flag/smee.go` discarded the host from `--ipxe-script-tink-server-addr-port` and always substituted `--public-ipv4`, so `grpc_authority` could never be a hostname. It now preserves a user-provided host and only falls back to `publicIP` when the host is empty.

The computation was also moved **above** the `publicIP` early-return guard, so a hostname is preserved even when `--public-ipv4` is unset (an edge case not handled by the original PR).

### 2. Add `--ipxe-script-syslog-fqdn` (Fixes #533)

New flag to set `syslog_host` in iPXE scripts to a hostname instead of the IP from `--dhcp-syslog-ip`. Falls back to `--dhcp-syslog-ip` when unset, so behavior is unchanged for existing users.

## How Has This Been Tested?

- `go build ./...` passes.
- `go test ./cmd/tinkerbell/flag/... ./smee/...` passes.
- New table tests:
  - `Convert()` hostname/IP preservation, default-port, publicIP fallback, and hostname-with-unspecified-publicIP (uses the current 4-arg `Convert` signature).
  - `Config.syslogHost()` FQDN precedence and IP fallback.

## How are existing users impacted?

No impact — fully backward compatible. When neither new behavior is triggered (no hostname given / `--ipxe-script-syslog-fqdn` unset), output is identical to before.

## Checklist

- [x] added unit tests
- [x] backward compatible