### PR TITLE
Fix service-specific bind address precedence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ helm-lint: ## Lint the Helm chart
 .PHONY: helm-template
 helm-template: ## Helm template for Tinkerbell
 	helm template test helm/tinkerbell --set "trustedProxies={127.0.0.1/24}" --set "publicIP=1.1.1.1" --set "artifactsFileServer=http://2.2.2.2" 2>&1 >/dev/null
+	helm template test helm/tinkerbell --set "trustedProxies={127.0.0.1/24}" --set "publicIP=1.1.1.1" --set "artifactsFileServer=http://2.2.2.2" --set "deployment.envs.globals.bindAddr=192.0.2.10" | grep -A1 "name: TINKERBELL_BIND_ADDRESS" | grep -F -q 'value: "192.0.2.10"'
 
 ######### Helm charts - end   #########
 

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -70,7 +70,7 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 	}
 
 	s := &flag.SmeeConfig{
-		Config: smee.NewConfig(smee.Config{}, detectPublicIPv4()),
+		Config: smee.NewConfig(smee.Config{}),
 	}
 
 	h := &flag.TootlesConfig{
@@ -78,7 +78,6 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 	}
 	ts := &flag.TinkServerConfig{
 		Config:   server.NewConfig(server.WithAutoDiscoveryNamespace("default")),
-		BindAddr: detectPublicIPv4(),
 		BindPort: defaultTinkServerPort,
 	}
 	controllerOpts := []controller.Option{

--- a/cmd/tinkerbell/flag/global_test.go
+++ b/cmd/tinkerbell/flag/global_test.go
@@ -1,0 +1,25 @@
+package flag
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/peterbourgon/ff/v4"
+)
+
+func TestRegisterGlobalBindAddressEnv(t *testing.T) {
+	t.Setenv("TINKERBELL_BIND_ADDRESS", "192.0.2.10")
+
+	cfg := &GlobalConfig{}
+	fs := ff.NewFlagSet("test")
+	RegisterGlobal(&Set{FlagSet: fs}, cfg)
+	cmd := &ff.Command{Name: "test", Flags: fs}
+
+	if err := cmd.Parse(nil, ff.WithEnvVarPrefix("TINKERBELL")); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := cfg.BindAddr, netip.MustParseAddr("192.0.2.10"); got != want {
+		t.Errorf("BindAddr = %v, want %v", got, want)
+	}
+}

--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -189,6 +189,16 @@ func (s *SmeeConfig) Convert(trustedProxies *[]netip.Prefix, publicIP netip.Addr
 		return addr
 	}()
 
+	// Service-specific bind addresses take precedence over the global bind address.
+	if bindAddr.IsValid() {
+		if !s.Config.Syslog.BindAddr.IsValid() {
+			s.Config.Syslog.BindAddr = bindAddr
+		}
+		if !s.Config.TFTP.BindAddr.IsValid() {
+			s.Config.TFTP.BindAddr = bindAddr
+		}
+	}
+
 	// publicIP is used to set IPForPacket, SyslogIP, TFTPIP, IPXEHTTPBinaryURL.Host, IPXEHTTPScript.URL.Host, and TinkServer.AddrPort.
 	if publicIP.IsUnspecified() || !publicIP.IsValid() {
 		return
@@ -211,14 +221,6 @@ func (s *SmeeConfig) Convert(trustedProxies *[]netip.Prefix, publicIP netip.Addr
 		}
 		return fmt.Sprintf("%s:%s", publicIP.String(), port)
 	}()
-
-	// Set bind addresses if bindAddr is specified.
-	if bindAddr.IsValid() {
-		// syslog server
-		s.Config.Syslog.BindAddr = bindAddr
-		// TFTP server
-		s.Config.TFTP.BindAddr = bindAddr
-	}
 }
 
 func macAddrFormatParser(s string) (constant.MACFormat, error) {

--- a/cmd/tinkerbell/flag/smee_test.go
+++ b/cmd/tinkerbell/flag/smee_test.go
@@ -1,0 +1,65 @@
+package flag
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/tinkerbell/tinkerbell/smee"
+)
+
+func TestSmeeConvertBindAddressPrecedence(t *testing.T) {
+	globalBindAddr := netip.MustParseAddr("192.0.2.10")
+	syslogBindAddr := netip.MustParseAddr("192.0.2.20")
+	tftpBindAddr := netip.MustParseAddr("192.0.2.21")
+
+	tests := []struct {
+		name       string
+		syslogAddr netip.Addr
+		tftpAddr   netip.Addr
+		wantSyslog netip.Addr
+		wantTFTP   netip.Addr
+	}{
+		{
+			name:       "global address is the default",
+			wantSyslog: globalBindAddr,
+			wantTFTP:   globalBindAddr,
+		},
+		{
+			name:       "service-specific addresses take precedence",
+			syslogAddr: syslogBindAddr,
+			tftpAddr:   tftpBindAddr,
+			wantSyslog: syslogBindAddr,
+			wantTFTP:   tftpBindAddr,
+		},
+		{
+			name:       "service-specific syslog address takes precedence independently",
+			syslogAddr: syslogBindAddr,
+			wantSyslog: syslogBindAddr,
+			wantTFTP:   globalBindAddr,
+		},
+		{
+			name:       "service-specific TFTP address takes precedence independently",
+			tftpAddr:   tftpBindAddr,
+			wantSyslog: globalBindAddr,
+			wantTFTP:   tftpBindAddr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &SmeeConfig{Config: smee.NewConfig(smee.Config{
+				Syslog: smee.Syslog{BindAddr: tt.syslogAddr},
+				TFTP:   smee.TFTP{BindAddr: tt.tftpAddr},
+			})}
+
+			cfg.Convert(nil, netip.Addr{}, globalBindAddr, 8080)
+
+			if got := cfg.Config.Syslog.BindAddr; got != tt.wantSyslog {
+				t.Errorf("Syslog.BindAddr = %v, want %v", got, tt.wantSyslog)
+			}
+			if got := cfg.Config.TFTP.BindAddr; got != tt.wantTFTP {
+				t.Errorf("TFTP.BindAddr = %v, want %v", got, tt.wantTFTP)
+			}
+		})
+	}
+}

--- a/cmd/tinkerbell/flag/tink_server.go
+++ b/cmd/tinkerbell/flag/tink_server.go
@@ -33,9 +33,9 @@ func RegisterTinkServerFlags(fs *Set, t *TinkServerConfig) {
 
 // Convert TinkServerConfig data types to tink server server.Config data types.
 func (t *TinkServerConfig) Convert(bindAddr netip.Addr) {
-	addr := t.BindAddr
-	if bindAddr.IsValid() {
-		addr = bindAddr
+	addr := bindAddr
+	if t.BindAddr.IsValid() {
+		addr = t.BindAddr
 	}
 	t.Config.BindAddrPort = netip.AddrPortFrom(addr, t.BindPort)
 }

--- a/cmd/tinkerbell/flag/tink_server_test.go
+++ b/cmd/tinkerbell/flag/tink_server_test.go
@@ -1,0 +1,45 @@
+package flag
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/tinkerbell/tinkerbell/tink/server"
+)
+
+func TestTinkServerConvertBindAddressPrecedence(t *testing.T) {
+	globalBindAddr := netip.MustParseAddr("192.0.2.10")
+	serviceBindAddr := netip.MustParseAddr("192.0.2.20")
+
+	tests := []struct {
+		name     string
+		bindAddr netip.Addr
+		want     string
+	}{
+		{
+			name: "global address is the default",
+			want: "192.0.2.10:42113",
+		},
+		{
+			name:     "service-specific address takes precedence",
+			bindAddr: serviceBindAddr,
+			want:     "192.0.2.20:42113",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &TinkServerConfig{
+				Config:   server.NewConfig(),
+				BindAddr: tt.bindAddr,
+				BindPort: 42113,
+			}
+
+			cfg.Convert(globalBindAddr)
+
+			if got := cfg.Config.BindAddrPort.String(); got != tt.want {
+				t.Errorf("BindAddrPort = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/helm/tinkerbell/templates/deployment.yaml
+++ b/helm/tinkerbell/templates/deployment.yaml
@@ -262,7 +262,7 @@ spec:
               value: {{ .Values.deployment.envs.globals.backendKubeNamespace | quote }}
             - name: TINKERBELL_BACKEND_KUBE_QPS
               value: {{ .Values.deployment.envs.globals.backendKubeQPS | quote }}
-            - name: TINKERBELL_BIND_ADDR
+            - name: TINKERBELL_BIND_ADDRESS
               value: {{ .Values.deployment.envs.globals.bindAddr | quote }}
             - name: TINKERBELL_OTEL_ENDPOINT
               value: {{ .Values.deployment.envs.globals.otelEndpoint | quote }}

--- a/smee/smee.go
+++ b/smee/smee.go
@@ -243,8 +243,9 @@ type TLS struct {
 }
 
 // NewConfig is a constructor for the Config struct. It will set default values for the Config struct.
+// Syslog and TFTP bind addresses remain unset unless provided in c.
 // Boolean fields are not set-able via c. To set boolean, modify the returned Config struct.
-func NewConfig(c Config, publicIP netip.Addr) *Config {
+func NewConfig(c Config) *Config {
 	defaults := &Config{
 		DHCP: DHCP{
 			Enabled:              true,
@@ -299,13 +300,11 @@ func NewConfig(c Config, publicIP netip.Addr) *Config {
 			PathPrefix: DefaultPXEHTTPPathPrefix,
 		},
 		Syslog: Syslog{
-			BindAddr: publicIP,
 			BindPort: DefaultSyslogPort,
 			Enabled:  true,
 		},
 		TFTP: TFTP{
 			AssetDir:   DefaultTFTPAssetDir,
-			BindAddr:   publicIP,
 			BindPort:   DefaultTFFTPPort,
 			BlockSize:  DefaultTFFTPBlockSize,
 			SinglePort: DefaultTFFTPSinglePort,


### PR DESCRIPTION
## Description

Fix service-specific bind address precedence

Let Smee syslog/TFTP and Tink Server-specific bind addresses override the global bind address while retaining the global address as their fallback.

Leave service bind defaults unset until flag parsing completes so conversion can distinguish explicit service values from defaults.

Use `TINKERBELL_BIND_ADDRESS` in the Helm deployment to match the `--bind-address` environment mapping, and add unit and chart checks for environment parsing and precedence.

## How Has This Been Tested?

Ran local playground.

## How are existing users impacted? What migration steps/scripts do we need?

The behavior of `--bind-address` become predictable, the helm `TINKERBELL_BIND_ADDRESS` starts working as expected.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
