### PR TITLE
Add version flags to Tinkerbell binaries

### DIFF
--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -14,9 +14,10 @@ import (
 )
 
 type config struct {
-	AgentID  string
-	LogLevel int
-	Options  *agent.Options
+	AgentID      string
+	LogLevel     int
+	PrintVersion bool
+	Options      *agent.Options
 }
 
 func RegisterFlagsLegacy(c *config, fs *flag.FlagSet) {
@@ -102,6 +103,7 @@ func RegisterAllFlags(c *config) *ff.FlagSet {
 func RegisterRootFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.AgentID, "id", "", "ID of the agent")
 	fs.IntVar(&c.LogLevel, "log-level", 0, "Log level")
+	fs.BoolVar(&c.PrintVersion, "version", false, "Print the version and exit")
 	fs.Var(&c.Options.RuntimeSelected, "runtime", fmt.Sprintf("Container runtime used to run Actions, must be one of [%s, %s, %s]", agent.DockerRuntimeType, agent.ContainerdRuntimeType, agent.KubernetesRuntimeType))
 	fs.Var(&c.Options.TransportSelected, "transport", fmt.Sprintf("Transport used to receive Workflows/Actions and to send results, must be one of [%s, %s, %s]", agent.GRPCTransportType, agent.NATSTransportType, agent.FileTransportType))
 	fs.BoolVar(&c.Options.AttributeDetectionEnabled, "attribute-detection", true, "Enable attribute detection")

--- a/cmd/agent/flags_test.go
+++ b/cmd/agent/flags_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v4"
+	"github.com/peterbourgon/ff/v4/ffhelp"
+	"github.com/tinkerbell/tinkerbell/tink/agent"
+)
+
+func TestVersionFlag(t *testing.T) {
+	c := &config{Options: &agent.Options{}}
+	command := &ff.Command{
+		Name:  name,
+		Usage: "tink-agent [flags]",
+		Flags: RegisterAllFlags(c),
+	}
+
+	if err := command.Parse([]string{"-version"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !c.PrintVersion {
+		t.Fatal("-version did not set PrintVersion")
+	}
+}
+
+func TestVersionFlagHelp(t *testing.T) {
+	c := &config{Options: &agent.Options{}}
+	command := &ff.Command{
+		Name:  name,
+		Usage: "tink-agent [flags]",
+		Flags: RegisterAllFlags(c),
+	}
+
+	err := command.Parse([]string{"--help"})
+	if !errors.Is(err, ff.ErrHelp) {
+		t.Fatalf("Parse() error = %v, want %v", err, ff.ErrHelp)
+	}
+	help := ffhelp.Command(command).String()
+	for _, want := range []string{"FLAGS (general)", "-version", "Print the version and exit"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help does not contain %q:\n%s", want, help)
+		}
+	}
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -76,6 +76,13 @@ func main() {
 		exitCode = 1
 		return
 	}
+	if c.PrintVersion {
+		if _, err := fmt.Fprintln(os.Stdout, name, build.GitRevision()); err != nil {
+			fmt.Fprintf(os.Stderr, "print version: %v\n", err)
+			exitCode = 1
+		}
+		return
+	}
 
 	// For legacy flags, we need to check the environment variables without the prefix.
 	SetFromEnvLegacy(c)

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -6,7 +6,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/netip"
+	"os"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -38,7 +40,12 @@ var (
 	embeddedKubeControllerManagerExecute func(context.Context, string) error
 )
 
-func Execute(ctx context.Context, cancel context.CancelFunc, args []string) error { //nolint:cyclop // Will need to look into reducing the cyclomatic complexity.
+func Execute(ctx context.Context, cancel context.CancelFunc, args []string) error {
+	return executeWithOutput(ctx, cancel, args, os.Stdout)
+}
+
+// executeWithOutput allows command output to be captured in tests.
+func executeWithOutput(ctx context.Context, cancel context.CancelFunc, args []string, stdout io.Writer) error { //nolint:cyclop // Will need to look into reducing the cyclomatic complexity.
 	startTime := time.Now() // used in the HTTP healthcheck handler to report uptime.
 	globals := &flag.GlobalConfig{
 		BackendKubeConfig:    kubeConfig(),
@@ -133,6 +140,8 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 	flag.RegisterSecondStarFlags(&flag.Set{FlagSet: ssfs}, ssc)
 	flag.RegisterUIFlags(&flag.Set{FlagSet: uifs}, uic)
 	flag.RegisterGlobal(&flag.Set{FlagSet: gfs}, globals)
+	var printVersion bool
+	gfs.BoolVar(&printVersion, 0, "version", "Print the version and exit")
 	if embeddedApiserverExecute != nil && embeddedFlagSet != nil {
 		// This way the embedded flags only show up when the embedded services have been compiled in.
 		flag.RegisterEmbeddedGlobals(&flag.Set{FlagSet: gfs}, globals)
@@ -152,6 +161,12 @@ func Execute(ctx context.Context, cancel context.CancelFunc, args []string) erro
 		}
 
 		return e
+	}
+	if printVersion {
+		if _, err := fmt.Fprintln(stdout, "tinkerbell", build.GitRevision()); err != nil {
+			return fmt.Errorf("print version: %w", err)
+		}
+		return nil
 	}
 
 	log := getLogger(globals.LogLevel)

--- a/cmd/tinkerbell/cmd_test.go
+++ b/cmd/tinkerbell/cmd_test.go
@@ -1,8 +1,45 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/tinkerbell/tinkerbell/pkg/build"
 )
+
+func TestExecuteVersion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout bytes.Buffer
+	if err := executeWithOutput(ctx, cancel, []string{"--version"}, &stdout); err != nil {
+		t.Fatalf("executeWithOutput() error = %v", err)
+	}
+
+	want := fmt.Sprintf("tinkerbell %s\n", build.GitRevision())
+	if got := stdout.String(); got != want {
+		t.Fatalf("executeWithOutput() output = %q, want %q", got, want)
+	}
+}
+
+func TestVersionHelp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stdout bytes.Buffer
+	err := executeWithOutput(ctx, cancel, []string{"--help"}, &stdout)
+	if err == nil {
+		t.Fatal("executeWithOutput() error = nil, want help output")
+	}
+	for _, want := range []string{"--version", "Print the version and exit"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("executeWithOutput() help does not contain %q:\n%s", want, err)
+		}
+	}
+}
 
 func TestNormalizeURLPrefix(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

Add `--version` to `tinkerbell` and `-version` to `tink-agent` binaries, using the existing build metadata to print each binary's version and exit.

## How are existing users impacted? What migration steps/scripts do we need?

No impact, adding a new argument to show version.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
