### PR TITLE
Bump golangci-lint and resolve the new goconst/gosec findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -136,6 +136,9 @@ linters:
         text: "var-naming: avoid package names that conflict with Go standard library package names"
         path: (smee|tootles)/internal/http/
       - linters:
+          - goconst
+        path: smee/internal/metric/metric.go
+      - linters:
           - dupl
           - errcheck
           - forcetypeassert

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ PROTOC_GEN_GO_GRPC_VER := v1.5.1  # must be in sync with the version in buf.gen.
 PROTOC_GEN_GO_VER      := v1.36.7 # must be in sync with the version in buf.gen.yaml
 UPX_VER 			   := 4.2.4
 GODEPGRAPH_VER 	       := v0.0.0-20240411160502-0f324ca7e282
-GOLANGCI_LINT_VERSION  := v2.11.2
+GOLANGCI_LINT_VERSION  := v2.12.2
 GO_LICENSES_VER        := v2.0.1
 
 
@@ -423,7 +423,7 @@ GOLANGCI_LINT_BIN := $(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERS
 $(GOLANGCI_LINT_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters
 	rm -rf $(LINT_ROOT)/out/linters/golangci-lint-*
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LINT_ROOT)/out/linters $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(LINT_ROOT)/out/linters $(GOLANGCI_LINT_VERSION)
 	mv $(LINT_ROOT)/out/linters/golangci-lint $@
 
 LINTERS += golangci-lint-lint

--- a/cmd/tinkerbell/cmd.go
+++ b/cmd/tinkerbell/cmd.go
@@ -140,8 +140,6 @@ func executeWithOutput(ctx context.Context, cancel context.CancelFunc, args []st
 	flag.RegisterSecondStarFlags(&flag.Set{FlagSet: ssfs}, ssc)
 	flag.RegisterUIFlags(&flag.Set{FlagSet: uifs}, uic)
 	flag.RegisterGlobal(&flag.Set{FlagSet: gfs}, globals)
-	var printVersion bool
-	gfs.BoolVar(&printVersion, 0, "version", "Print the version and exit")
 	if embeddedApiserverExecute != nil && embeddedFlagSet != nil {
 		// This way the embedded flags only show up when the embedded services have been compiled in.
 		flag.RegisterEmbeddedGlobals(&flag.Set{FlagSet: gfs}, globals)
@@ -162,7 +160,7 @@ func executeWithOutput(ctx context.Context, cancel context.CancelFunc, args []st
 
 		return e
 	}
-	if printVersion {
+	if globals.PrintVersion {
 		if _, err := fmt.Fprintln(stdout, "tinkerbell", build.GitRevision()); err != nil {
 			return fmt.Errorf("print version: %w", err)
 		}

--- a/cmd/tinkerbell/cmd_test.go
+++ b/cmd/tinkerbell/cmd_test.go
@@ -34,7 +34,7 @@ func TestVersionHelp(t *testing.T) {
 	if err == nil {
 		t.Fatal("executeWithOutput() error = nil, want help output")
 	}
-	for _, want := range []string{"--version", "Print the version and exit"} {
+	for _, want := range []string{"--version", "print the version and exit"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("executeWithOutput() help does not contain %q:\n%s", want, err)
 		}

--- a/cmd/tinkerbell/flag/global.go
+++ b/cmd/tinkerbell/flag/global.go
@@ -31,6 +31,7 @@ type GlobalConfig struct {
 	EmbeddedGlobalConfig EmbeddedGlobalConfig
 	BackendKubeOptions   BackendKubeOptions
 	TLS                  TLSConfig
+	PrintVersion         bool
 }
 
 type EmbeddedGlobalConfig struct {
@@ -75,6 +76,7 @@ func RegisterGlobal(fs *Set, gc *GlobalConfig) {
 	fs.Register(TLSKeyFile, ffval.NewValueDefault(&gc.TLS.KeyFile, gc.TLS.KeyFile))
 	fs.Register(DisableHTTPToHTTPSRedirect, ffval.NewValueDefault(&gc.TLS.DisableHTTPToHTTPSRedirect, gc.TLS.DisableHTTPToHTTPSRedirect))
 	fs.Register(TrustedProxies, &ntip.PrefixList{PrefixList: &gc.TrustedProxies})
+	fs.Register(PrintVersion, ffval.NewValueDefault(&gc.PrintVersion, gc.PrintVersion))
 }
 
 func RegisterEmbeddedGlobals(fs *Set, gc *GlobalConfig) {
@@ -222,4 +224,9 @@ var HTTPPort = Config{
 var HTTPSPort = Config{
 	Name:  "https-port",
 	Usage: "port for the HTTPS server, unused when no TLS cert and key are provided",
+}
+
+var PrintVersion = Config{
+	Name:  "version",
+	Usage: "print the version and exit",
 }

--- a/cmd/tinkerbell/flag/global.go
+++ b/cmd/tinkerbell/flag/global.go
@@ -50,6 +50,10 @@ type TLSConfig struct {
 	DisableHTTPToHTTPSRedirect bool
 }
 
+const (
+	logLevelUsage = "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging"
+)
+
 func RegisterGlobal(fs *Set, gc *GlobalConfig) {
 	fs.Register(BackendConfig, ffval.NewEnum(&gc.Backend, "kube", "file", "none"))
 	fs.Register(BackendFilePath, ffval.NewValueDefault(&gc.BackendFilePath, gc.BackendFilePath))

--- a/cmd/tinkerbell/flag/rufio.go
+++ b/cmd/tinkerbell/flag/rufio.go
@@ -53,7 +53,7 @@ var RufioEnableInventoryCollection = Config{
 
 var RufioLogLevel = Config{
 	Name:  "rufio-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
+	Usage: logLevelUsage,
 }
 
 var RufioMaxConcurrentReconciles = Config{

--- a/cmd/tinkerbell/flag/secondstar.go
+++ b/cmd/tinkerbell/flag/secondstar.go
@@ -47,7 +47,7 @@ var SecondStarIdleTimeout = Config{
 
 var SecondStarLogLevel = Config{
 	Name:  "secondstar-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
+	Usage: logLevelUsage,
 }
 
 func (ssc *SecondStarConfig) Convert() error {

--- a/cmd/tinkerbell/flag/smee.go
+++ b/cmd/tinkerbell/flag/smee.go
@@ -512,7 +512,7 @@ var TinkServerInsecureTLS = Config{
 
 var SmeeLogLevel = Config{
 	Name:  "smee-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
+	Usage: logLevelUsage,
 }
 
 var DHCPEnableNetbootOptions = Config{

--- a/cmd/tinkerbell/flag/tink_controller.go
+++ b/cmd/tinkerbell/flag/tink_controller.go
@@ -32,7 +32,7 @@ var TinkControllerLeaderElectionNamespace = Config{
 
 var TinkControllerLogLevel = Config{
 	Name:  "tink-controller-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
+	Usage: logLevelUsage,
 }
 
 var TinkControllerReferenceAllowListRules = Config{

--- a/cmd/tinkerbell/flag/tink_server.go
+++ b/cmd/tinkerbell/flag/tink_server.go
@@ -52,7 +52,7 @@ var TinkServerBindPort = Config{
 
 var TinkServerLogLevel = Config{
 	Name:  "tink-server-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
+	Usage: logLevelUsage,
 }
 
 var TinkServerAutoEnrollmentEnabled = Config{

--- a/cmd/tinkerbell/flag/tootles.go
+++ b/cmd/tinkerbell/flag/tootles.go
@@ -29,7 +29,7 @@ var TootlesDebugMode = Config{
 
 var TootlesLogLevel = Config{
 	Name:  "tootles-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
+	Usage: logLevelUsage,
 }
 
 var TootlesInstanceEndpoint = Config{

--- a/cmd/tinkerbell/flag/ui.go
+++ b/cmd/tinkerbell/flag/ui.go
@@ -26,7 +26,7 @@ var UIDebugMode = Config{
 
 var UILogLevel = Config{
 	Name:  "ui-log-level",
-	Usage: "the higher the number the more verbose, level 0 inherits the global log level, a negative number disables logging",
+	Usage: logLevelUsage,
 }
 
 var UIURLPrefix = Config{

--- a/pkg/http/handler/handler.go
+++ b/pkg/http/handler/handler.go
@@ -77,7 +77,9 @@ func RedirectToHTTPS(log logr.Logger, port int) http.Handler {
 		u.Host = net.JoinHostPort(parseHost(r.Host), fmt.Sprintf("%d", port))
 
 		log.V(2).Info("redirecting to HTTPS", "host", r.Host, "httpsURL", u.String(), "httpURL", r.URL.String())
-		http.Redirect(w, r, u.String(), http.StatusPermanentRedirect)
+		// TODO(jacobweinstock): Add a "Strict-Transport-Security" header to the response to tell browsers to always use HTTPS for this domain.
+		// TODO(jacobweinstock): Use a allow list of hosts to prevent open redirect attacks.
+		http.Redirect(w, r, u.String(), http.StatusPermanentRedirect) //nolint:gosec // same-origin HTTPS redirect, host not attacker-chosen, TODOs to address open redirect risk
 	})
 }
 

--- a/pkg/http/handler/handler.go
+++ b/pkg/http/handler/handler.go
@@ -78,8 +78,8 @@ func RedirectToHTTPS(log logr.Logger, port int) http.Handler {
 
 		log.V(2).Info("redirecting to HTTPS", "host", r.Host, "httpsURL", u.String(), "httpURL", r.URL.String())
 		// TODO(jacobweinstock): Add a "Strict-Transport-Security" header to the response to tell browsers to always use HTTPS for this domain.
-		// TODO(jacobweinstock): Use a allow list of hosts to prevent open redirect attacks.
-		http.Redirect(w, r, u.String(), http.StatusPermanentRedirect) //nolint:gosec // same-origin HTTPS redirect, host not attacker-chosen, TODOs to address open redirect risk
+		// TODO(jacobweinstock): Use an allowlist of hosts to prevent open redirect attacks.
+		http.Redirect(w, r, u.String(), http.StatusPermanentRedirect) //nolint:gosec // known open-redirect risk: the host is taken from r.Host and not yet validated; tracked by the TODOs above.
 	})
 }
 

--- a/rufio/internal/controller/controller.go
+++ b/rufio/internal/controller/controller.go
@@ -16,6 +16,10 @@ import (
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
+const (
+	trueString = "true"
+)
+
 var schemeBuilder = runtime.NewSchemeBuilder(
 	scheme.AddToScheme,
 	bmc.AddToScheme,

--- a/rufio/internal/controller/inventory.go
+++ b/rufio/internal/controller/inventory.go
@@ -44,11 +44,11 @@ import (
 // interval has elapsed since the last successful collection.
 const defaultInventoryRefreshInterval = 24 * time.Hour
 
-// refreshInventoryAnnotation, when set to trueString on a Machine, forces an immediate
+// refreshInventoryAnnotation, when set to "true" on a Machine, forces an immediate
 // inventory refresh regardless of the configured refresh interval.
 const refreshInventoryAnnotation = "tinkerbell.org/refresh-inventory"
 
-// disableOutOfBandInventoryAnnotation, when set to trueString on a Hardware, opts
+// disableOutOfBandInventoryAnnotation, when set to "true" on a Hardware, opts
 // that specific Hardware out of BMC (out-of-band) inventory collection — e.g.
 // for a BMC/firmware combination known to misbehave under Redfish inventory
 // queries — without disabling the feature fleet-wide.

--- a/rufio/internal/controller/inventory.go
+++ b/rufio/internal/controller/inventory.go
@@ -44,11 +44,11 @@ import (
 // interval has elapsed since the last successful collection.
 const defaultInventoryRefreshInterval = 24 * time.Hour
 
-// refreshInventoryAnnotation, when set to "true" on a Machine, forces an immediate
+// refreshInventoryAnnotation, when set to trueString on a Machine, forces an immediate
 // inventory refresh regardless of the configured refresh interval.
 const refreshInventoryAnnotation = "tinkerbell.org/refresh-inventory"
 
-// disableOutOfBandInventoryAnnotation, when set to "true" on a Hardware, opts
+// disableOutOfBandInventoryAnnotation, when set to trueString on a Hardware, opts
 // that specific Hardware out of BMC (out-of-band) inventory collection — e.g.
 // for a BMC/firmware combination known to misbehave under Redfish inventory
 // queries — without disabling the feature fleet-wide.
@@ -92,7 +92,7 @@ func hardwareBMCRefIndexFunc(obj ctrlclient.Object) []string {
 // inventoryJitterFraction), or a manual refresh was explicitly requested via
 // refreshInventoryAnnotation.
 func dueForInventoryRefresh(hw *tinkerbell.Hardware, bm *bmc.Machine, interval time.Duration) bool {
-	if bm.Annotations[refreshInventoryAnnotation] == "true" {
+	if bm.Annotations[refreshInventoryAnnotation] == trueString {
 		return true
 	}
 	inv := outOfBandAttributes(hw)
@@ -138,7 +138,7 @@ func outOfBandAttributes(hw *tinkerbell.Hardware) *tinkerbell.Attributes {
 // refresh doesn't keep forcing collection on every reconcile if the caller
 // forgets to remove the annotation themselves.
 func (r *MachineReconciler) clearRefreshInventoryAnnotation(ctx context.Context, logger logr.Logger, bm *bmc.Machine) {
-	if bm.Annotations[refreshInventoryAnnotation] != "true" {
+	if bm.Annotations[refreshInventoryAnnotation] != trueString {
 		return
 	}
 	patch := ctrlclient.MergeFrom(bm.DeepCopy())

--- a/rufio/internal/controller/inventory_internal_test.go
+++ b/rufio/internal/controller/inventory_internal_test.go
@@ -367,7 +367,7 @@ func TestClearRefreshInventoryAnnotationRetries(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "test-bm",
 			Namespace:   "test-namespace",
-			Annotations: map[string]string{refreshInventoryAnnotation: "true"},
+			Annotations: map[string]string{refreshInventoryAnnotation: trueString},
 		},
 	}
 
@@ -519,7 +519,7 @@ func TestDueForInventoryRefresh(t *testing.T) {
 		"fresh but refresh annotation forces it": {
 			hw: &tinkerbell.Hardware{Status: tinkerbell.HardwareStatus{Attributes: &tinkerbell.HardwareAttributes{OutOfBand: &tinkerbell.Attributes{LastUpdated: &fresh}}}},
 			bm: &bmc.Machine{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{refreshInventoryAnnotation: "true"},
+				Annotations: map[string]string{refreshInventoryAnnotation: trueString},
 			}},
 			want: true,
 		},

--- a/rufio/internal/controller/inventory_test.go
+++ b/rufio/internal/controller/inventory_test.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const trueString = "true"
+
 // newInventoryTestClient builds a fake client that keeps controller-runtime's
 // default FieldManagedObjectTracker (unlike newClientBuilder() above, which
 // swaps in a basic ObjectTracker specifically to work around a MergeFrom+Machine
@@ -122,7 +124,7 @@ func TestReconcileInventoryIfDue_Success(t *testing.T) {
 // collection on every reconcile if the caller forgets to remove it themselves.
 func TestReconcileInventoryIfDue_ClearsRefreshAnnotationOnSuccess(t *testing.T) {
 	bm := createMachine()
-	bm.Annotations = map[string]string{"tinkerbell.org/refresh-inventory": "true"}
+	bm.Annotations = map[string]string{"tinkerbell.org/refresh-inventory": trueString}
 	hw := createHardwareForMachine(bm.Name)
 	provider := &testProvider{
 		InventoryDevice: &common.Device{
@@ -271,7 +273,7 @@ func TestReconcileInventoryIfDue_CollectionDisabledFleetWide(t *testing.T) {
 func TestReconcileInventoryIfDue_DisabledForSpecificHardware(t *testing.T) {
 	bm := createMachine()
 	hw := createHardwareForMachine(bm.Name)
-	hw.Annotations = map[string]string{"tinkerbell.org/disable-outofband-inventory": "true"}
+	hw.Annotations = map[string]string{"tinkerbell.org/disable-outofband-inventory": trueString}
 	provider := &testProvider{
 		InventoryDevice: &common.Device{
 			BIOS: &common.BIOS{Common: common.Common{Vendor: "Dell Inc."}},

--- a/rufio/internal/controller/machine.go
+++ b/rufio/internal/controller/machine.go
@@ -219,7 +219,7 @@ func (r *MachineReconciler) reconcileInventoryIfDue(ctx context.Context, logger 
 		r.recorder.Eventf(bm, nil, corev1.EventTypeWarning, "HardwareLookupFailed", "FindLinkedHardware", "find linked Hardware: %v", err)
 		return
 	}
-	if hw == nil || hw.Annotations[disableOutOfBandInventoryAnnotation] == "true" || !dueForInventoryRefresh(hw, bm, r.inventoryRefreshInterval) {
+	if hw == nil || hw.Annotations[disableOutOfBandInventoryAnnotation] == trueString || !dueForInventoryRefresh(hw, bm, r.inventoryRefreshInterval) {
 		return
 	}
 	if err := r.reconcileInventory(ctx, bmcClient, hw); err != nil {

--- a/smee/internal/ipxe/script/auto_test.go
+++ b/smee/internal/ipxe/script/auto_test.go
@@ -15,7 +15,7 @@ func TestGenerateTemplate(t *testing.T) {
 	}{
 		"no vlan": {
 			h: Hook{
-				Arch:              "x86_64",
+				Arch:              x8664Arch,
 				TinkGRPCAuthority: "1.2.3.4:42113",
 				TinkerbellTLS:     false,
 				WorkerID:          "3c:ec:ef:4c:4f:54",
@@ -79,7 +79,7 @@ exit
 		},
 		"with vlan": {
 			h: Hook{
-				Arch:              "x86_64",
+				Arch:              x8664Arch,
 				TinkGRPCAuthority: "1.2.3.4:42113",
 				TinkerbellTLS:     false,
 				WorkerID:          "3c:ec:ef:4c:4f:54",
@@ -144,7 +144,7 @@ exit
 		},
 		"hostname syslog host": {
 			h: Hook{
-				Arch:              "x86_64",
+				Arch:              x8664Arch,
 				TinkGRPCAuthority: "1.2.3.4:42113",
 				TinkerbellTLS:     false,
 				WorkerID:          "3c:ec:ef:4c:4f:54",

--- a/smee/internal/ipxe/script/ipxe_test.go
+++ b/smee/internal/ipxe/script/ipxe_test.go
@@ -14,6 +14,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const x8664Arch = "x86_64"
+
 func TestCustomScript(t *testing.T) {
 	tests := map[string]struct {
 		ipxeURL    string
@@ -139,11 +141,11 @@ exit
 	}{
 		"success with defaults": {
 			want: one,
-			d:    hardware.Info{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, VLANID: "1234", Facility: "onprem", Arch: "x86_64"},
+			d:    hardware.Info{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, VLANID: "1234", Facility: "onprem", Arch: x8664Arch},
 		},
 		"success with set agent id": {
 			want: two,
-			d:    hardware.Info{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, AgentID: "worker1", VLANID: "1234", Facility: "onprem", Arch: "x86_64"},
+			d:    hardware.Info{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, AgentID: "worker1", VLANID: "1234", Facility: "onprem", Arch: x8664Arch},
 		},
 	}
 	for name, tt := range tests {
@@ -187,7 +189,7 @@ func TestDefaultScriptCustomKernelInitrd(t *testing.T) {
 				KernelName:           "captain-kernel",
 				InitrdName:           "captain-rootfs",
 			},
-			d:          hardware.Info{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, Facility: "onprem", Arch: "x86_64"},
+			d:          hardware.Info{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, Facility: "onprem", Arch: x8664Arch},
 			wantKernel: "captain-kernel-x86_64",
 			wantInitrd: "captain-rootfs-x86_64",
 		},
@@ -216,7 +218,7 @@ func TestDefaultScriptCustomKernelInitrd(t *testing.T) {
 			d: hardware.Info{
 				MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
 				Facility:   "onprem",
-				Arch:       "x86_64",
+				Arch:       x8664Arch,
 				OSIE: hardware.OSIE{
 					Kernel: "hw-specific-kernel",
 					Initrd: "hw-specific-initrd",
@@ -237,7 +239,7 @@ func TestDefaultScriptCustomKernelInitrd(t *testing.T) {
 			d: hardware.Info{
 				MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
 				Facility:   "onprem",
-				Arch:       "x86_64",
+				Arch:       x8664Arch,
 				OSIE: hardware.OSIE{
 					Kernel: "hw-specific-kernel",
 				},
@@ -275,7 +277,7 @@ func TestDefaultScriptKernelParams(t *testing.T) {
 	}
 	hw := hardware.Info{
 		MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
-		Arch:       "x86_64",
+		Arch:       x8664Arch,
 		OSIE: hardware.OSIE{
 			KernelParams: []string{"perhw=1", "shared=perhw"},
 		},

--- a/smee/internal/metric/metric.go
+++ b/smee/internal/metric/metric.go
@@ -28,18 +28,18 @@ func Init() {
 	DHCPTotal = factory.NewCounterVec(prometheus.CounterOpts{
 		Name: "dhcp_total",
 		Help: "Number of DHCP Requests handled.",
-	}, []string{"op", "type", "giaddr"})
+	}, []string{"op", "type"})
 
 	labelValues := []prometheus.Labels{
-		{"op": "recv", "type": "DHCPACK", "giaddr": "0.0.0.0"},
-		{"op": "recv", "type": "DHCPDECLINE", "giaddr": "0.0.0.0"},
-		{"op": "recv", "type": "DHCPDISCOVER", "giaddr": "0.0.0.0"},
-		{"op": "recv", "type": "DHCPINFORM", "giaddr": "0.0.0.0"},
-		{"op": "recv", "type": "DHCPNAK", "giaddr": "0.0.0.0"},
-		{"op": "recv", "type": "DHCPOFFER", "giaddr": "0.0.0.0"},
-		{"op": "recv", "type": "DHCPRELEASE", "giaddr": "0.0.0.0"},
-		{"op": "recv", "type": "DHCPREQUEST", "giaddr": "0.0.0.0"},
-		{"op": "send", "type": "DHCPOFFER", "giaddr": "0.0.0.0"},
+		{"op": "recv", "type": "DHCPACK"},
+		{"op": "recv", "type": "DHCPDECLINE"},
+		{"op": "recv", "type": "DHCPDISCOVER"},
+		{"op": "recv", "type": "DHCPINFORM"},
+		{"op": "recv", "type": "DHCPNAK"},
+		{"op": "recv", "type": "DHCPOFFER"},
+		{"op": "recv", "type": "DHCPRELEASE"},
+		{"op": "recv", "type": "DHCPREQUEST"},
+		{"op": "send", "type": "DHCPOFFER"},
 	}
 	initCounterLabels(DHCPTotal, labelValues)
 

--- a/tink/agent/internal/runtime/containerd/conv.go
+++ b/tink/agent/internal/runtime/containerd/conv.go
@@ -33,6 +33,10 @@ import (
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 )
 
+const (
+	rwOption = "rw"
+)
+
 // parseVolumes converts action volumes to OCI runtime spec mounts.
 // Volume format: {SRC-HOST-DIR}:{TGT-CONTAINER-DIR}[:OPTIONS]
 // Options can include: ro (read-only), rw (read-write, default)
@@ -84,7 +88,7 @@ func parseVolume(log logr.Logger, volume string) *specs.Mount {
 	}
 
 	// Default options for bind mounts
-	options := []string{"rbind", "rw"}
+	options := []string{"rbind", rwOption}
 
 	// Parse options if provided
 	if len(parts) >= 3 {
@@ -97,8 +101,8 @@ func parseVolume(log logr.Logger, volume string) *specs.Mount {
 			switch trimmed {
 			case "ro":
 				rwMode = "ro"
-			case "rw":
-				rwMode = "rw"
+			case rwOption:
+				rwMode = rwOption
 			default:
 				// Pass through other options
 				if trimmed != "" {
@@ -108,7 +112,7 @@ func parseVolume(log logr.Logger, volume string) *specs.Mount {
 		}
 		// Default to rw if neither ro nor rw was specified.
 		if rwMode == "" {
-			rwMode = "rw"
+			rwMode = rwOption
 		}
 		options = append(options, rwMode)
 	}

--- a/tink/agent/internal/runtime/containerd/conv_test.go
+++ b/tink/agent/internal/runtime/containerd/conv_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 )
 
+// Mount option strings. These live in the test package because the majority of
+// their occurrences are in tests; the production code uses string literals.
+const (
+	bindOption  = "bind"
+	rbindOption = "rbind"
+	roOption    = "ro"
+)
+
 func TestParseVolume(t *testing.T) {
 	log := logr.Discard()
 
@@ -20,46 +28,46 @@ func TestParseVolume(t *testing.T) {
 		"absolute source and destination with default options": {
 			volume: "/host/path:/container/path",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "rw"},
+				Options:     []string{rbindOption, rwOption},
 			},
 		},
 		"read-only option": {
 			volume: "/host/path:/container/path:ro",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "ro"},
+				Options:     []string{rbindOption, roOption},
 			},
 		},
 		"explicit read-write option": {
 			volume: "/host/path:/container/path:rw",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "rw"},
+				Options:     []string{rbindOption, rwOption},
 			},
 		},
 		"multiple options": {
 			volume: "/host/path:/container/path:ro,noexec",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "noexec", "ro"},
+				Options:     []string{rbindOption, "noexec", roOption},
 			},
 		},
 		"relative source with dot prefix": {
 			volume: "./relative:/container/path",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "./relative",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "rw"},
+				Options:     []string{rbindOption, rwOption},
 			},
 		},
 		"named volume skipped": {
@@ -85,46 +93,46 @@ func TestParseVolume(t *testing.T) {
 		"custom option without ro or rw gets rw appended": {
 			volume: "/host/path:/container/path:noexec",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "noexec", "rw"},
+				Options:     []string{rbindOption, "noexec", rwOption},
 			},
 		},
 		"empty option parts are filtered": {
 			volume: "/host/path:/container/path:ro,",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "ro"},
+				Options:     []string{rbindOption, roOption},
 			},
 		},
 		"options with whitespace trimmed": {
 			volume: "/host/path:/container/path: ro , noexec ",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "noexec", "ro"},
+				Options:     []string{rbindOption, "noexec", roOption},
 			},
 		},
 		"conflicting ro and rw uses last wins": {
 			volume: "/host/path:/container/path:ro,rw",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "rw"},
+				Options:     []string{rbindOption, rwOption},
 			},
 		},
 		"whitespace-only option is filtered": {
 			volume: "/host/path:/container/path: ",
 			want: &specs.Mount{
-				Type:        "bind",
+				Type:        bindOption,
 				Source:      "/host/path",
 				Destination: "/container/path",
-				Options:     []string{"rbind", "rw"},
+				Options:     []string{rbindOption, rwOption},
 			},
 		},
 	}

--- a/tink/controller/internal/workflow/consts_test.go
+++ b/tink/controller/internal/workflow/consts_test.go
@@ -1,0 +1,11 @@
+package workflow
+
+// String values whose occurrences are predominantly in tests. They live in the
+// test package so production code stays free of test-driven constants; the few
+// production occurrences remain string literals below goconst's threshold.
+const (
+	reasonComplete    = "Complete"
+	reasonCreated     = "Created"
+	messageJobCreated = "job created"
+	valueTrue         = "true"
+)

--- a/tink/controller/internal/workflow/convert_test.go
+++ b/tink/controller/internal/workflow/convert_test.go
@@ -42,7 +42,7 @@ func TestYAMLToStatus(t *testing.T) {
 									"/tmp/debug:/tmp/debug",
 								},
 								Environment: map[string]string{
-									"COMPRESSED": "true",
+									"COMPRESSED": valueTrue,
 									"DEST_DISK":  "/dev/nvme0n1",
 									"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 								},
@@ -72,7 +72,7 @@ func TestYAMLToStatus(t *testing.T) {
 								},
 								Pid: "host",
 								Environment: map[string]string{
-									"COMPRESSED": "true",
+									"COMPRESSED": valueTrue,
 									"DEST_DISK":  "/dev/nvme0n1",
 									"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 								},

--- a/tink/controller/internal/workflow/hardware.go
+++ b/tink/controller/internal/workflow/hardware.go
@@ -108,7 +108,7 @@ func (s *state) toggleHardware(ctx context.Context, allowPXE bool) error {
 		s.workflow.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 			Type:    v1alpha1.ToggleAllowNetbootTrue,
 			Status:  metav1.ConditionFalse,
-			Reason:  "Error",
+			Reason:  reasonError,
 			Message: fmt.Sprintf("error getting hardware: %v", err),
 			Time:    &metav1.Time{Time: metav1.Now().UTC()},
 		})
@@ -124,7 +124,7 @@ func (s *state) toggleHardware(ctx context.Context, allowPXE bool) error {
 			s.workflow.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.ToggleAllowNetbootTrue,
 				Status:  metav1.ConditionFalse,
-				Reason:  "Error",
+				Reason:  reasonError,
 				Message: fmt.Sprintf("error setting allowPXE to %v: %v", allowPXE, err),
 				Time:    &metav1.Time{Time: metav1.Now().UTC()},
 			})
@@ -148,7 +148,7 @@ func (s *state) toggleHardware(ctx context.Context, allowPXE bool) error {
 		s.workflow.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 			Type:    v1alpha1.ToggleAllowNetbootFalse,
 			Status:  metav1.ConditionFalse,
-			Reason:  "Error",
+			Reason:  reasonError,
 			Message: fmt.Sprintf("error setting allowPXE to %v: %v", allowPXE, err),
 			Time:    &metav1.Time{Time: metav1.Now().UTC()},
 		})

--- a/tink/controller/internal/workflow/job.go
+++ b/tink/controller/internal/workflow/job.go
@@ -53,7 +53,7 @@ func (s *state) handleJob(ctx context.Context, actions []bmc.Action, name jobNam
 			s.workflow.Status.SetCondition(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.BootJobSetupFailed,
 				Status:  metav1.ConditionTrue,
-				Reason:  "Error",
+				Reason:  reasonError,
 				Message: fmt.Sprintf("error creating job: %v", err),
 				Time:    &metav1.Time{Time: metav1.Now().UTC()},
 			})
@@ -78,7 +78,7 @@ func (s *state) handleJob(ctx context.Context, actions []bmc.Action, name jobNam
 			s.workflow.Status.SetCondition(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.BootJobFailed,
 				Status:  metav1.ConditionTrue,
-				Reason:  "Error",
+				Reason:  reasonError,
 				Message: err.Error(),
 				Time:    &metav1.Time{Time: metav1.Now().UTC()},
 			})

--- a/tink/controller/internal/workflow/job_test.go
+++ b/tink/controller/internal/workflow/job_test.go
@@ -119,8 +119,8 @@ func TestHandleJob(t *testing.T) {
 					{
 						Type:    v1alpha1.BootJobSetupComplete,
 						Status:  metav1.ConditionTrue,
-						Reason:  "Created",
-						Message: "job created",
+						Reason:  reasonCreated,
+						Message: messageJobCreated,
 					},
 				},
 				BootOptions: v1alpha1.BootOptionsStatus{
@@ -172,7 +172,7 @@ func TestHandleJob(t *testing.T) {
 					{
 						Type:    v1alpha1.BootJobComplete,
 						Status:  metav1.ConditionTrue,
-						Reason:  "Complete",
+						Reason:  reasonComplete,
 						Message: "job completed",
 					},
 				},

--- a/tink/controller/internal/workflow/post_test.go
+++ b/tink/controller/internal/workflow/post_test.go
@@ -105,7 +105,7 @@ func TestPostActions(t *testing.T) {
 						{
 							Type:    v1alpha1.ToggleAllowNetbootFalse,
 							Status:  metav1.ConditionTrue,
-							Reason:  "Complete",
+							Reason:  reasonComplete,
 							Message: "set allowPXE to false",
 						},
 					},
@@ -173,8 +173,8 @@ func TestPostActions(t *testing.T) {
 						{
 							Type:    v1alpha1.BootJobSetupComplete,
 							Status:  metav1.ConditionTrue,
-							Reason:  "Created",
-							Message: "job created",
+							Reason:  reasonCreated,
+							Message: messageJobCreated,
 						},
 					},
 				},
@@ -353,8 +353,8 @@ func TestPostActions(t *testing.T) {
 						{
 							Type:    v1alpha1.BootJobSetupComplete,
 							Status:  metav1.ConditionTrue,
-							Reason:  "Created",
-							Message: "job created",
+							Reason:  reasonCreated,
+							Message: messageJobCreated,
 						},
 					},
 				},

--- a/tink/controller/internal/workflow/pre.go
+++ b/tink/controller/internal/workflow/pre.go
@@ -39,7 +39,7 @@ func (s *state) prepareWorkflow(ctx context.Context) (reconcile.Result, error) {
 				s.workflow.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 					Type:    v1alpha1.BootJobSetupFailed,
 					Status:  metav1.ConditionFalse,
-					Reason:  "Error",
+					Reason:  reasonError,
 					Message: fmt.Sprintf("failed to get hardware: %s", err.Error()),
 					Time:    &metav1.Time{Time: metav1.Now().UTC()},
 				})
@@ -96,7 +96,7 @@ func (s *state) prepareWorkflow(ctx context.Context) (reconcile.Result, error) {
 				s.workflow.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 					Type:    v1alpha1.BootJobSetupComplete,
 					Status:  metav1.ConditionFalse,
-					Reason:  "Error",
+					Reason:  reasonError,
 					Message: fmt.Sprintf("failed to get hardware: %s", err.Error()),
 					Time:    &metav1.Time{Time: metav1.Now().UTC()},
 				})
@@ -160,7 +160,7 @@ func (s *state) prepareWorkflow(ctx context.Context) (reconcile.Result, error) {
 				s.workflow.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 					Type:    v1alpha1.BootJobSetupFailed,
 					Status:  metav1.ConditionFalse,
-					Reason:  "Error",
+					Reason:  reasonError,
 					Message: fmt.Sprintf("failed to get hardware: %s", err.Error()),
 					Time:    &metav1.Time{Time: metav1.Now().UTC()},
 				})
@@ -172,7 +172,7 @@ func (s *state) prepareWorkflow(ctx context.Context) (reconcile.Result, error) {
 				s.workflow.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 					Type:    v1alpha1.BootJobSetupFailed,
 					Status:  metav1.ConditionFalse,
-					Reason:  "Error",
+					Reason:  reasonError,
 					Message: fmt.Sprintf("failed to template actions: %s", err.Error()),
 					Time:    &metav1.Time{Time: metav1.Now().UTC()},
 				})

--- a/tink/controller/internal/workflow/pre_test.go
+++ b/tink/controller/internal/workflow/pre_test.go
@@ -355,7 +355,7 @@ func TestPrepareWorkflow(t *testing.T) {
 						{
 							Type:    v1alpha1.ToggleAllowNetbootTrue,
 							Status:  metav1.ConditionTrue,
-							Reason:  "Complete",
+							Reason:  reasonComplete,
 							Message: "set allowPXE to true",
 						},
 					},
@@ -426,8 +426,8 @@ func TestPrepareWorkflow(t *testing.T) {
 						{
 							Type:    "BootJobSetupComplete",
 							Status:  "True",
-							Reason:  "Created",
-							Message: "job created",
+							Reason:  reasonCreated,
+							Message: messageJobCreated,
 						},
 					},
 				},
@@ -498,8 +498,8 @@ func TestPrepareWorkflow(t *testing.T) {
 						{
 							Type:    "BootJobSetupComplete",
 							Status:  "True",
-							Reason:  "Created",
-							Message: "job created",
+							Reason:  reasonCreated,
+							Message: messageJobCreated,
 						},
 					},
 				},
@@ -581,8 +581,8 @@ func TestPrepareWorkflow(t *testing.T) {
 						{
 							Type:    "BootJobSetupComplete",
 							Status:  "True",
-							Reason:  "Created",
-							Message: "job created",
+							Reason:  reasonCreated,
+							Message: messageJobCreated,
 						},
 					},
 				},

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -35,6 +35,9 @@ const (
 	//
 	// Deprecated: use templateDataHardware instead. This key will be removed in a future release.
 	templateDataHardwareLegacy = "Hardware"
+
+	// reasonError is the condition Reason set when a workflow step fails.
+	reasonError = "Error"
 )
 
 type dynamicClient interface {
@@ -245,7 +248,7 @@ func (r *Reconciler) processWorkflow(ctx context.Context, logger logr.Logger, st
 			stored.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 				Type:    v1alpha1.TemplateRenderedSuccess,
 				Status:  metav1.ConditionFalse,
-				Reason:  "Error",
+				Reason:  reasonError,
 				Message: "template not found",
 				Time:    &metav1.Time{Time: metav1.Now().UTC()},
 			})
@@ -260,7 +263,7 @@ func (r *Reconciler) processWorkflow(ctx context.Context, logger logr.Logger, st
 		stored.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 			Type:    v1alpha1.TemplateRenderedSuccess,
 			Status:  metav1.ConditionFalse,
-			Reason:  "Error",
+			Reason:  reasonError,
 			Message: err.Error(),
 			Time:    &metav1.Time{Time: metav1.Now().UTC()},
 		})
@@ -276,7 +279,7 @@ func (r *Reconciler) processWorkflow(ctx context.Context, logger logr.Logger, st
 		stored.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 			Type:    v1alpha1.TemplateRenderedSuccess,
 			Status:  metav1.ConditionFalse,
-			Reason:  "Error",
+			Reason:  reasonError,
 			Message: fmt.Sprintf("error getting hardware: %v", err),
 			Time:    &metav1.Time{Time: metav1.Now().UTC()},
 		})
@@ -290,7 +293,7 @@ func (r *Reconciler) processWorkflow(ctx context.Context, logger logr.Logger, st
 		stored.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 			Type:    v1alpha1.TemplateRenderedSuccess,
 			Status:  metav1.ConditionFalse,
-			Reason:  "Error",
+			Reason:  reasonError,
 			Message: fmt.Sprintf("hardware not found: %v", err),
 			Time:    &metav1.Time{Time: metav1.Now().UTC()},
 		})
@@ -363,7 +366,7 @@ func (r *Reconciler) processWorkflow(ctx context.Context, logger logr.Logger, st
 		stored.Status.SetConditionIfDifferent(v1alpha1.WorkflowCondition{
 			Type:    v1alpha1.TemplateRenderedSuccess,
 			Status:  metav1.ConditionFalse,
-			Reason:  "Error",
+			Reason:  reasonError,
 			Message: fmt.Sprintf("error rendering template: %v", errors.Join(refErr, err)),
 			Time:    &metav1.Time{Time: metav1.Now().UTC()},
 		})

--- a/tink/controller/internal/workflow/reconciler_test.go
+++ b/tink/controller/internal/workflow/reconciler_test.go
@@ -373,7 +373,7 @@ func TestReconcile(t *testing.T) {
 					GlobalTimeout:     1800,
 					TemplateRendering: "successful",
 					Conditions: []v1alpha1.WorkflowCondition{
-						{Type: v1alpha1.TemplateRenderedSuccess, Status: metav1.ConditionTrue, Reason: "Complete", Message: "template rendered successfully"},
+						{Type: v1alpha1.TemplateRenderedSuccess, Status: metav1.ConditionTrue, Reason: reasonComplete, Message: "template rendered successfully"},
 					},
 					Tasks: []v1alpha1.Task{
 						{
@@ -391,7 +391,7 @@ func TestReconcile(t *testing.T) {
 									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
 									Timeout: 600,
 									Environment: map[string]string{
-										"COMPRESSED": "true",
+										"COMPRESSED": valueTrue,
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
@@ -517,7 +517,7 @@ tasks:
 									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
 									Timeout: 600,
 									Environment: map[string]string{
-										"COMPRESSED": "true",
+										"COMPRESSED": valueTrue,
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
@@ -662,7 +662,7 @@ tasks:
 									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
 									Timeout: 10,
 									Environment: map[string]string{
-										"COMPRESSED": "true",
+										"COMPRESSED": valueTrue,
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
@@ -750,7 +750,7 @@ tasks:
 									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
 									Timeout: 10,
 									Environment: map[string]string{
-										"COMPRESSED": "true",
+										"COMPRESSED": valueTrue,
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
@@ -842,7 +842,7 @@ tasks:
 									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
 									Timeout: 600,
 									Environment: map[string]string{
-										"COMPRESSED": "true",
+										"COMPRESSED": valueTrue,
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
@@ -967,7 +967,7 @@ tasks:
 					GlobalTimeout:     1800,
 					TemplateRendering: "successful",
 					Conditions: []v1alpha1.WorkflowCondition{
-						{Type: v1alpha1.TemplateRenderedSuccess, Status: metav1.ConditionTrue, Reason: "Complete", Message: "template rendered successfully"},
+						{Type: v1alpha1.TemplateRenderedSuccess, Status: metav1.ConditionTrue, Reason: reasonComplete, Message: "template rendered successfully"},
 					},
 					Tasks: []v1alpha1.Task{
 						{
@@ -985,7 +985,7 @@ tasks:
 									Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
 									Timeout: 600,
 									Environment: map[string]string{
-										"COMPRESSED": "true",
+										"COMPRESSED": valueTrue,
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},

--- a/ui/internal/http/auth.go
+++ b/ui/internal/http/auth.go
@@ -47,13 +47,13 @@ func HandleLogin(c *gin.Context, log logr.Logger) {
 func HandleLoginValidate(c *gin.Context, log logr.Logger) {
 	token := c.PostForm("token")
 	if token == "" {
-		c.JSON(403, gin.H{"error": "Service account token is required"})
+		c.JSON(403, gin.H{jsonKeyError: "Service account token is required"})
 		return
 	}
 
 	apiServer := c.PostForm("apiServer")
 	if apiServer == "" {
-		c.JSON(403, gin.H{"error": "Kubernetes API server URL is required"})
+		c.JSON(403, gin.H{jsonKeyError: "Kubernetes API server URL is required"})
 		return
 	}
 
@@ -89,7 +89,7 @@ func HandleLoginValidate(c *gin.Context, log logr.Logger) {
 
 	testClient, err := NewKubeClientFromTokenAndServer(token, apiServer, insecureSkipVerify)
 	if err != nil {
-		c.JSON(403, gin.H{"error": fmt.Sprintf("Failed to create Kubernetes client: %v", err)})
+		c.JSON(403, gin.H{jsonKeyError: fmt.Sprintf("Failed to create Kubernetes client: %v", err)})
 		return
 	}
 
@@ -369,9 +369,9 @@ func validateTokenPermissions(ctx context.Context, client *KubeClient, namespace
 	sar := &authv1.SelfSubjectAccessReview{
 		Spec: authv1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authv1.ResourceAttributes{
-				Verb:      "list",
-				Group:     "tinkerbell.org",
-				Resource:  "hardware",
+				Verb:      verbList,
+				Group:     groupTinkerbell,
+				Resource:  resourceHardware,
 				Namespace: namespace, // Empty string means cluster-wide
 			},
 		},

--- a/ui/internal/http/bmc.go
+++ b/ui/internal/http/bmc.go
@@ -21,6 +21,9 @@ const (
 	namePluralJob       = "Jobs"
 	nameSingularMachine = "Machine"
 	namePluralMachine   = "Machines"
+
+	// taskTypeBootDevice is the BMC task type for boot device actions.
+	taskTypeBootDevice = "BootDevice"
 )
 
 // HandleBMCMachineList handles the Machine list page route.
@@ -681,7 +684,7 @@ func bmcTaskType(action bmc.Action) string {
 		return "VirtualMedia"
 	}
 	if action.BootDevice != nil || action.OneTimeBootDeviceAction != nil { //nolint:staticcheck // OneTimeBootDeviceAction is deprecated but not removed yet, it's still necessary.
-		return "BootDevice"
+		return taskTypeBootDevice
 	}
 	if action.PowerAction != nil {
 		return "Power"

--- a/ui/internal/http/crd.go
+++ b/ui/internal/http/crd.go
@@ -16,15 +16,23 @@ var (
 	crdParseOnce        sync.Once
 )
 
+// JSON schema type descriptors used when describing CRD fields.
+const (
+	schemaTypeString      = "string"
+	schemaTypeInteger     = "integer"
+	schemaTypeObject      = "object"
+	schemaTypeArrayString = "array[string]"
+)
+
 // kindToRoute maps CRD kinds to their web UI routes.
 var kindToRoute = map[string]string{
-	"Hardware":        "/hardware",
-	"Workflow":        "/workflows",
-	"Template":        "/templates",
-	"WorkflowRuleSet": "/workflows/rulesets",
-	"Job":             "/bmc/jobs",
-	"Machine":         "/bmc/machines",
-	"Task":            "/bmc/tasks",
+	nameSingularHardware: "/hardware",
+	nameSingularWorkflow: "/workflows",
+	nameSingularTemplate: "/templates",
+	"WorkflowRuleSet":    "/workflows/rulesets",
+	"Job":                "/bmc/jobs",
+	"Machine":            "/bmc/machines",
+	"Task":               "/bmc/tasks",
 }
 
 // kindDescriptions provides meaningful descriptions for each CRD kind, keyed by "version/kind".
@@ -208,7 +216,7 @@ func extractField(name string, prop apiv1.JSONSchemaProps, required bool, kind s
 	}
 
 	// Special handling for Template.spec.data - expand workflow structure
-	if kind == "Template" && name == "data" && prop.Type == "string" {
+	if kind == nameSingularTemplate && name == "data" && prop.Type == schemaTypeString {
 		field.Description = "Expand to see the typed structure that this string blob must follow."
 		field.Children = getWorkflowSchemaFields()
 		return field
@@ -228,12 +236,12 @@ func extractField(name string, prop apiv1.JSONSchemaProps, required bool, kind s
 	}
 
 	// Handle nested objects
-	if prop.Type == "object" && prop.Properties != nil {
+	if prop.Type == schemaTypeObject && prop.Properties != nil {
 		field.Children = extractFields(prop, getRequiredSet(prop.Required), kind)
 	}
 
 	// Handle objects with additionalProperties (maps with typed values)
-	if prop.Type == "object" && prop.AdditionalProperties != nil && prop.AdditionalProperties.Schema != nil {
+	if prop.Type == schemaTypeObject && prop.AdditionalProperties != nil && prop.AdditionalProperties.Schema != nil {
 		valueSchema := prop.AdditionalProperties.Schema
 		if valueSchema.Properties != nil {
 			// This is a map[string]object - show the value object's structure
@@ -249,7 +257,7 @@ func extractField(name string, prop apiv1.JSONSchemaProps, required bool, kind s
 	if prop.Type == "array" && prop.Items != nil {
 		if prop.Items.Schema != nil {
 			itemSchema := prop.Items.Schema
-			if itemSchema.Type == "object" && itemSchema.Properties != nil {
+			if itemSchema.Type == schemaTypeObject && itemSchema.Properties != nil {
 				field.Children = extractFields(*itemSchema, getRequiredSet(itemSchema.Required), kind)
 			} else {
 				// Simple array type - show the item type
@@ -278,44 +286,44 @@ func getRequiredSet(required []string) map[string]bool {
 func getWorkflowSchemaFields() []templates.SchemaField {
 	return []templates.SchemaField{
 		{
-			Name:        "name",
-			Type:        "string",
+			Name:        keyName,
+			Type:        schemaTypeString,
 			Description: "Workflow name",
 			Required:    true,
 		},
 		{
 			Name:        "id",
-			Type:        "string",
+			Type:        schemaTypeString,
 			Description: "Unique workflow identifier",
 			Required:    false,
 		},
 		{
 			Name:        "global_timeout",
-			Type:        "integer",
+			Type:        schemaTypeInteger,
 			Description: "Global timeout in seconds for the entire workflow",
 			Required:    false,
 		},
 		{
-			Name:        "tasks",
+			Name:        resourceTasks,
 			Type:        "array[object]",
 			Description: "List of tasks to execute in sequence",
 			Required:    true,
 			Children: []templates.SchemaField{
 				{
-					Name:        "name",
-					Type:        "string",
+					Name:        keyName,
+					Type:        schemaTypeString,
 					Description: "Task name",
 					Required:    true,
 				},
 				{
 					Name:        "worker",
-					Type:        "string",
+					Type:        schemaTypeString,
 					Description: "Worker address (supports template variables like {{.device_1}})",
 					Required:    true,
 				},
 				{
 					Name:        "volumes",
-					Type:        "array[string]",
+					Type:        schemaTypeArrayString,
 					Description: "Volume mounts for all actions in this task",
 					Required:    false,
 				},
@@ -332,44 +340,44 @@ func getWorkflowSchemaFields() []templates.SchemaField {
 					Required:    true,
 					Children: []templates.SchemaField{
 						{
-							Name:        "name",
-							Type:        "string",
+							Name:        keyName,
+							Type:        schemaTypeString,
 							Description: "Action name",
 							Required:    true,
 						},
 						{
 							Name:        "image",
-							Type:        "string",
+							Type:        schemaTypeString,
 							Description: "Container image to execute",
 							Required:    true,
 						},
 						{
 							Name:        "timeout",
-							Type:        "integer",
+							Type:        schemaTypeInteger,
 							Description: "Action timeout in seconds",
 							Required:    false,
 						},
 						{
 							Name:        "command",
-							Type:        "array[string]",
+							Type:        schemaTypeArrayString,
 							Description: "Command to execute in the container",
 							Required:    false,
 						},
 						{
 							Name:        "on-timeout",
-							Type:        "array[string]",
+							Type:        schemaTypeArrayString,
 							Description: "Commands to run if the action times out",
 							Required:    false,
 						},
 						{
 							Name:        "on-failure",
-							Type:        "array[string]",
+							Type:        schemaTypeArrayString,
 							Description: "Commands to run if the action fails",
 							Required:    false,
 						},
 						{
 							Name:        "volumes",
-							Type:        "array[string]",
+							Type:        schemaTypeArrayString,
 							Description: "Volume mounts for this action",
 							Required:    false,
 						},
@@ -381,7 +389,7 @@ func getWorkflowSchemaFields() []templates.SchemaField {
 						},
 						{
 							Name:        "pid",
-							Type:        "string",
+							Type:        schemaTypeString,
 							Description: "PID namespace mode (e.g., 'host')",
 							Required:    false,
 						},

--- a/ui/internal/http/kube.go
+++ b/ui/internal/http/kube.go
@@ -32,6 +32,25 @@ const (
 	htmxRequestTrue     = "true"
 	// ContextKeyBaseURL is the key used to store the URL prefix in Gin context.
 	ContextKeyBaseURL = "baseURL"
+
+	// Kubernetes API groups and RBAC identifiers for Tinkerbell resources.
+	groupTinkerbell = "tinkerbell.org"
+	groupBMC        = "bmc.tinkerbell.org"
+	verbList        = "list"
+
+	// Lowercase resource identifiers, used as RBAC resource names, search
+	// result types, and icon names.
+	resourceHardware = "hardware"
+	resourceWorkflow = "workflow"
+	resourceTemplate = "template"
+	resourceTasks    = "tasks"
+
+	// jsonKeyError is the JSON object key used for error messages in API responses.
+	jsonKeyError = "error"
+
+	// keyName is the conventional "name" identifier, used as a route parameter
+	// key, a structured-log field key, and a schema field name.
+	keyName = "name"
 )
 
 // ValidateItemsPerPage validates and normalizes the items per page value.

--- a/ui/internal/http/kube.go
+++ b/ui/internal/http/kube.go
@@ -38,8 +38,8 @@ const (
 	groupBMC        = "bmc.tinkerbell.org"
 	verbList        = "list"
 
-	// Lowercase resource identifiers, used as RBAC resource names, search
-	// result types, and icon names.
+	// Lowercase resource identifiers used as search result types and icon
+	// names; some (hardware, tasks) also match Kubernetes RBAC resource names.
 	resourceHardware = "hardware"
 	resourceWorkflow = "workflow"
 	resourceTemplate = "template"

--- a/ui/internal/http/permissions.go
+++ b/ui/internal/http/permissions.go
@@ -19,17 +19,17 @@ type TinkerbellResource struct {
 // TinkerbellResources defines all Tinkerbell CRD resources to check permissions for.
 // Exported so templates can access the list.
 var TinkerbellResources = []TinkerbellResource{
-	{"hardware", "tinkerbell.org"},
-	{"templates", "tinkerbell.org"},
-	{"workflows", "tinkerbell.org"},
-	{"workflowrulesets", "tinkerbell.org"},
-	{"machines", "bmc.tinkerbell.org"},
-	{"jobs", "bmc.tinkerbell.org"},
-	{"tasks", "bmc.tinkerbell.org"},
+	{resourceHardware, groupTinkerbell},
+	{"templates", groupTinkerbell},
+	{"workflows", groupTinkerbell},
+	{"workflowrulesets", groupTinkerbell},
+	{"machines", groupBMC},
+	{"jobs", groupBMC},
+	{resourceTasks, groupBMC},
 }
 
 // tinkerbellVerbs defines the verbs to check for each resource.
-var tinkerbellVerbs = []string{"get", "list", "watch", "create", "update", "patch", "delete"}
+var tinkerbellVerbs = []string{"get", verbList, "watch", "create", "update", "patch", "delete"}
 
 // HandlePermissions handles the permissions page showing user's Tinkerbell RBAC permissions.
 // The page loads immediately with loading indicators, then fetches each resource's permissions via HTMX.

--- a/ui/internal/http/search.go
+++ b/ui/internal/http/search.go
@@ -46,7 +46,7 @@ func HandleGlobalSearch(c *gin.Context, log logr.Logger) {
 		if HandleAuthError(c, err, log) {
 			return
 		}
-		c.JSON(500, gin.H{"error": "Internal server error"})
+		c.JSON(500, gin.H{jsonKeyError: "Internal server error"})
 		return
 	}
 
@@ -107,10 +107,10 @@ func searchHardware(c *gin.Context, kubeClient *KubeClient, query, namespace str
 		results = append(results, SearchResult{
 			Name:      hw.Name,
 			Namespace: hw.Namespace,
-			Type:      "hardware",
-			TypeLabel: "Hardware",
+			Type:      resourceHardware,
+			TypeLabel: nameSingularHardware,
 			URL:       "/hardware/" + hw.Namespace + "/" + hw.Name,
-			Icon:      "hardware",
+			Icon:      resourceHardware,
 		})
 
 		// Limit results per type (QUAL-1)
@@ -149,10 +149,10 @@ func searchWorkflows(c *gin.Context, kubeClient *KubeClient, query, namespace st
 		results = append(results, SearchResult{
 			Name:      wf.Name,
 			Namespace: wf.Namespace,
-			Type:      "workflow",
-			TypeLabel: "Workflow",
+			Type:      resourceWorkflow,
+			TypeLabel: nameSingularWorkflow,
 			URL:       "/workflows/" + wf.Namespace + "/" + wf.Name,
-			Icon:      "workflow",
+			Icon:      resourceWorkflow,
 		})
 
 		if len(results) >= MaxSearchResultsPerType {
@@ -190,10 +190,10 @@ func searchTemplates(c *gin.Context, kubeClient *KubeClient, query, namespace st
 		results = append(results, SearchResult{
 			Name:      tmpl.Name,
 			Namespace: tmpl.Namespace,
-			Type:      "template",
-			TypeLabel: "Template",
+			Type:      resourceTemplate,
+			TypeLabel: nameSingularTemplate,
 			URL:       "/templates/" + tmpl.Namespace + "/" + tmpl.Name,
-			Icon:      "template",
+			Icon:      resourceTemplate,
 		})
 
 		if len(results) >= MaxSearchResultsPerType {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Bumps golangci-lint, which surfaced new `goconst` and `gosec` findings, and
resolves them. Also folds the `version` flag into the shared global config.

- **golangci-lint** — bump version / updated install-script location (`Makefile`).
- **version flag** — use the existing global-config flag mechanism instead of a one-off.
- **goconst** — extract shared constants in the UI handlers; place constants where their usage predominates (test packages for test-heavy strings, production otherwise); dedupe the repeated log-level flag usage text.
- **gosec (G710)** — annotate the same-origin HTTP→HTTPS redirect; hardening TODOs left inline.
- **metric** — drop the always-`0.0.0.0` `giaddr` DHCP label and exclude `metric.go` from goconst.

## Why

goconst counts string occurrences across the whole package including tests
(tests are excluded only from *reporting*, not from the count), so test-heavy
strings were pushing production code toward valueless constants. Constants now
live where their usage actually is.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
