### PR TITLE
agent: load containerd registry host configuration

### DIFF
--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -144,6 +144,7 @@ func RegisterContainerdRuntimeFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.Options.Runtime.Containerd.Namespace, "containerd-namespace", "tinkerbell", "Containerd namespace")
 	fs.StringVar(&c.Options.Runtime.Containerd.SocketPath, "containerd-socket", "/run/containerd/containerd.sock", "Containerd socket path")
 	fs.StringVar(&c.Options.Runtime.Containerd.DataRoot, "containerd-data-root", "/var/lib/nerdctl", "Root directory for nerdctl-compatible per-container state (json-file logs read by `nerdctl logs`)")
+	fs.StringVar(&c.Options.Runtime.Containerd.RegistryConfigPath, "containerd-registry-config-path", "/etc/containerd/certs.d", "Root directory containing containerd registry hosts.toml and certificate configuration")
 }
 
 func RegisterKubernetesRuntimeFlags(c *config, fs *flag.FlagSet) {

--- a/cmd/agent/flags_test.go
+++ b/cmd/agent/flags_test.go
@@ -45,3 +45,36 @@ func TestVersionFlagHelp(t *testing.T) {
 		}
 	}
 }
+
+func TestContainerdRegistryConfigPathFlag(t *testing.T) {
+	tests := map[string]struct {
+		args []string
+		want string
+	}{
+		"default": {
+			want: "/etc/containerd/certs.d",
+		},
+		"custom path": {
+			args: []string{"-containerd-registry-config-path", "/custom/registry-config"},
+			want: "/custom/registry-config",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &config{Options: &agent.Options{}}
+			command := &ff.Command{
+				Name:  name,
+				Usage: "tink-agent [flags]",
+				Flags: RegisterAllFlags(c),
+			}
+
+			if err := command.Parse(tt.args); err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if got := c.Options.Runtime.Containerd.RegistryConfigPath; got != tt.want {
+				t.Errorf("RegistryConfigPath = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tink/agent/agent.go
+++ b/tink/agent/agent.go
@@ -256,6 +256,8 @@ type ContainerdRuntime struct {
 	Namespace  string
 	SocketPath string
 	DataRoot   string
+	// RegistryConfigPath is the root directory containing per-registry hosts.toml and certificate configuration.
+	RegistryConfigPath string
 }
 type KubernetesRuntime struct {
 	Namespace          string
@@ -345,6 +347,9 @@ func (o *Options) ConfigureAndRun(inctx context.Context, log logr.Logger, id str
 		}
 		if o.Runtime.Containerd.DataRoot != "" {
 			opts = append(opts, containerd.WithDataRoot(o.Runtime.Containerd.DataRoot))
+		}
+		if o.Runtime.Containerd.RegistryConfigPath != "" {
+			opts = append(opts, containerd.WithRegistryConfigPath(o.Runtime.Containerd.RegistryConfigPath))
 		}
 		cd, err := containerd.NewConfig(log, opts...)
 		if err != nil {

--- a/tink/agent/internal/runtime/containerd/containerd.go
+++ b/tink/agent/internal/runtime/containerd/containerd.go
@@ -250,8 +250,9 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	image, err := c.Client.GetImage(ctx, imageName)
 	if err != nil {
 		// if the image isn't already in our namespaced context, then pull it
+		resolver := newResolver(ctx, c.RegistryConfigPath)
 		pullImage := func() error {
-			image, err = c.Client.Pull(ctx, imageName, containerd.WithPullUnpack, containerd.WithResolver(newResolver(ctx, c.RegistryConfigPath)))
+			image, err = c.Client.Pull(ctx, imageName, containerd.WithPullUnpack, containerd.WithResolver(resolver))
 			if err != nil {
 				return fmt.Errorf("error pulling image: %w", err)
 			}

--- a/tink/agent/internal/runtime/containerd/containerd.go
+++ b/tink/agent/internal/runtime/containerd/containerd.go
@@ -38,7 +38,9 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
+	dockerconfig "github.com/containerd/containerd/v2/core/remotes/docker/config"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -56,8 +58,9 @@ const (
 	defaultCNIBinDir  = "/opt/cni/bin"
 	defaultCNIConfDir = "/etc/cni/net.d"
 
-	defaultNamespace  = "tinkerbell"
-	defaultSocketPath = "/run/containerd/containerd.sock"
+	defaultNamespace          = "tinkerbell"
+	defaultSocketPath         = "/run/containerd/containerd.sock"
+	defaultRegistryConfigPath = "/etc/containerd/certs.d"
 
 	// Fallback bridge network configuration for tink-agent containers.
 	// Only used if no CNI configs exist in /etc/cni/net.d/.
@@ -110,12 +113,29 @@ const (
     }`
 )
 
+func newRegistryHosts(ctx context.Context, configPath string) docker.RegistryHosts {
+	opts := dockerconfig.HostOptions{}
+	if configPath != "" {
+		opts.HostDir = dockerconfig.HostDirFromRoot(configPath)
+	}
+
+	return dockerconfig.ConfigureHosts(ctx, opts)
+}
+
+func newResolver(ctx context.Context, configPath string) remotes.Resolver {
+	return docker.NewResolver(docker.ResolverOptions{
+		Hosts: newRegistryHosts(ctx, configPath),
+	})
+}
+
 type Config struct {
 	Namespace  string
 	Client     *containerd.Client
 	Log        logr.Logger
 	SocketPath string
-	CNI        gocni.CNI
+	// RegistryConfigPath is the root directory containing per-registry hosts.toml and certificate configuration.
+	RegistryConfigPath string
+	CNI                gocni.CNI
 	// DataRoot is the on-disk root used for nerdctl-compatible per-container
 	// state (the json-file logs that `nerdctl logs` reads).
 	DataRoot string
@@ -147,12 +167,19 @@ func WithDataRoot(dataRoot string) Opt {
 	}
 }
 
+func WithRegistryConfigPath(registryConfigPath string) Opt {
+	return func(c *Config) {
+		c.RegistryConfigPath = registryConfigPath
+	}
+}
+
 func NewConfig(log logr.Logger, opts ...Opt) (*Config, error) {
 	c := &Config{
-		Log:        log,
-		Namespace:  defaultNamespace,
-		SocketPath: defaultSocketPath,
-		DataRoot:   defaultDataRoot,
+		Log:                log,
+		Namespace:          defaultNamespace,
+		SocketPath:         defaultSocketPath,
+		DataRoot:           defaultDataRoot,
+		RegistryConfigPath: defaultRegistryConfigPath,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -224,7 +251,7 @@ func (c *Config) Execute(ctx context.Context, a spec.Action) error {
 	if err != nil {
 		// if the image isn't already in our namespaced context, then pull it
 		pullImage := func() error {
-			image, err = c.Client.Pull(ctx, imageName, containerd.WithPullUnpack, containerd.WithResolver(docker.NewResolver(docker.ResolverOptions{})))
+			image, err = c.Client.Pull(ctx, imageName, containerd.WithPullUnpack, containerd.WithResolver(newResolver(ctx, c.RegistryConfigPath)))
 			if err != nil {
 				return fmt.Errorf("error pulling image: %w", err)
 			}

--- a/tink/agent/internal/runtime/containerd/containerd_test.go
+++ b/tink/agent/internal/runtime/containerd/containerd_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright The Tinkerbell Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const testRegistryHost = "registry.example.test"
+
+func TestResolverUsesRegistryHostsConfiguration(t *testing.T) {
+	tests := map[string]struct {
+		tls        bool
+		writeCA    bool
+		hostConfig func(serverURL string) string
+	}{
+		"plain HTTP": {
+			hostConfig: func(serverURL string) string {
+				return registryHostConfig(serverURL, "")
+			},
+		},
+		"HTTPS skip verify": {
+			tls: true,
+			hostConfig: func(serverURL string) string {
+				return registryHostConfig(serverURL, "  skip_verify = true")
+			},
+		},
+		"HTTPS custom CA": {
+			tls:     true,
+			writeCA: true,
+			hostConfig: func(serverURL string) string {
+				return registryHostConfig(serverURL, `  ca = "ca.crt"`)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var manifestRequests atomic.Int32
+			server := newTestRegistry(t, tt.tls, &manifestRequests)
+
+			root := t.TempDir()
+			hostDir := filepath.Join(root, testRegistryHost)
+			if err := os.MkdirAll(hostDir, 0o755); err != nil {
+				t.Fatalf("create registry host directory: %v", err)
+			}
+
+			if tt.writeCA {
+				certificate := server.Certificate()
+				certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+				if err := os.WriteFile(filepath.Join(hostDir, "ca.crt"), certificatePEM, 0o600); err != nil {
+					t.Fatalf("write registry CA: %v", err)
+				}
+			}
+
+			if err := os.WriteFile(filepath.Join(hostDir, "hosts.toml"), []byte(tt.hostConfig(server.URL)), 0o600); err != nil {
+				t.Fatalf("write hosts.toml: %v", err)
+			}
+
+			resolver := newResolver(context.Background(), root)
+			if _, _, err := resolver.Resolve(context.Background(), testRegistryHost+"/actions/test:latest"); err != nil {
+				t.Fatalf("resolve image: %v", err)
+			}
+			if got := manifestRequests.Load(); got == 0 {
+				t.Fatal("configured registry did not receive a manifest request")
+			}
+		})
+	}
+}
+
+func TestRegistryHostsFallsBackWithoutConfiguration(t *testing.T) {
+	tests := map[string]string{
+		"empty path":   "",
+		"missing path": filepath.Join(t.TempDir(), "missing"),
+	}
+
+	for name, configPath := range tests {
+		t.Run(name, func(t *testing.T) {
+			hosts, err := newRegistryHosts(context.Background(), configPath)(testRegistryHost)
+			if err != nil {
+				t.Fatalf("resolve default registry hosts: %v", err)
+			}
+			if len(hosts) != 1 {
+				t.Fatalf("default registry hosts count = %d, want 1", len(hosts))
+			}
+			if hosts[0].Scheme != "https" {
+				t.Errorf("default registry scheme = %q, want https", hosts[0].Scheme)
+			}
+			if hosts[0].Host != testRegistryHost {
+				t.Errorf("default registry host = %q, want %q", hosts[0].Host, testRegistryHost)
+			}
+		})
+	}
+}
+
+func registryHostConfig(serverURL, extra string) string {
+	return fmt.Sprintf(`server = %q
+
+[host.%q]
+  capabilities = ["pull", "resolve"]
+%s
+`, serverURL, serverURL, extra)
+}
+
+func newTestRegistry(t *testing.T, useTLS bool, manifestRequests *atomic.Int32) *httptest.Server {
+	t.Helper()
+
+	manifest := []byte(`{"schemaVersion":2}`)
+	manifestDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(manifest))
+	manifestPath := "/v2/actions/test/manifests/latest"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case manifestPath:
+			manifestRequests.Add(1)
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+			w.Header().Set("Content-Length", strconv.Itoa(len(manifest)))
+			w.Header().Set("Docker-Content-Digest", manifestDigest)
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write(manifest); err != nil {
+				t.Errorf("write manifest response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	var server *httptest.Server
+	if useTLS {
+		server = httptest.NewTLSServer(handler)
+	} else {
+		server = httptest.NewServer(handler)
+	}
+	t.Cleanup(server.Close)
+
+	return server
+}


### PR DESCRIPTION
## Summary

Configure the tink-agent containerd runtime to load per-registry host configuration when pulling workflow action images.

The containerd runtime currently creates a resolver with empty options:

```go
docker.NewResolver(docker.ResolverOptions{})
```

Because tink-agent performs pulls directly through the containerd client, this resolver does not automatically inherit the containerd daemon's registry configuration. As a result, registry settings such as plain HTTP, custom certificate authorities, and `skip_verify` are ignored.

## Changes

- Build the resolver using containerd's `ConfigureHosts` and `HostDirFromRoot` APIs.
- Add `-containerd-registry-config-path` for selecting the registry configuration directory.
- Default the path to `/etc/containerd/certs.d`.
- Preserve containerd's normal HTTPS resolver behavior when no matching registry configuration exists.
- Leave registry authentication behavior unchanged.

The configuration path is process-level containerd runtime configuration; no workflow or action schema changes are required.

## Testing

Added tests covering:

- Plain HTTP registries
- HTTPS registries using `skip_verify`
- HTTPS registries using a custom CA
- Default HTTPS behavior when registry configuration is absent
- Default and custom values for `-containerd-registry-config-path`

Local validation:

- `CGO_ENABLED=0 go test -count=1 ./...`
- `CGO_ENABLED=0 go vet ./...`
- `make lint`
- `git diff --check`

All completed successfully. The race-enabled `make test` target could not run locally because the NixOS environment cannot execute the generated CGO test binaries; the race-enabled suite is expected to run in CI.
