### PR TITLE
tink: prevent stale updates from rewrtiting terminal workflows

### DIFF
--- a/tink/agent/agent_test.go
+++ b/tink/agent/agent_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,7 +13,32 @@ import (
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 )
 
+const testWaitTimeout = 5 * time.Second
+
 type mock struct{}
+
+type readerFunc func(context.Context) (spec.Action, error)
+
+func (f readerFunc) Read(ctx context.Context) (spec.Action, error) {
+	return f(ctx)
+}
+
+type executorFunc func(context.Context, spec.Action) error
+
+func (f executorFunc) Execute(ctx context.Context, action spec.Action) error {
+	return f(ctx, action)
+}
+
+type writerFunc func(context.Context, spec.Event) error
+
+func (f writerFunc) Write(ctx context.Context, event spec.Event) error {
+	return f(ctx, event)
+}
+
+type testNoActionError struct{}
+
+func (testNoActionError) Error() string  { return "no action" }
+func (testNoActionError) NoAction() bool { return true }
 
 func (m *mock) Read(_ context.Context) (spec.Action, error) {
 	return spec.Action{}, nil
@@ -32,6 +58,165 @@ func TestRun(_ *testing.T) {
 	go c.Run(ctx, logr.Discard())
 	<-time.After(1 * time.Second)
 	cancel()
+}
+
+func TestRunSkipsRuntimeWhenRunningReportIsRejected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	repolled := make(chan struct{})
+	var repollOnce sync.Once
+	var reads atomic.Int32
+	reader := readerFunc(func(context.Context) (spec.Action, error) {
+		if reads.Add(1) == 1 {
+			return spec.Action{ID: "action-1", TimeoutSeconds: 5}, nil
+		}
+		repollOnce.Do(func() { close(repolled) })
+		return spec.Action{}, testNoActionError{}
+	})
+
+	var executions atomic.Int32
+	executor := executorFunc(func(context.Context, spec.Action) error {
+		executions.Add(1)
+		return nil
+	})
+
+	var writes atomic.Int32
+	writer := writerFunc(func(_ context.Context, event spec.Event) error {
+		writes.Add(1)
+		if event.State != spec.StateRunning {
+			t.Errorf("unexpected completion report after RUNNING was rejected: %s", event.State)
+		}
+		return backoff.Permanent(fmt.Errorf("workflow is failed"))
+	})
+
+	c := &Config{
+		TransportReader: reader,
+		RuntimeExecutor: executor,
+		TransportWriter: writer,
+		Backoff:         testBackoff(),
+	}
+	done := make(chan struct{})
+	go func() {
+		c.Run(ctx, logr.Discard())
+		close(done)
+	}()
+
+	select {
+	case <-repolled:
+	case <-time.After(testWaitTimeout):
+		t.Fatal("agent did not return to polling after the RUNNING report was rejected")
+	}
+	if got := executions.Load(); got != 0 {
+		t.Fatalf("runtime executed %d times after the RUNNING report was rejected", got)
+	}
+	if got := writes.Load(); got != 1 {
+		t.Fatalf("expected one rejected RUNNING report, got %d writes", got)
+	}
+	select {
+	case <-done:
+		t.Fatal("agent exited instead of remaining alive and polling")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(testWaitTimeout):
+		t.Fatal("agent did not exit after context cancellation")
+	}
+}
+
+func TestRunAcknowledgedCompletionReturnsToPolling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	repolled := make(chan struct{})
+	var repollOnce sync.Once
+	var reads atomic.Int32
+	reader := readerFunc(func(context.Context) (spec.Action, error) {
+		if reads.Add(1) == 1 {
+			return spec.Action{ID: "action-1", TimeoutSeconds: 5}, nil
+		}
+		repollOnce.Do(func() { close(repolled) })
+		return spec.Action{}, testNoActionError{}
+	})
+
+	runtimeStarted := make(chan struct{})
+	releaseRuntime := make(chan struct{})
+	var executions atomic.Int32
+	executor := executorFunc(func(ctx context.Context, _ spec.Action) error {
+		executions.Add(1)
+		close(runtimeStarted)
+		select {
+		case <-releaseRuntime:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	completionAcknowledged := make(chan struct{})
+	var completionOnce sync.Once
+	writer := writerFunc(func(_ context.Context, event spec.Event) error {
+		if event.State != spec.StateRunning {
+			completionOnce.Do(func() { close(completionAcknowledged) })
+		}
+		return nil
+	})
+
+	c := &Config{
+		TransportReader: reader,
+		RuntimeExecutor: executor,
+		TransportWriter: writer,
+		Backoff:         testBackoff(),
+	}
+	done := make(chan struct{})
+	go func() {
+		c.Run(ctx, logr.Discard())
+		close(done)
+	}()
+
+	select {
+	case <-runtimeStarted:
+	case <-time.After(testWaitTimeout):
+		t.Fatal("runtime did not start after the RUNNING report was accepted")
+	}
+	close(releaseRuntime)
+	select {
+	case <-completionAcknowledged:
+	case <-time.After(testWaitTimeout):
+		t.Fatal("agent did not report the in-flight action completion")
+	}
+	select {
+	case <-repolled:
+	case <-time.After(testWaitTimeout):
+		t.Fatal("agent did not return to polling after completion was acknowledged")
+	}
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("expected one runtime execution, got %d", got)
+	}
+	select {
+	case <-done:
+		t.Fatal("agent exited instead of remaining alive and polling")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(testWaitTimeout):
+		t.Fatal("agent did not exit after context cancellation")
+	}
+}
+
+func testBackoff() *backoff.ExponentialBackOff {
+	return &backoff.ExponentialBackOff{
+		InitialInterval:     time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          1,
+		MaxInterval:         time.Millisecond,
+	}
 }
 
 // oneActionReader returns one action then blocks until ctx is cancelled.

--- a/tink/agent/internal/transport/grpc/grpc_test.go
+++ b/tink/agent/internal/transport/grpc/grpc_test.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/google/go-cmp/cmp"
 	"github.com/tinkerbell/tinkerbell/pkg/proto"
 	"github.com/tinkerbell/tinkerbell/tink/agent/internal/spec"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type mockWorkflowServiceClient struct {
@@ -170,13 +173,18 @@ func TestRead(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	tests := map[string]struct {
-		expectedError error
+		expectedError     error
+		expectedPermanent bool
 	}{
 		"Success": {
 			expectedError: nil,
 		},
 		"Error": {
 			expectedError: errors.New("failed to report action"),
+		},
+		"FailedPrecondition is permanent": {
+			expectedError:     status.Error(codes.FailedPrecondition, "workflow is failed"),
+			expectedPermanent: true,
 		},
 	}
 
@@ -203,6 +211,10 @@ func TestWrite(t *testing.T) {
 				if err != nil {
 					t.Fatalf("expected no error, got: %v", err)
 				}
+			}
+			var permanent *backoff.PermanentError
+			if got := errors.As(err, &permanent); got != test.expectedPermanent {
+				t.Fatalf("permanent error = %v, want %v", got, test.expectedPermanent)
 			}
 		})
 	}

--- a/tink/controller/internal/workflow/reconciler.go
+++ b/tink/controller/internal/workflow/reconciler.go
@@ -230,7 +230,8 @@ func mergePatchStatus(ctx context.Context, cc ctrlclient.Client, original, updat
 	// Patch any changes, regardless of errors
 	if !equality.Semantic.DeepEqual(updated.Status, original.Status) {
 		journal.Log(ctx, "patching status")
-		if err := cc.Status().Patch(ctx, updated, ctrlclient.MergeFrom(original)); err != nil {
+		patch := ctrlclient.MergeFromWithOptions(original, ctrlclient.MergeFromWithOptimisticLock{})
+		if err := cc.Status().Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("error patching status of workflow: %s, error: %w", updated.Name, err)
 		}
 	}

--- a/tink/controller/internal/workflow/reconciler_test.go
+++ b/tink/controller/internal/workflow/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1alpha1 "github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -2058,5 +2059,102 @@ func TestReconcileWithMultipleTasksAndAgents(t *testing.T) {
 				t.Errorf("unexpected difference:\n%v\nDescription: %s", diff, tc.description)
 			}
 		})
+	}
+}
+
+func TestReconcileFailedWorkflowWinsStalePatch(t *testing.T) {
+	future := metav1.NewTime(TestTime.AfterSec(600))
+	workflow := &v1alpha1.Workflow{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Workflow",
+			APIVersion: "tinkerbell.org/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cancelled-during-reconcile",
+			Namespace:       "default",
+			ResourceVersion: "1000",
+			Annotations: map[string]string{
+				"tinkerbell.org/internal": "preserve-me",
+			},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			State:               v1alpha1.WorkflowStateRunning,
+			AgentID:             "agent-1",
+			GlobalExecutionStop: &future,
+			CurrentState: &v1alpha1.CurrentState{
+				AgentID:  "agent-1",
+				TaskID:   "task-1",
+				ActionID: "action-1",
+				State:    v1alpha1.WorkflowStateSuccess,
+			},
+			Tasks: []v1alpha1.Task{
+				{
+					ID:      "task-1",
+					Name:    "first",
+					AgentID: "agent-1",
+					Actions: []v1alpha1.Action{{ID: "action-1", State: v1alpha1.WorkflowStateSuccess}},
+				},
+				{
+					ID:      "task-2",
+					Name:    "second",
+					AgentID: "agent-2",
+					Actions: []v1alpha1.Action{{ID: "action-2", State: v1alpha1.WorkflowStatePending}},
+				},
+			},
+		},
+	}
+
+	base := GetFakeClientBuilder().WithObjects(workflow).WithStatusSubresource(workflow).Build()
+	patchCalls := 0
+	var committed *v1alpha1.Workflow
+	cc := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourcePatch: func(ctx context.Context, c client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			patchCalls++
+			if patchCalls == 1 {
+				cancelled := &v1alpha1.Workflow{}
+				if err := c.Get(ctx, client.ObjectKeyFromObject(workflow), cancelled); err != nil {
+					return err
+				}
+				cancelled.Status.State = v1alpha1.WorkflowStateFailed
+				if err := c.Status().Update(ctx, cancelled); err != nil {
+					return err
+				}
+				committed = cancelled.DeepCopy()
+				committed.TypeMeta = workflow.TypeMeta
+			}
+
+			return c.SubResource(subResource).Patch(ctx, obj, patch, opts...)
+		},
+	})
+	controller := &Reconciler{
+		client:        cc,
+		nowFunc:       TestTime.Now,
+		dynamicClient: &fakeDynamicClient{},
+	}
+	req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(workflow)}
+
+	if _, err := controller.Reconcile(context.Background(), req); !kerrors.IsConflict(err) {
+		t.Fatalf("expected stale status patch conflict, got %v", err)
+	}
+	if committed == nil {
+		t.Fatal("expected cancellation to be committed before the stale patch")
+	}
+	if patchCalls != 1 {
+		t.Fatalf("expected one stale patch attempt, got %d", patchCalls)
+	}
+
+	if _, err := controller.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile from FAILED returned an error: %v", err)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("expected FAILED reconcile to be a no-op, got %d patch attempts", patchCalls)
+	}
+
+	got := &v1alpha1.Workflow{}
+	if err := cc.Get(context.Background(), client.ObjectKeyFromObject(workflow), got); err != nil {
+		t.Fatalf("get committed workflow: %v", err)
+	}
+	if diff := cmp.Diff(committed, got); diff != "" {
+		t.Fatalf("committed FAILED workflow changed (-want +got):\n%s", diff)
 	}
 }

--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -204,7 +204,11 @@ func (h *Handler) doGetAction(ctx context.Context, req *proto.ActionRequest, opt
 		}
 		if w.Status.State != tinkerbell.WorkflowStatePending && w.Status.State != tinkerbell.WorkflowStateRunning {
 			journal.Log(ctx, "Workflow not in pending or running state")
-			return nil, status.Error(codes.FailedPrecondition, "Workflow not in pending or running state")
+			err := status.Error(codes.FailedPrecondition, "Workflow not in pending or running state")
+			if isAgentTerminalWorkflowState(w.Status.State) {
+				return nil, backoff.Permanent(err)
+			}
+			return nil, err
 		}
 		wf = w
 		journal.Log(ctx, "found Workflow", "workflow", wf.Name)
@@ -377,6 +381,19 @@ func isTaskSuccessful(t tinkerbell.Task) bool {
 	return false
 }
 
+// isAgentTerminalWorkflowState reports whether a workflow has finished its agent-driven execution.
+func isAgentTerminalWorkflowState(state tinkerbell.WorkflowState) bool {
+	switch state {
+	case tinkerbell.WorkflowStatePost,
+		tinkerbell.WorkflowStateSuccess,
+		tinkerbell.WorkflowStateFailed,
+		tinkerbell.WorkflowStateTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
 func (h *Handler) ReportActionStatus(ctx context.Context, req *proto.ActionStatusRequest) (*proto.ActionStatusResponse, error) {
 	operation := func() (*proto.ActionStatusResponse, error) {
 		return h.doReportActionStatus(ctx, req)
@@ -419,6 +436,19 @@ func (h *Handler) doReportActionStatus(ctx context.Context, req *proto.ActionSta
 		for ai, action := range task.Actions {
 			// action IDs match or this is the first action in a task
 			if action.ID == req.GetActionId() && task.AgentID == req.GetAgentId() {
+				if isAgentTerminalWorkflowState(wf.Status.State) {
+					switch req.GetActionState() {
+					case proto.ActionStatusRequest_SUCCESS, proto.ActionStatusRequest_FAILED, proto.ActionStatusRequest_TIMEOUT:
+						return &proto.ActionStatusResponse{}, nil
+					default:
+						return nil, backoff.Permanent(status.Errorf(
+							codes.FailedPrecondition,
+							"Workflow is in %s state",
+							wf.Status.State,
+						))
+					}
+				}
+
 				wf.Status.Tasks[ti].Actions[ai].State = tinkerbell.WorkflowState(req.GetActionState().String())
 				wf.Status.Tasks[ti].Actions[ai].ExecutionStart = &metav1.Time{Time: req.GetExecutionStart().AsTime()}
 				wf.Status.Tasks[ti].Actions[ai].ExecutionStop = &metav1.Time{Time: req.GetExecutionStop().AsTime()}

--- a/tink/server/internal/grpc/grpc_test.go
+++ b/tink/server/internal/grpc/grpc_test.go
@@ -20,7 +20,9 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestGetAction(t *testing.T) {
@@ -508,11 +510,22 @@ type mockBackendReadWriter struct {
 	hardware    *tinkerbell.Hardware
 	hardwareErr error
 
+	readWorkflowFunc   func() (*tinkerbell.Workflow, error)
+	listWorkflowsFunc  func() ([]tinkerbell.Workflow, error)
+	updateWorkflowFunc func(*tinkerbell.Workflow) error
+	workflowReads      int
+	workflowLists      int
+	workflowUpdates    int
+
 	updatedHardware *tinkerbell.Hardware // captures the hardware passed to UpdateHardware
 	updateOpts      data.UpdateOptions   // captures the options passed to UpdateHardware
 }
 
 func (m *mockBackendReadWriter) ReadWorkflow(_ context.Context, _ string, _ string) (*tinkerbell.Workflow, error) {
+	m.workflowReads++
+	if m.readWorkflowFunc != nil {
+		return m.readWorkflowFunc()
+	}
 	if m.workflow == nil {
 		return nil, errors.New("workflow not found")
 	}
@@ -520,13 +533,21 @@ func (m *mockBackendReadWriter) ReadWorkflow(_ context.Context, _ string, _ stri
 }
 
 func (m *mockBackendReadWriter) ListWorkflows(_ context.Context, _ data.WorkflowFilter) ([]tinkerbell.Workflow, error) {
+	m.workflowLists++
+	if m.listWorkflowsFunc != nil {
+		return m.listWorkflowsFunc()
+	}
 	if m.workflow != nil {
 		return []tinkerbell.Workflow{*m.workflow}, nil
 	}
 	return []tinkerbell.Workflow{}, nil
 }
 
-func (m *mockBackendReadWriter) UpdateWorkflow(_ context.Context, _ *tinkerbell.Workflow, _ data.UpdateOptions) error {
+func (m *mockBackendReadWriter) UpdateWorkflow(_ context.Context, wf *tinkerbell.Workflow, _ data.UpdateOptions) error {
+	m.workflowUpdates++
+	if m.updateWorkflowFunc != nil {
+		return m.updateWorkflowFunc(wf)
+	}
 	return m.writeErr
 }
 
@@ -844,5 +865,302 @@ func TestReportActionStatus(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestTerminalWorkflowFence(t *testing.T) {
+	terminalWorkflowStates := []tinkerbell.WorkflowState{
+		tinkerbell.WorkflowStatePost,
+		tinkerbell.WorkflowStateSuccess,
+		tinkerbell.WorkflowStateFailed,
+		tinkerbell.WorkflowStateTimeout,
+	}
+	for _, workflowState := range terminalWorkflowStates {
+		t.Run("GetAction "+string(workflowState)+" is rejected without a status write", func(t *testing.T) {
+			workflow := failedWorkflowFixture()
+			workflow.Status.State = workflowState
+			before := workflow.DeepCopy()
+			backend := &mockBackendReadWriter{workflow: workflow}
+			handler := &Handler{
+				Logger:  logr.Discard(),
+				Backend: backend,
+				RetryOptions: []backoff.RetryOption{
+					backoff.WithMaxTries(3),
+					backoff.WithBackOff(backoff.NewConstantBackOff(0)),
+				},
+			}
+
+			resp, err := handler.GetAction(context.Background(), &proto.ActionRequest{AgentId: toPtr("agent-1")})
+			if status.Code(err) != codes.FailedPrecondition {
+				t.Fatalf("unexpected error code: got %s, want %s (error: %v)", status.Code(err), codes.FailedPrecondition, err)
+			}
+			if resp != nil {
+				t.Fatalf("expected no action, got %+v", resp)
+			}
+			if backend.workflowLists != 1 {
+				t.Fatalf("expected one workflow list, got %d", backend.workflowLists)
+			}
+			if backend.workflowUpdates != 0 {
+				t.Fatalf("expected zero workflow updates, got %d", backend.workflowUpdates)
+			}
+			if diff := cmp.Diff(before, backend.workflow); diff != "" {
+				t.Fatalf("terminal workflow changed (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	for _, workflowState := range terminalWorkflowStates {
+		t.Run("ReportActionStatus "+string(workflowState), func(t *testing.T) {
+			testTerminalWorkflowReports(t, workflowState)
+		})
+	}
+
+	unknownAction := actionStatusRequest(proto.ActionStatusRequest_SUCCESS)
+	unknownAction.ActionId = toPtr("unknown-action")
+	wrongAgent := actionStatusRequest(proto.ActionStatusRequest_SUCCESS)
+	wrongAgent.AgentId = toPtr("wrong-agent")
+	for _, tc := range []struct {
+		name    string
+		request *proto.ActionStatusRequest
+	}{
+		{name: "unknown action returns NotFound", request: unknownAction},
+		{name: "wrong agent returns NotFound", request: wrongAgent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workflow := failedWorkflowFixture()
+			before := workflow.DeepCopy()
+			backend := &mockBackendReadWriter{workflow: workflow}
+			handler := &Handler{
+				Backend:      backend,
+				RetryOptions: []backoff.RetryOption{backoff.WithMaxTries(1)},
+			}
+
+			resp, err := handler.ReportActionStatus(context.Background(), tc.request)
+			if status.Code(err) != codes.NotFound {
+				t.Fatalf("unexpected error code: got %s, want %s (error: %v)", status.Code(err), codes.NotFound, err)
+			}
+			if resp != nil {
+				t.Fatalf("expected no response, got %+v", resp)
+			}
+			if backend.workflowReads != 1 {
+				t.Fatalf("expected one workflow read, got %d", backend.workflowReads)
+			}
+			if backend.workflowUpdates != 0 {
+				t.Fatalf("expected zero workflow updates, got %d", backend.workflowUpdates)
+			}
+			if diff := cmp.Diff(before, backend.workflow); diff != "" {
+				t.Fatalf("failed workflow changed (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func testTerminalWorkflowReports(t *testing.T, workflowState tinkerbell.WorkflowState) {
+	t.Helper()
+
+	for _, actionState := range []proto.ActionStatusRequest_StateType{
+		proto.ActionStatusRequest_RUNNING,
+		proto.ActionStatusRequest_SUCCESS,
+		proto.ActionStatusRequest_FAILED,
+		proto.ActionStatusRequest_TIMEOUT,
+	} {
+		t.Run(actionState.String(), func(t *testing.T) {
+			workflow := failedWorkflowFixture()
+			workflow.Status.State = workflowState
+			before := workflow.DeepCopy()
+			backend := &mockBackendReadWriter{workflow: workflow}
+			handler := &Handler{
+				Backend: backend,
+				RetryOptions: []backoff.RetryOption{
+					backoff.WithMaxTries(3),
+					backoff.WithBackOff(backoff.NewConstantBackOff(0)),
+				},
+			}
+
+			resp, err := handler.ReportActionStatus(context.Background(), actionStatusRequest(actionState))
+			if actionState == proto.ActionStatusRequest_RUNNING {
+				if status.Code(err) != codes.FailedPrecondition {
+					t.Fatalf("unexpected error code: got %s, want %s (error: %v)", status.Code(err), codes.FailedPrecondition, err)
+				}
+				if resp != nil {
+					t.Fatalf("expected no response, got %+v", resp)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("completion report returned an error: %v", err)
+				}
+				if resp == nil {
+					t.Fatal("expected completion report to be acknowledged")
+				}
+			}
+			if backend.workflowReads != 1 {
+				t.Fatalf("expected one workflow read, got %d", backend.workflowReads)
+			}
+			if backend.workflowUpdates != 0 {
+				t.Fatalf("expected zero workflow updates, got %d", backend.workflowUpdates)
+			}
+			if diff := cmp.Diff(before, backend.workflow); diff != "" {
+				t.Fatalf("terminal workflow changed (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTerminalWorkflowFenceWinsUpdateConflict(t *testing.T) {
+	t.Run("GetAction retry cannot replace cancellation", func(t *testing.T) {
+		workflow := failedWorkflowFixture()
+		workflow.Status.State = tinkerbell.WorkflowStateRunning
+		workflow.Status.CurrentState = nil
+		workflow.Status.Tasks[0].Actions[0].State = tinkerbell.WorkflowStatePending
+
+		cancelled := workflow.DeepCopy()
+		cancelled.Status.State = tinkerbell.WorkflowStateFailed
+		cancelled.Annotations["tinkerbell.org/cancellation"] = "committed"
+
+		backend := &mockBackendReadWriter{workflow: workflow.DeepCopy()}
+		backend.listWorkflowsFunc = func() ([]tinkerbell.Workflow, error) {
+			return []tinkerbell.Workflow{*backend.workflow.DeepCopy()}, nil
+		}
+		backend.updateWorkflowFunc = func(_ *tinkerbell.Workflow) error {
+			backend.workflow = cancelled.DeepCopy()
+			return kerrors.NewConflict(schema.GroupResource{Group: "tinkerbell.org", Resource: "workflows"}, workflow.Name, errors.New("cancellation won"))
+		}
+		handler := &Handler{
+			Logger:  logr.Discard(),
+			Backend: backend,
+			RetryOptions: []backoff.RetryOption{
+				backoff.WithMaxTries(2),
+				backoff.WithBackOff(backoff.NewConstantBackOff(0)),
+			},
+		}
+
+		_, err := handler.GetAction(context.Background(), &proto.ActionRequest{AgentId: toPtr("agent-1")})
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("unexpected error code: got %s, want %s (error: %v)", status.Code(err), codes.FailedPrecondition, err)
+		}
+		if backend.workflowLists != 2 {
+			t.Fatalf("expected retry to read cancellation, got %d workflow lists", backend.workflowLists)
+		}
+		if backend.workflowUpdates != 1 {
+			t.Fatalf("expected no update after cancellation was read, got %d updates", backend.workflowUpdates)
+		}
+		if diff := cmp.Diff(cancelled, backend.workflow); diff != "" {
+			t.Fatalf("committed cancellation changed (-want +got):\n%s", diff)
+		}
+	})
+
+	for _, workflowState := range []tinkerbell.WorkflowState{
+		tinkerbell.WorkflowStatePost,
+		tinkerbell.WorkflowStateSuccess,
+		tinkerbell.WorkflowStateFailed,
+		tinkerbell.WorkflowStateTimeout,
+	} {
+		t.Run("completion retry is acknowledged and discarded after "+string(workflowState), func(t *testing.T) {
+			testCompletionRetryAfterTerminalWorkflowUpdateConflict(t, workflowState)
+		})
+	}
+}
+
+func testCompletionRetryAfterTerminalWorkflowUpdateConflict(t *testing.T, workflowState tinkerbell.WorkflowState) {
+	t.Helper()
+
+	workflow := failedWorkflowFixture()
+	workflow.Status.State = tinkerbell.WorkflowStateRunning
+
+	committed := workflow.DeepCopy()
+	committed.Status.State = workflowState
+	committed.Annotations["tinkerbell.org/terminal-state"] = "committed"
+
+	backend := &mockBackendReadWriter{workflow: workflow.DeepCopy()}
+	backend.readWorkflowFunc = func() (*tinkerbell.Workflow, error) {
+		return backend.workflow.DeepCopy(), nil
+	}
+	backend.updateWorkflowFunc = func(_ *tinkerbell.Workflow) error {
+		backend.workflow = committed.DeepCopy()
+		return kerrors.NewConflict(schema.GroupResource{Group: "tinkerbell.org", Resource: "workflows"}, workflow.Name, errors.New("terminal state won"))
+	}
+	handler := &Handler{
+		Backend: backend,
+		RetryOptions: []backoff.RetryOption{
+			backoff.WithMaxTries(3),
+			backoff.WithBackOff(backoff.NewConstantBackOff(0)),
+		},
+	}
+
+	resp, err := handler.ReportActionStatus(context.Background(), actionStatusRequest(proto.ActionStatusRequest_SUCCESS))
+	if err != nil {
+		t.Fatalf("completion report returned an error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected completion report to be acknowledged")
+	}
+	if backend.workflowReads != 2 {
+		t.Fatalf("expected retry to read terminal workflow, got %d workflow reads", backend.workflowReads)
+	}
+	if backend.workflowUpdates != 1 {
+		t.Fatalf("expected no update after terminal workflow was read, got %d updates", backend.workflowUpdates)
+	}
+	if diff := cmp.Diff(committed, backend.workflow); diff != "" {
+		t.Fatalf("committed terminal workflow changed (-want +got):\n%s", diff)
+	}
+}
+
+func failedWorkflowFixture() *tinkerbell.Workflow {
+	executionStart := metav1.NewTime(time.Unix(1_700_000_000, 0).UTC())
+	return &tinkerbell.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "workflow-1",
+			Namespace:       "default",
+			ResourceVersion: "7",
+			Annotations: map[string]string{
+				"tinkerbell.org/internal": "preserve-me",
+			},
+		},
+		Status: tinkerbell.WorkflowStatus{
+			AgentID:       "agent-1",
+			State:         tinkerbell.WorkflowStateFailed,
+			GlobalTimeout: 600,
+			CurrentState: &tinkerbell.CurrentState{
+				AgentID:    "agent-1",
+				TaskID:     "task-1",
+				ActionID:   "action-1",
+				State:      tinkerbell.WorkflowStateRunning,
+				ActionName: "install",
+				TaskName:   "provision",
+			},
+			Tasks: []tinkerbell.Task{
+				{
+					ID:      "task-1",
+					Name:    "provision",
+					AgentID: "agent-1",
+					Actions: []tinkerbell.Action{
+						{
+							ID:                "action-1",
+							Name:              "install",
+							Image:             "example/install:latest",
+							State:             tinkerbell.WorkflowStateRunning,
+							ExecutionStart:    &executionStart,
+							ExecutionDuration: "10s",
+							Message:           "still running when cancelled",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func actionStatusRequest(actionState proto.ActionStatusRequest_StateType) *proto.ActionStatusRequest {
+	return &proto.ActionStatusRequest{
+		WorkflowId:        toPtr("default/workflow-1"),
+		AgentId:           toPtr("agent-1"),
+		TaskId:            toPtr("task-1"),
+		ActionId:          toPtr("action-1"),
+		ActionName:        toPtr("install"),
+		ActionState:       toPtr(actionState),
+		ExecutionStart:    timestamppb.New(time.Unix(1_700_000_000, 0).UTC()),
+		ExecutionStop:     timestamppb.New(time.Unix(1_700_000_030, 0).UTC()),
+		ExecutionDuration: toPtr("30s"),
+		Message:           &proto.ActionMessage{Message: toPtr("late report")},
 	}
 }


### PR DESCRIPTION
## Description

There is currently a possibility of a race condition in which the terminal status of a `Workflow` could be overwritten. The two most likely scenarios are:

1. The Tink controller could set the status to `TIMEOUT` when the global timeout is reached, but the client could overwrite it. The reverse is also possible.
2. Agent retries could affect the `Workflow` terminal status. For example:

- Agent reports final action `SUCCESS`.
- Server saves: 
```
     Action   = SUCCESS
     Workflow = POST
```
- The response is lost because the connection drops/server restarts.
- Agent does not know the write succeeded, so it retries `SUCCESS` and can set the workflow back to `POST`

## Fixes:

Use optimistic locking for reconciler status patches and protect agent requests once workflows reach a terminal state. Acknowledge late completion reports without mutating the committed workflow state.

## How Has This Been Tested?

Unit tests and manual running

## How are existing users impacted? What migration steps/scripts do we need?

No impact is expected

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
