### PR TITLE
smee: honour AllowNetboot in the Raspberry Pi netboot route

### DIFF
--- a/smee/internal/ipxe/binary/route_rpi.go
+++ b/smee/internal/ipxe/binary/route_rpi.go
@@ -53,11 +53,14 @@ func (r RPiNetbootRoute) TryServe(ctx context.Context, req Request, w io.ReaderF
 	}
 
 	// Netboot has to be allowed, the same gate the iPXE script handler
-	// applies. Without this the route serves boot files forever: a machine
-	// that has just been provisioned reboots, the Workflow controller sets
-	// AllowPXE false via bootOptions.toggleAllowNetboot, and this route hands
-	// it the OSIE again instead of letting it fall through its BOOT_ORDER to
-	// the disk it was just installed to. It never boots the installed OS.
+	// applies. AllowNetboot is what the Hardware's netboot.allowPXE becomes
+	// once dhcp.Convert* has translated it into hardware.Info.
+	//
+	// Without this the route serves boot files forever: a machine that has
+	// just been provisioned reboots, the Workflow controller clears allowPXE
+	// (bootOptions.toggleAllowNetboot), and this route hands it the OSIE again
+	// instead of letting it fall through its BOOT_ORDER to the disk it was
+	// just installed to. It never boots the installed OS.
 	if !hw.AllowNetboot {
 		log.V(1).Info("hardware does not allow netboot; skipping")
 		return false, nil

--- a/smee/internal/ipxe/binary/route_rpi.go
+++ b/smee/internal/ipxe/binary/route_rpi.go
@@ -24,9 +24,10 @@ import (
 //     OSIE.KernelParams for cmdline.txt) or rewrites the path's serial
 //     prefix to FirmwarePath and streams the file from AssetDir.
 //
-// Returns handled=false when there's no Hardware match, no RPI config on
-// the Hardware, no AssetDir, the path doesn't have the serial prefix, or
-// the rewritten on-disk file does not exist.
+// Returns handled=false when there's no Hardware match, netboot is not
+// allowed for it, no RPI config on the Hardware, no AssetDir, the path
+// doesn't have the serial prefix, or the rewritten on-disk file does not
+// exist.
 type RPiNetbootRoute struct {
 	Log      logr.Logger
 	Resolver hardware.Resolver
@@ -48,6 +49,17 @@ func (r RPiNetbootRoute) TryServe(ctx context.Context, req Request, w io.ReaderF
 		// route is tried for every client), not a fatal error; log quietly so
 		// routine misses don't spam error logs or trip alerting.
 		log.V(1).Info("failed to get hardware by IP; skipping", "err", err)
+		return false, nil
+	}
+
+	// Netboot has to be allowed, the same gate the iPXE script handler
+	// applies. Without this the route serves boot files forever: a machine
+	// that has just been provisioned reboots, the Workflow controller sets
+	// AllowPXE false via bootOptions.toggleAllowNetboot, and this route hands
+	// it the OSIE again instead of letting it fall through its BOOT_ORDER to
+	// the disk it was just installed to. It never boots the installed OS.
+	if !hw.AllowNetboot {
+		log.V(1).Info("hardware does not allow netboot; skipping")
 		return false, nil
 	}
 

--- a/smee/internal/ipxe/binary/tftp_test.go
+++ b/smee/internal/ipxe/binary/tftp_test.go
@@ -335,17 +335,20 @@ func TestRPiNetbootRoute(t *testing.T) {
 			resolver:    &fakeResolver{},
 			wantHandled: false,
 		},
+		// AllowNetboot must be set here or the netboot gate short-circuits
+		// before the RPI check and this case stops testing what it names.
 		"hardware without RPi config passes through": {
 			filename: serial + "/config.txt",
 			assetDir: assetDir,
 			resolver: &fakeResolver{byIP: map[string]hardware.Info{
-				clientIP.String(): {},
+				clientIP.String(): {AllowNetboot: true},
 			}},
 			wantHandled: false,
 		},
 		// Without this the route keeps handing a freshly provisioned machine
-		// the OSIE after the Workflow controller has set AllowPXE false, and
-		// it never boots the disk it was just installed to.
+		// the OSIE after the Workflow controller has cleared AllowNetboot (the
+		// Hardware's netboot.allowPXE), and it never boots the disk it was
+		// just installed to.
 		"netboot not allowed passes through": {
 			filename: serial + "/config.txt",
 			assetDir: assetDir,
@@ -386,7 +389,10 @@ func TestRPiNetbootRoute(t *testing.T) {
 			filename: serial + "/cmdline.txt",
 			assetDir: assetDir,
 			resolver: &fakeResolver{byIP: map[string]hardware.Info{clientIP.String(): {
-				RPI: hardware.RPI{SerialNum: serial, FirmwarePath: rewrite},
+				// As above, AllowNetboot has to be set for the case to reach
+				// the cmdline.txt branch at all.
+				AllowNetboot: true,
+				RPI:          hardware.RPI{SerialNum: serial, FirmwarePath: rewrite},
 				// no KernelParams
 			}}},
 			wantHandled: false,

--- a/smee/internal/ipxe/binary/tftp_test.go
+++ b/smee/internal/ipxe/binary/tftp_test.go
@@ -290,6 +290,7 @@ func TestRPiNetbootRoute(t *testing.T) {
 	const rewrite = "rpi4b"
 
 	hwWithRPi := hardware.Info{
+		AllowNetboot: true,
 		RPI: hardware.RPI{
 			SerialNum:    serial,
 			FirmwarePath: rewrite,
@@ -299,6 +300,11 @@ func TestRPiNetbootRoute(t *testing.T) {
 			KernelParams: []string{"console=tty1", "rw"},
 		},
 	}
+
+	// The same hardware with netboot disabled, which is the state the Workflow
+	// controller leaves a machine in once provisioning has succeeded.
+	hwNetbootDisabled := hwWithRPi
+	hwNetbootDisabled.AllowNetboot = false
 
 	// Set up an asset dir with a known file
 	assetDir := t.TempDir()
@@ -334,6 +340,25 @@ func TestRPiNetbootRoute(t *testing.T) {
 			assetDir: assetDir,
 			resolver: &fakeResolver{byIP: map[string]hardware.Info{
 				clientIP.String(): {},
+			}},
+			wantHandled: false,
+		},
+		// Without this the route keeps handing a freshly provisioned machine
+		// the OSIE after the Workflow controller has set AllowPXE false, and
+		// it never boots the disk it was just installed to.
+		"netboot not allowed passes through": {
+			filename: serial + "/config.txt",
+			assetDir: assetDir,
+			resolver: &fakeResolver{byIP: map[string]hardware.Info{
+				clientIP.String(): hwNetbootDisabled,
+			}},
+			wantHandled: false,
+		},
+		"netboot not allowed passes through for rewritten assets too": {
+			filename: serial + "/start.elf",
+			assetDir: assetDir,
+			resolver: &fakeResolver{byIP: map[string]hardware.Info{
+				clientIP.String(): hwNetbootDisabled,
 			}},
 			wantHandled: false,
 		},


### PR DESCRIPTION
Fixes #951.

`RPiNetbootRoute` gated only on `RPI.SerialNum`/`FirmwarePath` being set and the request path carrying the serial prefix. It never read `AllowNetboot`, so it served boot files to a machine whenever the Hardware had `rpi` config at all.

That breaks the handoff to disk. `bootOptions.toggleAllowNetboot` sets `AllowPXE` false once a Workflow succeeds, which is how a provisioned machine is meant to stop netbooting and fall through its `BOOT_ORDER` to the disk it just had an OS written to. On this route the flag was ignored, so the machine rebooted, was handed the OSIE again, and looped — never booting what had been installed.

The gate added here is the same one the iPXE script handler already applies, using the same field from the same `hardware.Info`, so it makes the two paths consistent rather than introducing a new concept:

```go
if !hw.AllowNetboot {
    log.V(1).Info("hardware does not allow netboot; skipping")
    return false, nil
}
```

### Verification

Reproduced and then confirmed fixed on a Raspberry Pi 5 netbooting an in-memory OSIE from smee's `tftpAssetDir`.

Before, with `allowPXE` already false on the Hardware:

```
18:34:20  workflow SUCCESS (all actions)
18:35:51  machine reboots
18:37:16  rewritten asset served from disk   714e7d7f/vmlinuz-...
```

It cycled every ~32s until the CAPI bootstrap token expired and the eventual `kubeadm join` failed.

After, same machine, same Hardware config, `allowPXE` false:

```
19:31:38  hardware does not allow netboot; skipping   714e7d7f/config.txt
19:31:38  hardware does not allow netboot; skipping   config.txt
```

`serving RPI ConfigTxt` count 0, and the Pi fell through to disk. A full unattended provision then ran end to end — install, self-reboot, boot from the installed disk, cluster join — with no manual intervention, where previously it required deleting `netboot.rpi.configTxt` from the Hardware by hand, timed between the last install action and the reboot.

### Tests

Three existing cases in `TestRPiNetbootRoute` failed once the gate was added, because their fixtures never set `AllowNetboot` — which is itself why this went unnoticed. Those now set it, and two cases are added pinning the new behaviour, covering both the inline-served (`config.txt`) and rewritten-asset paths.

### Aside, not part of this change

A request that no route handles is logged as `no route handled request` at V(1) only, so at the default log level a failing netboot presents as "the Pi fetched a few files and then went silent". Raising the level was what made this diagnosable at all. Logging unserved TFTP requests at V(0), or mentioning it in the Raspberry Pi netboot docs, would help — happy to open that separately if it is wanted.
