### PR TITLE
smee: answer the doubled-slash form of the RPi config.txt request

### DIFF
--- a/smee/internal/ipxe/binary/route_rpi.go
+++ b/smee/internal/ipxe/binary/route_rpi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"path"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -23,6 +24,9 @@ import (
 //     serves an inline value (RPI.ConfigTxt for config.txt; the joined
 //     OSIE.KernelParams for cmdline.txt) or rewrites the path's serial
 //     prefix to FirmwarePath and streams the file from AssetDir.
+//   - Matches the inline files on the cleaned path, so the doubled-slash
+//     form the bootloader also asks for ("<SerialNum>//config.txt") is
+//     answered as well as the single-slash one.
 //
 // Returns handled=false when there's no Hardware match, no RPI config on
 // the Hardware, no AssetDir, the path doesn't have the serial prefix, or
@@ -64,20 +68,45 @@ func (r RPiNetbootRoute) TryServe(ctx context.Context, req Request, w io.ReaderF
 		return false, nil
 	}
 
-	switch req.Filename {
-	case rpi.SerialNum + "/config.txt":
+	suffix := req.Filename[len(rpi.SerialNum):]
+
+	// Compared cleaned, because the bootloader asks for each of these TWICE:
+	// once as "<serial>/config.txt" and again as "<serial>//config.txt", with a
+	// doubled slash. Both are the same request. An exact match on req.Filename
+	// answers only the first, and it is the second that the firmware acts on --
+	// when it misses, the Pi discards the config it was just served, probes the
+	// default kernel names (kernel_2712.img, kernel8.img, kernel8_rt.img), finds
+	// nothing and loops forever. Observed on a Pi 5 booting a custom OSIE.
+	//
+	// The miss is close to invisible: this route simply returns handled=false,
+	// the router falls through, and the client gets a 404 for a file it has
+	// already been told exists. What it looks like from outside is a Pi that
+	// fetched a few files and then went quiet.
+	//
+	// Only the comparison is normalised. The rewritten path below keeps the raw
+	// suffix, for a reason worth spelling out: os.OpenRoot already resolves the
+	// doubled slash for real files, so cleaning buys nothing there -- but it
+	// costs something. OpenRoot refuses a path that escapes the root, and
+	// "<FirmwarePath>/../../../etc/passwd" does. Cleaning the suffix first
+	// rewrites that request to "/etc/passwd", making the rewritten path
+	// "<FirmwarePath>/etc/passwd", which is inside the root and served if it
+	// happens to exist. Normalising here would convert a refusal into a hit.
+	switch path.Clean(suffix) {
+	case "/config.txt":
 		log.Info("serving RPI ConfigTxt")
 		return serveTemplate(w, log, span, req.Filename, rpi.ConfigTxt)
-	case rpi.SerialNum + "/cmdline.txt":
+	case "/cmdline.txt":
 		cmdline := strings.Join(hw.OSIE.KernelParams, " ")
 		log.Info("serving cmdline.txt from OSIE.KernelParams", "params", hw.OSIE.KernelParams)
 		return serveTemplate(w, log, span, req.Filename, cmdline)
 	}
 
 	// The rewritten path mixes hardware-supplied FirmwarePath with the
-	// client-supplied suffix; openAsset confines it to AssetDir and rejects
-	// absolute paths and ".." traversal so neither can escape the directory.
-	rewritten := rpi.FirmwarePath + req.Filename[len(rpi.SerialNum):]
+	// client-supplied suffix; openAsset confines it to AssetDir via os.OpenRoot,
+	// so neither can escape the directory. Note OpenRoot refuses a path that
+	// leaves the root, not every ".." -- one that resolves back inside is served
+	// -- which is the distinction the comment above depends on.
+	rewritten := rpi.FirmwarePath + suffix
 	log.V(1).Info("attempting to load rewritten file from asset dir", "rewritten", rewritten, "assetDir", r.AssetDir)
 
 	file, err := openAsset(r.AssetDir, rewritten)

--- a/smee/internal/ipxe/binary/route_rpi.go
+++ b/smee/internal/ipxe/binary/route_rpi.go
@@ -70,13 +70,20 @@ func (r RPiNetbootRoute) TryServe(ctx context.Context, req Request, w io.ReaderF
 
 	suffix := req.Filename[len(rpi.SerialNum):]
 
-	// Compared cleaned, because the bootloader asks for each of these TWICE:
-	// once as "<serial>/config.txt" and again as "<serial>//config.txt", with a
-	// doubled slash. Both are the same request. An exact match on req.Filename
-	// answers only the first, and it is the second that the firmware acts on --
-	// when it misses, the Pi discards the config it was just served, probes the
-	// default kernel names (kernel_2712.img, kernel8.img, kernel8_rt.img), finds
-	// nothing and loops forever. Observed on a Pi 5 booting a custom OSIE.
+	// Compared cleaned, because the Raspberry Pi 5 bootloader asks for each of
+	// these TWICE: once as "<serial>/config.txt" and again as
+	// "<serial>//config.txt", with a doubled slash. Both are the same request.
+	// An exact match on req.Filename answers only the first, and it is the
+	// second that the firmware acts on -- when it misses, the Pi discards the
+	// config it was just served, probes the default kernel names
+	// (kernel_2712.img, kernel8.img, kernel8_rt.img), finds nothing and loops
+	// forever.
+	//
+	// This is observed behaviour of the Pi 5 bootloader specifically, seen on a
+	// Pi 5 booting a custom OSIE. It has not been observed on other models, and
+	// no such behaviour is documented by Raspberry Pi. Cleaning the comparison
+	// is a no-op for a client that only ever sends the single-slash form, so
+	// the route behaves identically for models that do not do this.
 	//
 	// The miss is close to invisible: this route simply returns handled=false,
 	// the router falls through, and the client gets a 404 for a file it has

--- a/smee/internal/ipxe/binary/tftp_test.go
+++ b/smee/internal/ipxe/binary/tftp_test.go
@@ -310,6 +310,17 @@ func TestRPiNetbootRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// A second asset dir holding <rewrite>/etc/passwd: the file an escaping
+	// traversal would land on if the suffix were cleaned before openAsset saw
+	// it. Kept separate so the ordinary cases above cannot reach it.
+	assetDirWithDecoy := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(assetDirWithDecoy, rewrite, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assetDirWithDecoy, rewrite, "etc", "passwd"), []byte("root:x:0:0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	tests := map[string]struct {
 		filename    string
 		assetDir    string
@@ -382,6 +393,51 @@ func TestRPiNetbootRoute(t *testing.T) {
 		"traversal in suffix is rejected": {
 			filename:    serial + "/../../../etc/passwd",
 			assetDir:    assetDir,
+			resolver:    &fakeResolver{byIP: map[string]hardware.Info{clientIP.String(): hwWithRPi}},
+			wantHandled: false,
+		},
+		// The bootloader asks for config.txt and cmdline.txt twice, the second
+		// time with a doubled slash, and it is the second answer the firmware
+		// acts on. Matching only the single-slash form made the Pi discard the
+		// config it had just been served and loop on the default kernel names.
+		"config.txt with a doubled slash served from ConfigTxt": {
+			filename:    serial + "//config.txt",
+			assetDir:    assetDir,
+			resolver:    &fakeResolver{byIP: map[string]hardware.Info{clientIP.String(): hwWithRPi}},
+			wantHandled: true,
+			wantBody:    "config-txt-body",
+		},
+		"cmdline.txt with a doubled slash served from joined OSIE.KernelParams": {
+			filename:    serial + "//cmdline.txt",
+			assetDir:    assetDir,
+			resolver:    &fakeResolver{byIP: map[string]hardware.Info{clientIP.String(): hwWithRPi}},
+			wantHandled: true,
+			wantBody:    "console=tty1 rw",
+		},
+		// Real files already tolerated the doubled slash before this route
+		// normalised anything -- os.OpenRoot resolves it -- which is why only
+		// the two inline files ever broke. Pinned so a future rewrite of the
+		// path handling does not quietly lose it.
+		"doubled slash on a rewritten asset still served from disk": {
+			filename:    serial + "//start.elf",
+			assetDir:    assetDir,
+			resolver:    &fakeResolver{byIP: map[string]hardware.Info{clientIP.String(): hwWithRPi}},
+			wantHandled: true,
+			wantBody:    assetBody,
+		},
+		// The doubled-slash fix normalises the path used to PICK the inline
+		// files. It must not also normalise the one handed to openAsset.
+		//
+		// os.OpenRoot rejects a path that escapes the root, and
+		// "rpi4b/../../../etc/passwd" does. path.Clean would rewrite that same
+		// request to "/etc/passwd" first, making the rewritten path
+		// "rpi4b/etc/passwd" -- inside the root, and served, because the file
+		// below exists. So this is the case where cleaning the suffix would
+		// change the answer from refused to served, which is why the rewrite
+		// path keeps the raw suffix.
+		"escaping traversal is refused even when the cleaned path would resolve": {
+			filename:    serial + "/../../../etc/passwd",
+			assetDir:    assetDirWithDecoy,
 			resolver:    &fakeResolver{byIP: map[string]hardware.Info{clientIP.String(): hwWithRPi}},
 			wantHandled: false,
 		},


### PR DESCRIPTION
Fixes #953.

### The bug

`RPiNetbootRoute` matched the two inline files with an exact `switch req.Filename`. The Raspberry Pi 5 bootloader asks for each of them **twice** — once as `<serial>/config.txt` and again as `<serial>//config.txt`, with a doubled slash — so only the first form was answered.

This is observed Pi 5 behaviour, from one Pi 5 booting a custom OSIE. No other model has been tested and Raspberry Pi documents nothing of the kind, so the claim is deliberately scoped to the Pi 5. The fix does not depend on which models do it: `path.Clean` on the comparison is a no-op for a well-formed path, so a client that only ever sends the single-slash form takes exactly the same branch it does today.

The second is the one the firmware acts on. On a miss the Pi discards the config it was just served, probes the default kernel names (`kernel_2712.img`, `kernel8.img`, `kernel8_rt.img`), finds nothing and loops.

Real files were unaffected the whole time, because the rewritten path goes through `os.OpenRoot`, which resolves the doubled slash — `<serial>//overlays/overlay_map.dtb` was served correctly. That is why only `configTxt` and `kernelParams` broke, and why it presents as a bad `config.txt` rather than a routing bug.

It is also close to silent. The prefix check passes (`<serial>//config.txt` does start with `<serial>/`), so not even the `V(1)` "request path does not begin with SerialNum" line fires — the `switch` just falls out the bottom. From outside it looks like a Pi that fetched a few files and went quiet.

### The fix

Compare on `path.Clean` of the suffix, so both forms reach the inline templates.

**Only the comparison is normalised — the rewritten path keeps the raw suffix**, and that is deliberate. `OpenRoot` already resolves the doubled slash for real files, so cleaning buys nothing there, but it costs something: `OpenRoot` refuses a path that escapes the root, and `<FirmwarePath>/../../../etc/passwd` does. `path.Clean` rewrites that to `/etc/passwd` first, making the rewritten path `<FirmwarePath>/etc/passwd` — inside the root, and served if it exists. Cleaning the rewrite path would turn a refusal into a hit.

There is a test for exactly that case, with a decoy file in place so it is a real distinction rather than a coincidental miss. I checked it fails (`handled=true want=false`) when the rewrite path is cleaned.

### Tests

Four cases added to `TestRPiNetbootRoute`:

- `config.txt with a doubled slash served from ConfigTxt` — the bug
- `cmdline.txt with a doubled slash served from joined OSIE.KernelParams` — same, other file
- `doubled slash on a rewritten asset still served from disk` — pins the behaviour that already worked, so a future rewrite of the path handling does not lose it
- `escaping traversal is refused even when the cleaned path would resolve` — pins the raw-suffix decision above

### Also

Corrected a comment on `openAsset` while in there: it refuses paths that *leave* the root, not every `..`. One that resolves back inside is served — which is the distinction the fix depends on, so it seemed worth having the comment say so.

### Note

Independent of #952, which touches the same file. Whichever merges first, I will rebase the other.

