### PR TITLE
smee: honour AllowNetboot also in the PXELinux (u-boot) route

### DIFF
--- a/smee/internal/ipxe/binary/http_test.go
+++ b/smee/internal/ipxe/binary/http_test.go
@@ -31,7 +31,7 @@ func TestHTTPHandler(t *testing.T) {
 	}
 	const pxeConfig = "PROMPT 0\nDEFAULT linux"
 	resolver := &fakeResolver{byMAC: map[string]hardware.Info{
-		mac.String(): {PXELINUX: hardware.PXELINUX{Config: pxeConfig}},
+		mac.String(): {AllowNetboot: true, PXELINUX: hardware.PXELINUX{Config: pxeConfig}},
 	}}
 
 	dir := t.TempDir()

--- a/smee/internal/ipxe/binary/route_pxelinux.go
+++ b/smee/internal/ipxe/binary/route_pxelinux.go
@@ -19,9 +19,10 @@ import (
 // and the Hardware's PXELINUX.Config is served.
 //
 // The route returns handled=false when the path doesn't have that exact
-// shape, when MAC parsing fails, when the Hardware lookup fails, or when
-// the matched Hardware has no PXELINUX.Config. In all of those cases
-// the next Route in the Router gets a chance.
+// shape, when MAC parsing fails, when the Hardware lookup fails, when
+// netboot is not allowed for the matched Hardware, or when it has no
+// PXELINUX.Config. In all of those cases the next Route in the Router
+// gets a chance.
 type PXELinuxMACRoute struct {
 	Log      logr.Logger
 	Resolver hardware.Resolver
@@ -54,6 +55,21 @@ func (r PXELinuxMACRoute) TryServe(ctx context.Context, req Request, w io.Reader
 	hw, err := r.Resolver.ByMAC(ctx, mac)
 	if err != nil {
 		log.Error(err, "failed to get hardware by MAC", "mac", mac.String())
+		return false, nil
+	}
+
+	// Netboot has to be allowed, the same gate the iPXE script handler and
+	// the Raspberry Pi netboot route apply. AllowNetboot is what the
+	// Hardware's netboot.allowPXE becomes once dhcp.Convert* has translated
+	// it into hardware.Info.
+	//
+	// Without this the route serves the pxelinux.cfg forever: a machine that
+	// has just been provisioned reboots, the Workflow controller clears
+	// allowPXE (bootOptions.toggleAllowNetboot), and u-boot is handed the
+	// OSIE again instead of falling through to the disk it was just
+	// installed to. It never boots the installed OS.
+	if !hw.AllowNetboot {
+		log.V(1).Info("hardware does not allow netboot; skipping", "mac", mac.String())
 		return false, nil
 	}
 

--- a/smee/internal/ipxe/binary/tftp_test.go
+++ b/smee/internal/ipxe/binary/tftp_test.go
@@ -228,10 +228,19 @@ func TestPXELinuxMACRoute(t *testing.T) {
 		"valid path, template served": {
 			filename: "pxelinux.cfg/01-" + dashed,
 			resolver: &fakeResolver{byMAC: map[string]hardware.Info{
-				mac.String(): {PXELINUX: hardware.PXELINUX{Config: "PROMPT 0\nDEFAULT linux"}},
+				mac.String(): {AllowNetboot: true, PXELINUX: hardware.PXELINUX{Config: "PROMPT 0\nDEFAULT linux"}},
 			}},
 			wantHandled:    true,
 			wantBytesMatch: "PROMPT 0\nDEFAULT linux",
+		},
+		// AllowNetboot is netboot.allowPXE after dhcp.Convert*; the Workflow
+		// controller clears it once a machine is provisioned.
+		"netboot not allowed passes through": {
+			filename: "pxelinux.cfg/01-" + dashed,
+			resolver: &fakeResolver{byMAC: map[string]hardware.Info{
+				mac.String(): {AllowNetboot: false, PXELINUX: hardware.PXELINUX{Config: "PROMPT 0\nDEFAULT linux"}},
+			}},
+			wantHandled: false,
 		},
 		"wrong length passes through": {
 			filename:    "pxelinux.cfg/01-short",
@@ -253,10 +262,12 @@ func TestPXELinuxMACRoute(t *testing.T) {
 			resolver:    &fakeResolver{},
 			wantHandled: false,
 		},
+		// AllowNetboot set so the gate above doesn't short-circuit the case
+		// this is actually testing.
 		"empty template passes through": {
 			filename: "pxelinux.cfg/01-" + dashed,
 			resolver: &fakeResolver{byMAC: map[string]hardware.Info{
-				mac.String(): {PXELINUX: hardware.PXELINUX{Config: ""}},
+				mac.String(): {AllowNetboot: true, PXELINUX: hardware.PXELINUX{Config: ""}},
 			}},
 			wantHandled: false,
 		},


### PR DESCRIPTION
- 🌴 Same gate as c856c0b (RPi netboot route) and 15dce38 (fixture fix), applied to PXELinuxMACRoute: without it a provisioned machine keeps being served pxelinux.cfg after the Workflow controller clears allowPXE, so it never falls through to disk.
- 🍃 Fixtures set AllowNetboot so the existing cases still reach the branch they name; one case added for the gate itself.