### PR TITLE
smee: preserve traceparent sampling flags

### DIFF
--- a/smee/internal/ipxe/binary/binary.go
+++ b/smee/internal/ipxe/binary/binary.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -93,37 +94,27 @@ func (h Handler) Handle(w http.ResponseWriter, req *http.Request) {
 	span.SetStatus(codes.Ok, filename)
 }
 
+var traceparentFilenameRe = regexp.MustCompile(`^(.*)-([[:xdigit:]]{2}-[[:xdigit:]]{32}-[[:xdigit:]]{16}-[[:xdigit:]]{2})$`)
+
 // extractTraceparentFromFilename takes a context and filename and checks the filename for
-// a traceparent tacked onto the end of it. If there is a match, the traceparent is extracted
-// and a new SpanContext is constructed and added to the context.Context that is returned.
-// The filename is shortened to just the original filename so the rest of the serving process can
-// carry on as usual.
+// a traceparent tacked onto the end of it. If there is a match, the traceparent is extracted,
+// validated with the OpenTelemetry W3C propagator, and added as a remote SpanContext to the
+// returned context. The filename is shortened to just the original filename so the rest of the
+// serving process can carry on as usual.
 func extractTraceparentFromFilename(ctx context.Context, filename string) (context.Context, string, error) {
-	// traceparentRe captures 4 items, the original filename, the trace id, span id, and trace flags
-	traceparentRe := regexp.MustCompile("^(.*)-[[:xdigit:]]{2}-([[:xdigit:]]{32})-([[:xdigit:]]{16})-([[:xdigit:]]{2})")
-	parts := traceparentRe.FindStringSubmatch(filename)
-	if len(parts) == 5 {
-		traceID, err := trace.TraceIDFromHex(parts[2])
-		if err != nil {
-			return ctx, filename, fmt.Errorf("parsing OpenTelemetry trace id %q failed: %w", parts[2], err)
-		}
-
-		spanID, err := trace.SpanIDFromHex(parts[3])
-		if err != nil {
-			return ctx, filename, fmt.Errorf("parsing OpenTelemetry span id %q failed: %w", parts[3], err)
-		}
-
-		// create a span context with the parent trace id & span id
-		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
-			TraceID:    traceID,
-			SpanID:     spanID,
-			Remote:     true,
-			TraceFlags: trace.FlagsSampled, // TODO: use the parts[4] value instead
-		})
-
-		// inject it into the context.Context and return it along with the original filename
-		return trace.ContextWithSpanContext(ctx, spanCtx), parts[1], nil
+	parts := traceparentFilenameRe.FindStringSubmatch(filename)
+	if len(parts) != 3 {
+		return ctx, filename, nil
 	}
-	// no traceparent found, return everything as it was
-	return ctx, filename, nil
+
+	// Let OpenTelemetry's W3C propagator validate the complete traceparent and
+	// preserve the spec-defined trace flags instead of forcing every parent to sampled.
+	carrier := propagation.MapCarrier{"traceparent": parts[2]}
+	parsedCtx := propagation.TraceContext{}.Extract(context.Background(), carrier)
+	spanCtx := trace.SpanContextFromContext(parsedCtx)
+	if !spanCtx.IsValid() {
+		return ctx, filename, fmt.Errorf("parsing OpenTelemetry traceparent %q failed", parts[2])
+	}
+
+	return trace.ContextWithRemoteSpanContext(ctx, spanCtx), parts[1], nil
 }

--- a/smee/internal/ipxe/binary/binary_traceparent_test.go
+++ b/smee/internal/ipxe/binary/binary_traceparent_test.go
@@ -1,0 +1,130 @@
+package binary
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	testTraceID = "0af7651916cd43dd8448eb211c80319c"
+	testSpanID  = "b7ad6b7169203331"
+)
+
+func TestExtractTraceparentFromFilenamePreservesFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		flags         string
+		wantSampled   bool
+		wantRandom    bool
+		wantTraceFlag trace.TraceFlags
+	}{
+		{name: "not sampled", flags: "00", wantTraceFlag: 0},
+		{name: "sampled", flags: "01", wantSampled: true, wantTraceFlag: trace.FlagsSampled},
+		{name: "random", flags: "02", wantRandom: true, wantTraceFlag: trace.FlagsRandom},
+		{name: "sampled and random", flags: "03", wantSampled: true, wantRandom: true, wantTraceFlag: trace.FlagsSampled | trace.FlagsRandom},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filename := "snp-x86_64.efi-00-" + testTraceID + "-" + testSpanID + "-" + tt.flags
+
+			ctx, short, err := extractTraceparentFromFilename(context.Background(), filename)
+			if err != nil {
+				t.Fatalf("extractTraceparentFromFilename() error = %v", err)
+			}
+			if short != "snp-x86_64.efi" {
+				t.Fatalf("short filename = %q, want %q", short, "snp-x86_64.efi")
+			}
+
+			sc := trace.SpanContextFromContext(ctx)
+			if !sc.IsValid() {
+				t.Fatal("expected a valid remote span context")
+			}
+			if !sc.IsRemote() {
+				t.Fatal("expected extracted span context to be remote")
+			}
+			if sc.TraceID().String() != testTraceID {
+				t.Fatalf("trace ID = %q, want %q", sc.TraceID().String(), testTraceID)
+			}
+			if sc.SpanID().String() != testSpanID {
+				t.Fatalf("span ID = %q, want %q", sc.SpanID().String(), testSpanID)
+			}
+			if sc.TraceFlags() != tt.wantTraceFlag {
+				t.Fatalf("trace flags = %02x, want %02x", byte(sc.TraceFlags()), byte(tt.wantTraceFlag))
+			}
+			if sc.IsSampled() != tt.wantSampled {
+				t.Fatalf("IsSampled() = %v, want %v", sc.IsSampled(), tt.wantSampled)
+			}
+			if sc.IsRandom() != tt.wantRandom {
+				t.Fatalf("IsRandom() = %v, want %v", sc.IsRandom(), tt.wantRandom)
+			}
+		})
+	}
+}
+
+func TestExtractTraceparentFromFilenameRejectsInvalidTraceparent(t *testing.T) {
+	original := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1},
+		SpanID:  trace.SpanID{1},
+	})
+	input := trace.ContextWithSpanContext(context.Background(), original)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "reserved flags for version zero",
+			filename: "snp-x86_64.efi-00-" + testTraceID + "-" + testSpanID + "-04",
+		},
+		{
+			name:     "all zero trace id",
+			filename: "snp-x86_64.efi-00-00000000000000000000000000000000-" + testSpanID + "-01",
+		},
+		{
+			name:     "all zero span id",
+			filename: "snp-x86_64.efi-00-" + testTraceID + "-0000000000000000-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, short, err := extractTraceparentFromFilename(input, tt.filename)
+			if err == nil {
+				t.Fatal("expected invalid traceparent to return an error")
+			}
+			if short != tt.filename {
+				t.Fatalf("short filename = %q, want original %q", short, tt.filename)
+			}
+			if got := trace.SpanContextFromContext(ctx); !got.Equal(original) {
+				t.Fatalf("span context changed on invalid traceparent: got %+v want %+v", got, original)
+			}
+		})
+	}
+}
+
+func TestExtractTraceparentFromFilenameLeavesOrdinaryFilenameUntouched(t *testing.T) {
+	original := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1},
+		SpanID:  trace.SpanID{1},
+	})
+	input := trace.ContextWithSpanContext(context.Background(), original)
+
+	for _, filename := range []string{
+		"snp-x86_64.efi",
+		"snp-x86_64.efi-00-" + testTraceID + "-" + testSpanID + "-01-extra",
+	} {
+		ctx, short, err := extractTraceparentFromFilename(input, filename)
+		if err != nil {
+			t.Fatalf("extractTraceparentFromFilename(%q) error = %v", filename, err)
+		}
+		if short != filename {
+			t.Fatalf("short filename = %q, want %q", short, filename)
+		}
+		if got := trace.SpanContextFromContext(ctx); !got.Equal(original) {
+			t.Fatalf("span context changed for ordinary filename: got %+v want %+v", got, original)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Smee currently extracts a W3C `traceparent` from iPXE/TFTP filenames so that provisioning requests can remain connected to an upstream distributed trace.

However, while the trace ID and parent span ID are preserved, the incoming `trace-flags` byte is ignored and the reconstructed `SpanContext` is always marked as sampled:

```go
TraceFlags: trace.FlagsSampled
```

This means that an upstream parent such as:

```text
00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00
```

is incorrectly converted into a sampled remote parent inside Smee.

Besides changing the upstream sampling decision, this can create unnecessary telemetry and makes the propagated trace context semantically different from the one received by Smee.

This PR fixes that behavior by delegating traceparent parsing to OpenTelemetry's W3C `TraceContext` propagator instead of reconstructing the `SpanContext` manually.

### What changes

The traceparent embedded in the filename is now:

1. detected and separated from the original requested filename;
2. parsed using `propagation.TraceContext`;
3. accepted only when OpenTelemetry considers the W3C trace context valid;
4. inserted into the returned context as a remote parent without modifying its trace flags.

This preserves the trace context as received, including:

* `00` — not sampled
* `01` — sampled
* `02` — random trace ID
* `03` — sampled + random trace ID

The filename matching is also anchored to the end of the request so that filenames containing additional trailing data are not accidentally interpreted as valid traceparents.

### Why this matters

Tinkerbell already propagates tracing information across DHCP, PXE/TFTP, and provisioning components. Preserving the incoming trace context is important for maintaining correct end-to-end observability semantics.

A downstream service should not silently change the parent's sampling decision while propagating the same trace.

Using OpenTelemetry's own W3C parser also avoids maintaining a partial traceparent implementation in Smee and keeps parsing behavior aligned with the OpenTelemetry version already used by the project.

This contributes to the broader end-to-end OpenTelemetry work tracked in #764.

### Testing

Added regression coverage for:

* non-sampled traceparent (`00`);
* sampled traceparent (`01`);
* random trace ID flag (`02`);
* sampled + random flags (`03`);
* reserved flags in W3C traceparent version `00`;
* all-zero trace IDs;
* all-zero span IDs;
* ordinary filenames without trace context;
* traceparent-shaped suffixes followed by unexpected trailing data;
* preservation of the original context when the embedded traceparent is invalid.

### Compatibility

There are no API or configuration changes.

Valid existing sampled traceparents continue to behave as before. The behavioral change is limited to preserving the actual flags supplied by the upstream trace context rather than forcing every propagated trace to be sampled.

Fixes part of #764.
