### PR TITLE
serve pending workflows shadowed by terminal ones:

### DIFF
--- a/tink/server/internal/grpc/grpc.go
+++ b/tink/server/internal/grpc/grpc.go
@@ -199,6 +199,12 @@ func (h *Handler) doGetAction(ctx context.Context, req *proto.ActionRequest, opt
 
 	journal.Log(ctx, "found Workflows", "workflows", len(wfs))
 	var wf tinkerbell.Workflow
+	// Scan every Workflow for this agent instead of returning on the first
+	// ineligible one. Terminal Workflows keep their Status.AgentID and so remain
+	// in the agent-ID index indefinitely; returning early would let one of them
+	// permanently shadow a later pending/running Workflow assigned to the same
+	// agent, so its Action would never be served.
+	var found, preparing, terminal, otherNotRunning bool
 	for _, w := range wfs {
 		if len(w.Status.Tasks) == 0 {
 			continue
@@ -207,23 +213,38 @@ func (h *Handler) doGetAction(ctx context.Context, req *proto.ActionRequest, opt
 		// This is to prevent the Agent from starting Actions before Workflow boot options are performed.
 		if w.Spec.BootOptions.BootMode != "" && w.Status.State == tinkerbell.WorkflowStatePreparing {
 			journal.Log(ctx, "Workflow is in preparing state")
-			return nil, status.Error(codes.FailedPrecondition, "Workflow is in preparing state")
+			preparing = true
+			continue
 		}
 		if w.Status.State != tinkerbell.WorkflowStatePending && w.Status.State != tinkerbell.WorkflowStateRunning {
 			journal.Log(ctx, "Workflow not in pending or running state")
-			err := status.Error(codes.FailedPrecondition, "Workflow not in pending or running state")
 			if isAgentTerminalWorkflowState(w.Status.State) {
-				return nil, backoff.Permanent(err)
+				terminal = true
+			} else {
+				otherNotRunning = true
 			}
-			return nil, err
+			continue
 		}
 		wf = w
+		found = true
 		journal.Log(ctx, "found Workflow", "workflow", wf.Name)
 		break
 	}
-	if len(wf.Status.Tasks) == 0 {
-		journal.Log(ctx, "no Tasks found in Workflow")
-		return nil, status.Error(codes.NotFound, "no Tasks found in Workflow")
+	if !found {
+		switch {
+		case preparing:
+			// Preparing is transient, so keep the error retryable.
+			return nil, status.Error(codes.FailedPrecondition, "Workflow is in preparing state")
+		case otherNotRunning:
+			return nil, status.Error(codes.FailedPrecondition, "Workflow not in pending or running state")
+		case terminal:
+			// Every candidate is terminal and terminal state never changes, so stop
+			// the server-side retry loop instead of retrying for the full timeout.
+			return nil, backoff.Permanent(status.Error(codes.FailedPrecondition, "Workflow not in pending or running state"))
+		default:
+			journal.Log(ctx, "no Tasks found in Workflow")
+			return nil, status.Error(codes.NotFound, "no Tasks found in Workflow")
+		}
 	}
 
 	var task *tinkerbell.Task

--- a/tink/server/internal/grpc/grpc_test.go
+++ b/tink/server/internal/grpc/grpc_test.go
@@ -1348,3 +1348,123 @@ func actionStatusRequest(actionState proto.ActionStatusRequest_StateType) *proto
 		Message:           &proto.ActionMessage{Message: toPtr("late report")},
 	}
 }
+
+// terminalWorkflowFixture returns a completed Workflow that still carries the
+// agent's ID, so it remains in the agent-ID index alongside newer Workflows.
+func terminalWorkflowFixture(name string) tinkerbell.Workflow {
+	return tinkerbell.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status: tinkerbell.WorkflowStatus{
+			AgentID: "machine-mac-1",
+			State:   tinkerbell.WorkflowStateSuccess,
+			Tasks: []tinkerbell.Task{
+				{
+					Name:    "provision",
+					AgentID: "machine-mac-1",
+					ID:      "provision",
+					Actions: []tinkerbell.Action{{
+						Name:  "stream",
+						Image: "quay.io/tinkerbell-actions/image2disk:v1.0.0",
+						State: tinkerbell.WorkflowStateSuccess,
+						ID:    "stream",
+					}},
+				},
+			},
+		},
+	}
+}
+
+// activeWorkflowFixture returns a running Workflow whose first Action is servable.
+func activeWorkflowFixture(name string) tinkerbell.Workflow {
+	return tinkerbell.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status: tinkerbell.WorkflowStatus{
+			AgentID:       "machine-mac-1",
+			State:         tinkerbell.WorkflowStateRunning,
+			GlobalTimeout: 600,
+			Tasks: []tinkerbell.Task{
+				{
+					Name:    "provision",
+					AgentID: "machine-mac-1",
+					Actions: []tinkerbell.Action{{
+						Name:    "stream",
+						Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
+						Timeout: 300,
+						State:   tinkerbell.WorkflowStatePending,
+					}},
+				},
+			},
+		},
+	}
+}
+
+// TestGetActionTerminalDoesNotShadowActive verifies that a terminal Workflow
+// left in the agent-ID index does not prevent a co-listed pending/running
+// Workflow for the same agent from being served, regardless of list order.
+func TestGetActionTerminalDoesNotShadowActive(t *testing.T) {
+	t.Run("terminal listed before active still serves active", func(t *testing.T) {
+		backend := &mockBackendReadWriter{}
+		backend.listWorkflowsFunc = func() ([]tinkerbell.Workflow, error) {
+			return []tinkerbell.Workflow{terminalWorkflowFixture("machine0"), activeWorkflowFixture("machine1")}, nil
+		}
+		handler := &Handler{
+			Logger:       logr.Discard(),
+			Backend:      backend,
+			NowFunc:      func() time.Time { return time.Time{} },
+			RetryOptions: []backoff.RetryOption{backoff.WithMaxTries(1)},
+		}
+
+		resp, err := handler.GetAction(context.Background(), &proto.ActionRequest{AgentId: toPtr("machine-mac-1")})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.GetName() != "stream" || resp.GetWorkflowId() != "default/machine1" {
+			t.Fatalf("expected active Workflow's action to be served, got workflow %q action %q", resp.GetWorkflowId(), resp.GetName())
+		}
+	})
+
+	t.Run("active listed before terminal still serves active", func(t *testing.T) {
+		backend := &mockBackendReadWriter{}
+		backend.listWorkflowsFunc = func() ([]tinkerbell.Workflow, error) {
+			return []tinkerbell.Workflow{activeWorkflowFixture("machine1"), terminalWorkflowFixture("machine0")}, nil
+		}
+		handler := &Handler{
+			Logger:       logr.Discard(),
+			Backend:      backend,
+			NowFunc:      func() time.Time { return time.Time{} },
+			RetryOptions: []backoff.RetryOption{backoff.WithMaxTries(1)},
+		}
+
+		resp, err := handler.GetAction(context.Background(), &proto.ActionRequest{AgentId: toPtr("machine-mac-1")})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.GetName() != "stream" || resp.GetWorkflowId() != "default/machine1" {
+			t.Fatalf("expected active Workflow's action to be served, got workflow %q action %q", resp.GetWorkflowId(), resp.GetName())
+		}
+	})
+
+	t.Run("all terminal fails permanently without retrying", func(t *testing.T) {
+		backend := &mockBackendReadWriter{}
+		backend.listWorkflowsFunc = func() ([]tinkerbell.Workflow, error) {
+			return []tinkerbell.Workflow{terminalWorkflowFixture("machine0"), terminalWorkflowFixture("machine2")}, nil
+		}
+		handler := &Handler{
+			Logger:  logr.Discard(),
+			Backend: backend,
+			NowFunc: func() time.Time { return time.Time{} },
+			RetryOptions: []backoff.RetryOption{
+				backoff.WithMaxTries(3),
+				backoff.WithBackOff(backoff.NewConstantBackOff(0)),
+			},
+		}
+
+		_, err := handler.GetAction(context.Background(), &proto.ActionRequest{AgentId: toPtr("machine-mac-1")})
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("unexpected error code: got %s, want %s (error: %v)", status.Code(err), codes.FailedPrecondition, err)
+		}
+		if backend.workflowLists != 1 {
+			t.Fatalf("expected a permanent error to stop retrying after one list, got %d lists", backend.workflowLists)
+		}
+	})
+}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
A Workflow keeps its Status.AgentID after it completes, so it never leaves the agent-ID index that GetAction scans. When an agent is reassigned a new Workflow while an old completed one still lingers, the list returned for that agent can contain both, in no guaranteed order. GetAction stopped at the first ineligible entry it saw, so a lingering terminal Workflow ordered ahead of the new one left the agent unable to ever fetch its actions — the machine would sit idle indefinitely with work waiting for it.


Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
