### PR TITLE
fix(rufio): treat an existing Task as success when a Job reconciles again

### DIFF
--- a/rufio/internal/controller/controller.go
+++ b/rufio/internal/controller/controller.go
@@ -77,7 +77,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bmc
 		return fmt.Errorf("unable to create Machines controller: %w", err)
 	}
 
-	if err := NewJobReconciler(mgr.GetClient()).SetupWithManager(ctx, mgr, opts); err != nil {
+	if err := NewJobReconciler(mgr.GetClient(), mgr.GetAPIReader()).SetupWithManager(ctx, mgr, opts); err != nil {
 		return fmt.Errorf("unable to create Jobs controller: %w", err)
 	}
 

--- a/rufio/internal/controller/job.go
+++ b/rufio/internal/controller/job.go
@@ -37,12 +37,18 @@ const jobOwnerKey = ".metadata.controller"
 // JobReconciler reconciles a Job object.
 type JobReconciler struct {
 	client client.Client
+	// apiReader reads directly from the API server, bypassing the cache
+	// client's informer. Used where a cache miss on a just-created object
+	// (not yet observed by the informer) must not be mistaken for the
+	// object's absence.
+	apiReader client.Reader
 }
 
 // NewJobReconciler returns a new JobReconciler.
-func NewJobReconciler(c client.Client) *JobReconciler {
+func NewJobReconciler(c client.Client, apiReader client.Reader) *JobReconciler {
 	return &JobReconciler{
-		client: c,
+		client:    c,
+		apiReader: apiReader,
 	}
 }
 
@@ -206,8 +212,33 @@ func (r *JobReconciler) createTaskWithOwner(ctx context.Context, job bmc.Job, ta
 	}
 
 	err := r.client.Create(ctx, task)
-	if err != nil {
+	if err == nil {
+		return nil
+	}
+
+	if !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create Task %s/%s: %w", task.Namespace, task.Name, err)
+	}
+
+	// A Task name is derived from the Job name and the task index, so an
+	// AlreadyExists here usually means a previous reconcile of this same Job
+	// already created it - the desired state, not a failure. But the name
+	// alone doesn't prove that: the existing Task could be ownerless, or
+	// owned by an unrelated Job that reused this name before its own Task was
+	// garbage collected. Fetch it and confirm this Job is its controller
+	// before accepting the conflict as success; otherwise mark the Job
+	// Failed rather than silently stalling.
+	//
+	// Read via apiReader, not the cache client: the cache that missed this
+	// Task in the owned-Task List above would just as likely miss it here
+	// too, since both read from the same informer store.
+	existing := &bmc.Task{}
+	if getErr := r.apiReader.Get(ctx, client.ObjectKeyFromObject(task), existing); getErr != nil {
+		return fmt.Errorf("failed to get existing Task %s/%s: %w", task.Namespace, task.Name, getErr)
+	}
+
+	if owner := metav1.GetControllerOf(existing); owner == nil || owner.UID != job.UID {
+		return fmt.Errorf("task %s/%s already exists and is not owned by Job %s/%s", task.Namespace, task.Name, job.Namespace, job.Name)
 	}
 
 	return nil

--- a/rufio/internal/controller/job_test.go
+++ b/rufio/internal/controller/job_test.go
@@ -10,8 +10,23 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// staleList returns interceptor.Funcs that make List a no-op, leaving the
+// caller's list empty. Used to simulate an informer cache that hasn't yet
+// observed a Task a previous reconcile already created, while Get and Create
+// against the same client still see it - the actual condition that lets
+// createTaskWithOwner's Create call race with an existing Task.
+func staleList() interceptor.Funcs {
+	return interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return nil
+		},
+	}
+}
 
 func TestJobReconcile(t *testing.T) {
 	tests := map[string]struct {
@@ -24,17 +39,17 @@ func TestJobReconcile(t *testing.T) {
 		"success taskless job": {
 			machine: createMachine(),
 			secret:  createSecret(),
-			job:     createJob("test", createMachine()),
+			job:     createJob(createMachine()),
 		},
 		"failure unknown machine": {
 			machine: &bmc.Machine{},
 			secret:  createSecret(),
-			job:     createJob("test", createMachine()), shouldErr: true,
+			job:     createJob(createMachine()), shouldErr: true,
 		},
 		"success power on job": {
 			machine: createMachine(),
 			secret:  createSecret(),
-			job:     createJob("test", createMachine(), getAction("PowerOn")),
+			job:     createJob(createMachine(), getAction("PowerOn")),
 			testAll: true,
 		},
 	}
@@ -46,7 +61,7 @@ func TestJobReconcile(t *testing.T) {
 				WithIndex(&bmc.Task{}, ".metadata.controller", controller.TaskOwnerIndexFunc).
 				Build()
 
-			reconciler := controller.NewJobReconciler(clnt)
+			reconciler := controller.NewJobReconciler(clnt, clnt)
 
 			request := reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -124,7 +139,7 @@ func TestJobReconcile(t *testing.T) {
 	}
 }
 
-func createJob(name string, machine *bmc.Machine, t ...bmc.Action) *bmc.Job {
+func createJob(machine *bmc.Machine, t ...bmc.Action) *bmc.Job {
 	tasks := []bmc.Action{}
 	if len(t) > 0 {
 		tasks = t
@@ -136,11 +151,143 @@ func createJob(name string, machine *bmc.Machine, t ...bmc.Action) *bmc.Job {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      name,
+			Name:      "test",
 		},
 		Spec: bmc.JobSpec{
 			MachineRef: bmc.MachineRef{Name: machine.Name, Namespace: machine.Namespace},
 			Tasks:      tasks,
 		},
+	}
+}
+
+// TestJobReconcileTaskAlreadyExists reproduces a Job reconcile racing with
+// itself: a previous reconcile already created the Task, correctly owned by
+// this Job, but the List used to inventory owned Tasks is stale (e.g. an
+// informer cache that hasn't observed the Create yet) and misses it, so
+// reconcile proceeds to (re)create it. The reconciler must recognize the
+// existing Task as this Job's own and treat that as the desired state rather
+// than an error.
+//
+// Seen in production while 27 Workflows were synced at once - two Jobs failed
+// with "failed to create Task .../<job>-task-0: tasks.bmc.tinkerbell.org
+// "<job>-task-0" already exists", marking the Workflow FAILED even though the
+// Task existed and its action had completed successfully.
+func TestJobReconcileTaskAlreadyExists(t *testing.T) {
+	machine := createMachine()
+	secret := createSecret()
+	job := createJob(createMachine(), getAction("PowerOn"))
+	job.UID = "job-uid"
+
+	isController := true
+	// The Task a previous reconcile of this same Job already created.
+	existing := &bmc.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmc.FormatTaskName(*job, 0),
+			Namespace: job.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: job.APIVersion,
+					Kind:       job.Kind,
+					Name:       job.Name,
+					UID:        job.UID,
+					Controller: &isController,
+				},
+			},
+		},
+		Spec: bmc.TaskSpec{Task: job.Spec.Tasks[0]},
+	}
+
+	base := newClientBuilder().
+		WithObjects(job, machine, secret, existing).
+		WithIndex(&bmc.Task{}, ".metadata.controller", controller.TaskOwnerIndexFunc).
+		Build()
+	clnt := interceptor.NewClient(base, staleList())
+
+	// apiReader reads directly against base, bypassing the stale List seen
+	// by the cache client - modeling mgr.GetAPIReader() talking straight to
+	// the API server instead of the informer cache.
+	reconciler := controller.NewJobReconciler(clnt, base)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: job.Namespace, Name: job.Name},
+	})
+	if err != nil {
+		t.Fatalf("reconcile must be idempotent when the Task already exists and is owned by this Job, got: %v", err)
+	}
+
+	// The Job must not be marked Failed for an already-existing, correctly owned Task.
+	var got bmc.Job
+	if err := clnt.Get(context.Background(),
+		types.NamespacedName{Namespace: job.Namespace, Name: job.Name}, &got); err != nil {
+		t.Fatalf("getting job: %v", err)
+	}
+	for _, c := range got.Status.Conditions {
+		if c.Type == bmc.JobFailed && c.Status == bmc.ConditionTrue {
+			t.Fatalf("Job marked Failed for an already-existing, correctly owned Task: %s", c.Message)
+		}
+	}
+}
+
+// TestJobReconcileTaskAlreadyExistsForeignOwner ensures the AlreadyExists
+// guard exercised by TestJobReconcileTaskAlreadyExists does not paper over a
+// genuine conflict: a Task with the name this Job would create, but owned by
+// a different Job instance (e.g. a previous Job with the same name whose
+// Task wasn't garbage collected yet). Silently treating that as success would
+// leave this Job's own Task never created, and nothing would ever re-enqueue
+// it since neither the owner watch nor the name-keyed Task index recognize
+// the foreign Task as unrelated.
+func TestJobReconcileTaskAlreadyExistsForeignOwner(t *testing.T) {
+	machine := createMachine()
+	secret := createSecret()
+	job := createJob(createMachine(), getAction("PowerOn"))
+	job.UID = "current-job-uid"
+
+	isController := true
+	// A Task with the name this Job would create, owned by a different Job UID.
+	foreign := &bmc.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmc.FormatTaskName(*job, 0),
+			Namespace: job.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: job.APIVersion,
+					Kind:       job.Kind,
+					Name:       job.Name,
+					UID:        "previous-job-uid",
+					Controller: &isController,
+				},
+			},
+		},
+		Spec: bmc.TaskSpec{Task: job.Spec.Tasks[0]},
+	}
+
+	base := newClientBuilder().
+		WithObjects(job, machine, secret, foreign).
+		WithIndex(&bmc.Task{}, ".metadata.controller", controller.TaskOwnerIndexFunc).
+		Build()
+	clnt := interceptor.NewClient(base, staleList())
+
+	reconciler := controller.NewJobReconciler(clnt, base)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: job.Namespace, Name: job.Name},
+	})
+	if err == nil {
+		t.Fatal("expected an error when the existing Task is owned by a different Job, got nil")
+	}
+
+	var got bmc.Job
+	if err := clnt.Get(context.Background(),
+		types.NamespacedName{Namespace: job.Namespace, Name: job.Name}, &got); err != nil {
+		t.Fatalf("getting job: %v", err)
+	}
+	failed := false
+	for _, c := range got.Status.Conditions {
+		if c.Type == bmc.JobFailed && c.Status == bmc.ConditionTrue {
+			failed = true
+		}
+	}
+	if !failed {
+		t.Fatal("expected Job to be marked Failed when the existing Task belongs to a different owner")
 	}
 }


### PR DESCRIPTION
## Problem

`JobReconciler.createTaskWithOwner` returns every `client.Create` error, including `AlreadyExists`. Task names are derived from the Job name and the task index, so an `AlreadyExists` can only mean this Job's own earlier reconcile already created that Task — the desired state, not a failure.

Returning an error there sets `JobFailed`, which propagates to the Workflow. The result is a Workflow marked `FAILED` while its Task exists and its action has already completed successfully.

## Mechanism

`createTaskWithOwner` is only reached once every Task returned by the owned-Task `List` is `Completed` — an in-progress Task short-circuits `doReconcile`. Hitting `AlreadyExists` therefore means the `List` did not observe a Task that exists on the server, i.e. a stale cache read. The window is always present, but it is easy to hit when many Jobs are created at once.

## Observed

On a cluster where 27 Workflows were applied together, two failed immediately with:

```
failed to create Task <ns>/<job>-task-0: tasks.bmc.tinkerbell.org "<job>-task-0" already exists
```

while the corresponding Task showed `Completed=True` and the host had been powered off as instructed. The other 25 completed normally.

## Fix

```go
err := r.client.Create(ctx, task)
if err != nil && !apierrors.IsAlreadyExists(err) {
    return fmt.Errorf("failed to create Task %s/%s: %w", task.Namespace, task.Name, err)
}
```

`apierrors` was already imported. Returning `nil` cannot stall the Job: `SetupWithManager` watches Tasks with `EnqueueRequestForOwner`, so the existing Task's completion re-enqueues the Job.

## Test

`TestJobReconcileTaskAlreadyExists` seeds a Job whose `task-0` already exists, then asserts reconcile neither errors nor marks the Job `Failed`. Verified to fail on unmodified `main` with the same message seen in production, and to pass with the fix.

## Note for reviewers

This accepts a pre-existing Task without comparing its spec against what the Job intends.