### PR TITLE
fix(rufio): index owned Tasks by owner UID, not name

### DIFF
--- a/rufio/internal/controller/job.go
+++ b/rufio/internal/controller/job.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
-// Index key for Job Owner Name.
+// Index key for Job Owner UID.
 const jobOwnerKey = ".metadata.controller"
 
 // JobReconciler reconciles a Job object.
@@ -105,9 +105,12 @@ func (r *JobReconciler) doReconcile(ctx context.Context, job *bmc.Job, jobPatch 
 		return ctrl.Result{}, fmt.Errorf("get Job %s/%s MachineRef: %w", job.Namespace, job.Name, err)
 	}
 
-	// List all Task owned by Job
+	// List all Task owned by Job, matched by owner UID: a Task belonging to
+	// a different Job instance that happens to reuse this Job's name (e.g. a
+	// controller that deletes and recreates a fixed-name Job) has a
+	// different owner UID and must not be mistaken for this Job's own Task.
 	tasks := &bmc.TaskList{}
-	err = r.client.List(ctx, tasks, client.MatchingFields{jobOwnerKey: job.Name}, client.InNamespace(job.Namespace))
+	err = r.client.List(ctx, tasks, client.MatchingFields{jobOwnerKey: string(job.UID)}, client.InNamespace(job.Namespace))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list owned Tasks for Job %s/%s: %w", job.Namespace, job.Name, err)
 	}
@@ -249,7 +252,7 @@ func (r *JobReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, 
 		Complete(r)
 }
 
-// TaskOwnerIndexFunc is Indexer func which returns the owner name for obj.
+// TaskOwnerIndexFunc is Indexer func which returns the owner UID for obj.
 func TaskOwnerIndexFunc(obj client.Object) []string {
 	task, ok := obj.(*bmc.Task)
 	if !ok {
@@ -266,5 +269,5 @@ func TaskOwnerIndexFunc(obj client.Object) []string {
 		return nil
 	}
 
-	return []string{owner.Name}
+	return []string{string(owner.UID)}
 }

--- a/rufio/internal/controller/job_test.go
+++ b/rufio/internal/controller/job_test.go
@@ -137,10 +137,71 @@ func createJob(name string, machine *bmc.Machine, t ...bmc.Action) *bmc.Job {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      name,
+			UID:       types.UID(name + "-uid"),
 		},
 		Spec: bmc.JobSpec{
 			MachineRef: bmc.MachineRef{Name: machine.Name, Namespace: machine.Namespace},
 			Tasks:      tasks,
 		},
 	}
+}
+
+// TestJobReconcileIgnoresForeignTaskWithSameName covers a Task that shares
+// its name with the Task this Job would create but is owned by a different
+// Job UID - e.g. a leftover from a previous, deleted Job instance that
+// reused a fixed name (tink/controller's Workflow state machine does this
+// for Jobs like "netboot") and hasn't been garbage collected yet. The
+// owned-Task List must exclude it, so reconcile proceeds to attempt
+// creating this Job's own Task rather than mistaking the foreign one for it.
+func TestJobReconcileIgnoresForeignTaskWithSameName(t *testing.T) {
+	machine := createMachine()
+	secret := createSecret()
+	job := createJob("netboot", machine, getAction("PowerOn"))
+	job.UID = "current-job-uid"
+
+	isController := true
+	foreign := &bmc.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmc.FormatTaskName(*job, 0),
+			Namespace: job.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: job.APIVersion,
+					Kind:       job.Kind,
+					Name:       job.Name,
+					UID:        "previous-job-uid",
+					Controller: &isController,
+				},
+			},
+		},
+		Spec: bmc.TaskSpec{Task: job.Spec.Tasks[0]},
+	}
+
+	clnt := newClientBuilder().
+		WithObjects(job, machine, secret, foreign).
+		WithIndex(&bmc.Task{}, ".metadata.controller", controller.TaskOwnerIndexFunc).
+		Build()
+
+	reconciler := controller.NewJobReconciler(clnt)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: job.Namespace, Name: job.Name},
+	})
+	// The foreign Task's name collides with the one this Job attempts to
+	// create, so Create returns AlreadyExists.
+	if err == nil {
+		t.Fatal("expected an error surfacing the Task name conflict, got nil")
+	}
+
+	var got bmc.Job
+	if err := clnt.Get(context.Background(),
+		types.NamespacedName{Namespace: job.Namespace, Name: job.Name}, &got); err != nil {
+		t.Fatalf("getting job: %v", err)
+	}
+	for _, c := range got.Status.Conditions {
+		if c.Type == bmc.JobFailed && c.Status == bmc.ConditionTrue {
+			return
+		}
+	}
+	t.Fatal("expected Job to be marked Failed once the Task name conflict surfaced")
 }


### PR DESCRIPTION
## Summary

`TaskOwnerIndexFunc` indexed a Job's owned Tasks by owner **name**, so a Job's owned-Task `List` could pick up a Task left over from a *different* Job instance that happened to reuse the same name before its old Task was garbage collected - for example, `tink/controller`'s Workflow state machine, which deletes and recreates fixed-name Jobs like `netboot` per Workflow.

- A stale **Failed** leftover Task would wrongly fail the new Job.
- A stale **incomplete** leftover Task would silently stall the new Job forever, since neither the owner watch nor a name-keyed index would ever recognize it as unrelated to the current Job's UID.

Fixed by indexing and matching on owner **UID** instead.

## Test plan

- Added `TestJobReconcileIgnoresForeignTaskWithSameName`, reproducing the `tink/controller` trigger: a same-named Task owned by a different Job UID. Manually verified it fails on the pre-fix code (silent stall, no error) and passes with the fix.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass in `rufio`.

## Note for reviewers

Separate and narrower than #968, which fixes a different race (a stale-cache List missing a Job's own just-created Task). This PR fixes a name-collision race with a foreign Job's Task instead. The two are independent of merge order. One caveat carried over from existing behavior, not introduced here: a genuine foreign-name collision still leaves the Job (and upstream Workflow) permanently Failed with no retry - same terminal-failure pattern #968 accepts for its own foreign-owner case.