### PR TITLE
ipxe: embed.ipxe: Return non-zero status to UEFI when iPXE fails to netboot

### DIFF
--- a/smee/internal/ipxe/binary/file/script/embed.ipxe
+++ b/smee/internal/ipxe/binary/file/script/embed.ipxe
@@ -28,7 +28,8 @@ set count:int32 1
 echo trying dhcp ( attempt ${count}/${retry-max} )
 dhcp net${idx} && goto done1 || iseq ${count} ${retry-max} && goto done1 || inc count && goto retry-loop1
 :done1
-autoboot net${idx} || exit
+autoboot net${idx} || goto no-netboot
+goto no-netboot
 
 :autoboot
 set retry-max:int32 10
@@ -37,7 +38,8 @@ set count:int32 1
 echo trying dhcp ( attempt ${count}/${retry-max} )
 dhcp && goto done2 || iseq ${count} ${retry-max} && goto done2 || inc count && goto retry-loop2
 :done2
-autoboot || exit
+autoboot || goto no-netboot
+goto no-netboot
 
 :boot-with-vlan
 set idx:int32 0
@@ -48,8 +50,13 @@ set idx:int32 0
 
 :loop_done
 echo Booting from net${idx}-${vlan-id}...
-autoboot net${idx}-${vlan-id}
+autoboot net${idx}-${vlan-id} || goto no-netboot
+goto no-netboot
 
 :error
 echo Failed to find the vlan interface
-shell
+goto no-netboot
+
+:no-netboot
+echo No netboot target; returning to firmware for next boot device
+exit 1


### PR DESCRIPTION
 > - just `exit` means `exit 0` (success); UEFI will go into Boot Manager 
> - by exiting with an error, UEFI will try the next boot entry

- 🐸 embed.ipxe ended every failure path with a bare `exit`. iPXE's exit command defaults to status 0, which the EFI wrapper turns into `EFI_SUCCESS`. `BdsDxe`'s `BootBootOptions()` only advances to the next `Boot####` when an option *fails*; an option that returns success ends the boot loop and drops into the Boot Manager Menu.
- 🌵 The result: on any machine where the netboot attempt didn't produce a bootable target -- no Hardware record for the MAC, AllowPXE toggled off after provisioning, Smee unreachable -- iPXE loaded, failed to fetch its script, exited 0, and the firmware went to the setup menu instead of falling through to the local disk. This breaks the netboot-then-disk lifecycle that AllowPXE is meant to drive: after provisioning, the machine could never reach the OS it had just been provisioned with.
- 🌳 Route every failure path to a `:no-netboot` label that exits 1, and add an unconditional `goto no-netboot` after each autoboot so a chainloaded image that returns also hands control back to the firmware rather than falling into the next label.
- 🌱 Also fixes the VLAN path, which had no failure handling at all: `autoboot net${idx}-${vlan-id}` fell straight through into `:error`, which ran `shell` -- an interactive prompt. Both now exit 1.