### PR TITLE
fix(rufio): honor the configured BMC connect timeout

### DIFF
--- a/rufio/internal/controller/controller.go
+++ b/rufio/internal/controller/controller.go
@@ -18,6 +18,9 @@ import (
 
 const (
 	trueString = "true"
+
+	// defaultBMCConnectTimeout is used when the caller leaves the BMC connect timeout unset.
+	defaultBMCConnectTimeout = time.Minute
 )
 
 var schemeBuilder = runtime.NewSchemeBuilder(
@@ -42,9 +45,13 @@ type Reconciler struct {
 	backoff *backoff.ExponentialBackOff
 }
 
-func NewManager(cfg *rest.Config, opts ctrl.Options, powerCheckInterval, inventoryRefreshInterval time.Duration, inventoryCollectionEnabled bool, maxConcurrentReconciles int) (ctrl.Manager, error) {
+func NewManager(cfg *rest.Config, opts ctrl.Options, bmcConnectTimeout, powerCheckInterval, inventoryRefreshInterval time.Duration, inventoryCollectionEnabled bool, maxConcurrentReconciles int) (ctrl.Manager, error) {
 	if opts.Scheme == nil {
 		opts.Scheme = DefaultScheme()
+	}
+
+	if bmcConnectTimeout <= 0 {
+		bmcConnectTimeout = defaultBMCConnectTimeout
 	}
 
 	mgr, err := ctrl.NewManager(cfg, opts)
@@ -53,7 +60,7 @@ func NewManager(cfg *rest.Config, opts ctrl.Options, powerCheckInterval, invento
 	}
 
 	ctrlOpts := ctrlcontroller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}
-	if err := NewReconciler(mgr.GetClient()).SetupWithManager(context.Background(), mgr, NewClientFunc(time.Minute), powerCheckInterval, inventoryRefreshInterval, inventoryCollectionEnabled, ctrlOpts); err != nil {
+	if err := NewReconciler(mgr.GetClient()).SetupWithManager(context.Background(), mgr, NewClientFunc(bmcConnectTimeout), powerCheckInterval, inventoryRefreshInterval, inventoryCollectionEnabled, ctrlOpts); err != nil {
 		return nil, fmt.Errorf("unable to create reconciler: %w", err)
 	}
 

--- a/rufio/rufio.go
+++ b/rufio/rufio.go
@@ -122,7 +122,7 @@ func (c *Config) Start(ctx context.Context, log logr.Logger) error {
 		options.Cache = cache.Options{DefaultNamespaces: map[string]cache.Config{c.Namespace: {}}}
 	}
 
-	mgr, err := controller.NewManager(c.Client, options, c.PowerCheckInterval, c.InventoryRefreshInterval, c.EnableInventoryCollection, c.MaxConcurrentReconciles)
+	mgr, err := controller.NewManager(c.Client, options, c.BMCConnectTimeout, c.PowerCheckInterval, c.InventoryRefreshInterval, c.EnableInventoryCollection, c.MaxConcurrentReconciles)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Config.BMCConnectTimeout was declared, exposed as `-rufio-bmc-connect-timeout`, and defaulted to 2m in `cmd`, but never reached the BMC client: `NewManager` hardcoded `NewClientFunc(time.Minute)`, so every deployment ran with a 60s connect budget no matter what was configured.

That budget is not just a connect bound. bmclib derives its per-provider timeout from the caller's context deadline divided by however many providers are registered (11 in the version currently pinned, and that count only grows), so a fixed 60s budget leaves well under 10s per provider — which, until `bmc-toolbox/bmclib#465`, also became the per-request timeout for the rest of the connection's life. Operators raising this value to accommodate slow BMCs saw no effect.

Pass the configured value through, falling back to the previous 60s when unset.